### PR TITLE
chore: ability to determine which app is running (ftux or nextgen)

### DIFF
--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -8,8 +8,10 @@ export const createEnv = (e: Partial<Env> = {}): Env => {
     authUrl: import.meta.env.VITE_AUTH_URL || "",
     billingUrl: import.meta.env.VITE_BILLING_URL || "",
     apiUrl: import.meta.env.VITE_API_URL || "",
-    legacyDashboardUrl: import.meta.env.VITE_LEGACY_DASHBOARD_URL || "",
-    origin: "nextgen",
+    legacyDashboardUrl:
+      import.meta.env.VITE_LEGACY_DASHBOARD_URL ||
+      "https://dashboard.aptible.com",
+    origin: (import.meta.env.VITE_ORIGIN as any) || "nextgen",
     ...e,
   };
 };

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -23,8 +23,8 @@ export interface Env {
   authUrl: string;
   billingUrl: string;
   apiUrl: string;
-  origin: string;
   legacyDashboardUrl: string;
+  origin: "nextgen" | "ftux";
 }
 
 export interface User {

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -14,6 +14,7 @@ import {
 
 import { prettyDateRelative } from "@app/date";
 import {
+  appDetailUrl,
   createProjectAddKeyUrl,
   createProjectAddNameUrl,
   createProjectGitPushUrl,
@@ -39,6 +40,7 @@ import {
   BannerMessages,
   Box,
   Button,
+  ButtonLink,
   ButtonLinkExternal,
   ErrorResources,
   ExternalLink,
@@ -106,7 +108,7 @@ import {
   selectLatestScanOp,
   selectLatestSucceessScanOp,
 } from "@app/deploy/operation";
-import { selectEnv } from "@app/env";
+import { selectEnv, selectLegacyDashboardUrl, selectOrigin } from "@app/env";
 import { selectOrganizationSelected } from "@app/organizations";
 import {
   DbSelectorProps,
@@ -1441,6 +1443,8 @@ const CreateEndpointView = ({
 export const CreateProjectGitStatusPage = () => {
   const { appId = "" } = useParams();
   const dispatch = useDispatch();
+  const origin = useSelector(selectOrigin);
+  const legacyUrl = useSelector(selectLegacyDashboardUrl);
   const appQuery = useQuery(fetchApp({ id: appId }));
   const app = useSelector((s: AppState) => selectAppById(s, { id: appId }));
   const envId = app.environmentId;
@@ -1651,12 +1655,18 @@ export const CreateProjectGitStatusPage = () => {
         />
         <hr />
 
-        <ButtonLinkExternal
-          href={`https://dashboard.aptible.com/accounts/${envId}/apps`}
-          className="mt-4 mb-2"
-        >
-          View Project <IconArrowRight variant="sm" className="ml-2" />
-        </ButtonLinkExternal>
+        {origin === "ftux" ? (
+          <ButtonLinkExternal
+            href={`${legacyUrl}/accounts/${envId}/apps`}
+            className="mt-4 mb-2"
+          >
+            View Project <IconArrowRight variant="sm" className="ml-2" />
+          </ButtonLinkExternal>
+        ) : (
+          <ButtonLink to={appDetailUrl(appId)} className="mt-4 mb-2">
+            View Project <IconArrowRight variant="sm" className="ml-2" />
+          </ButtonLink>
+        )}
       </StatusBox>
     </div>
   );

--- a/src/vite.d.ts
+++ b/src/vite.d.ts
@@ -12,4 +12,5 @@ interface ImportMetaEnv {
   VITE_BILLING_URL: string;
   VITE_DEBUG: string;
   VITE_LEGACY_DASHBOARD_URL: string;
+  VITE_ORIGIN: string;
 }


### PR DESCRIPTION
We already have an `origin` that we use to send to `auth-api` in order to determine which app the email verification links should redirect to so we can reuse that for determining if we are using the full-blown app or ftux.