### PR TITLE
sc-11529 - sentry addition

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 VITE_AUTH_URL="http://localhost:4000"
 VITE_API_URL="http://localhost:4001"
 VITE_BILLING_URL="http:localhost:4005"
+SENTRY_DSN=""

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 VITE_AUTH_URL="http://localhost:4000"
 VITE_API_URL="http://localhost:4001"
 VITE_BILLING_URL="http:localhost:4005"
-SENTRY_DSN=""
+VITE_SENTRY_DSN=""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           build-args: |
-            SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.docker-meta.outputs.tags }}
+          build-args: |
+            SENTRY_DSN=${{ secrets.SENTRY_DSN }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -33,6 +33,7 @@ jobs:
             VITE_AUTH_URL=https://auth-api-master.aptible-staging.com
             VITE_BILLING_URL=https://billing-api-master.aptible-staging.com
             VITE_API_URL=https://deploy-api-master.aptible-staging.com
+            SENTRY_DSN=${{ secrets.SENTRY_DSN }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -33,7 +33,7 @@ jobs:
             VITE_AUTH_URL=https://auth-api-master.aptible-staging.com
             VITE_BILLING_URL=https://billing-api-master.aptible-staging.com
             VITE_API_URL=https://deploy-api-master.aptible-staging.com
-            SENTRY_DSN=${{ secrets.SENTRY_DSN }}
+            VITE_SENTRY_DSN=${{ secrets.VITE_SENTRY_DSN }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG VITE_AUTH_URL=https://auth.aptible.com
 ARG VITE_BILLING_URL=https://goldenboy.aptible.com
 ARG VITE_API_URL=https://api.aptible.com
 ARG NODE_ENV=production
+ARG SENTRY_DSN
 
 RUN corepack enable
 RUN corepack prepare yarn@stable --activate

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM node:18.15-slim AS builder
 ARG VITE_AUTH_URL=https://auth.aptible.com
 ARG VITE_BILLING_URL=https://goldenboy.aptible.com
 ARG VITE_API_URL=https://api.aptible.com
+ARG VITE_SENTRY_DSN
 ARG NODE_ENV=production
-ARG SENTRY_DSN
 
 RUN corepack enable
 RUN corepack prepare yarn@stable --activate

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ yarn
 export VITE_AUTH_URL="http://localhost:4000"
 export VITE_API_URL="http://localhost:4001"
 export VITE_BILLING_URL="http:localhost:4005"
-export SENTRY_DSN="" # populate this as needed for error reporting, optional
+export VITE_SENTRY_DSN="" # populate this as needed for error reporting, optional
 ```
 
 ### .env

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ yarn
 export VITE_AUTH_URL="http://localhost:4000"
 export VITE_API_URL="http://localhost:4001"
 export VITE_BILLING_URL="http:localhost:4005"
+export SENTRY_DSN="" # populate this as needed for error reporting, optional
 ```
 
 ### .env

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@github/webauthn-json": "^2.1.1",
     "@reduxjs/toolkit": "^1.9.1",
+    "@sentry/react": "^7.47.0",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
     "@tailwindcss/typography": "^0.5.9",
@@ -57,5 +58,6 @@
     "vite": "^4.0.4",
     "vite-tsconfig-paths": "^4.0.5",
     "vitest": "^0.28.2"
-  }
+  },
+  "packageManager": "yarn@3.5.0"
 }

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -10,6 +10,7 @@ import { ErrorBoundary } from "@app/ui/shared/error-boundary";
 import { RouterProvider } from "react-router";
 
 export const App = ({ store }: { store: Store<AppState> }) => {
+  // ErrorBoundary is set here if there are errors in the router and/or provider
   return (
     <StrictMode>
       <ErrorBoundary>

--- a/src/app/init.ts
+++ b/src/app/init.ts
@@ -1,5 +1,7 @@
 import "../../index.css";
 
 import { init } from "./client";
+import { initSentry } from "./sentry";
 
 init();
+initSentry();

--- a/src/app/sentry.ts
+++ b/src/app/sentry.ts
@@ -3,6 +3,14 @@ import * as Sentry from "@sentry/react";
 export const initSentry = () =>
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
-    integrations: [new Sentry.BrowserTracing()],
-    tracesSampleRate: 1.0,
+    // WARNING - disabled browser tracing, but this can be enabled for perf tracking
+    integrations: [],
   });
+
+export const sentryErrorReporter = (_: any) => (next: any) => (action: any) => {
+  try {
+    next(action);
+  } catch (err) {
+    Sentry.captureException(err);
+  }
+};

--- a/src/app/sentry.ts
+++ b/src/app/sentry.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/react";
 
 export const initSentry = () =>
   Sentry.init({
-    dsn: import.meta.env.SENTRY_DSN,
+    dsn: import.meta.env.VITE_SENTRY_DSN,
     integrations: [new Sentry.BrowserTracing()],
     tracesSampleRate: 1.0,
   });

--- a/src/app/sentry.ts
+++ b/src/app/sentry.ts
@@ -1,0 +1,8 @@
+import * as Sentry from "@sentry/react";
+
+export const initSentry = () =>
+  Sentry.init({
+    dsn: import.meta.env.SENTRY_DSN,
+    integrations: [new Sentry.BrowserTracing()],
+    tracesSampleRate: 1.0,
+  });

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -12,6 +12,7 @@ import { ELEVATED_TOKEN_NAME, TOKEN_NAME } from "@app/token";
 import type { AppState } from "@app/types";
 
 import { reducers, sagas } from "./packages";
+import { sentryErrorReporter } from "./sentry";
 
 interface Props {
   initState?: Partial<AppState>;
@@ -48,6 +49,7 @@ export function setupStore({ initState }: Props): AppStore<AppState> {
     middleware.push(logger);
   }
 
+  middleware.push(sentryErrorReporter);
   const prepared = prepareStore({
     reducers,
     sagas,

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -8,6 +8,7 @@ export const createEnv = (e: Partial<Env> = {}): Env => {
     authUrl: import.meta.env.VITE_AUTH_URL || "",
     billingUrl: import.meta.env.VITE_BILLING_URL || "",
     apiUrl: import.meta.env.VITE_API_URL || "",
+    sentryDsn: import.meta.env.SENTRY_DSN || "",
     origin: "nextgen",
     ...e,
   };

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -8,7 +8,7 @@ export const createEnv = (e: Partial<Env> = {}): Env => {
     authUrl: import.meta.env.VITE_AUTH_URL || "",
     billingUrl: import.meta.env.VITE_BILLING_URL || "",
     apiUrl: import.meta.env.VITE_API_URL || "",
-    sentryDsn: import.meta.env.SENTRY_DSN || "",
+    sentryDsn: import.meta.env.VITE_SENTRY_DSN || "",
     origin: "nextgen",
     ...e,
   };

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -23,6 +23,7 @@ export interface Env {
   authUrl: string;
   billingUrl: string;
   apiUrl: string;
+  sentryDsn: string;
   origin: string;
 }
 

--- a/src/ui/shared/error-boundary.tsx
+++ b/src/ui/shared/error-boundary.tsx
@@ -6,93 +6,70 @@
 // taken from: https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/error_boundaries/
 
 import { AptibleLogo, Button, IconAlertTriangle } from "../shared";
-import { Component, ErrorInfo, ReactNode } from "react";
+import { ErrorBoundary as SentryErrorBoundary } from "@sentry/react";
+import { ReactElement } from "react";
 
-interface Props {
-  children?: ReactNode;
-}
-
-interface State {
-  message: string;
-  name: string;
-  hasError: boolean;
-}
-
-export class ErrorBoundary extends Component<Props, State> {
-  public state: State = {
-    message: "Error - something went wrong",
-    name: "Error - something went wrong",
-    hasError: false,
-  };
-
-  public static getDerivedStateFromError(err: Error): State {
-    // TODO - we likely want to curate error messages based on the common type guards here
-    // with possible custom logic on help text
-    return {
-      message: err.message ?? "Error - something went wrong",
-      name: err.name ?? "Error - something went wrong",
-      hasError: true,
-    };
-  }
-
-  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    // TODO - likely want to submit sentry errors here under specific cases
-    console.error("Uncaught error:", error, errorInfo);
-  }
-
-  public render() {
-    if (this.state.hasError) {
-      return (
-        <div
-          className="flex-1 h-full bg-no-repeat bg-center bg-cover"
-          style={{
-            backgroundImage: "url(/background-pattern-v2.png)",
-          }}
-        >
-          <div className="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
-            <div className="sm:mx-auto sm:w-full sm:max-w-md">
-              <div className="flex items-center justify-center">
-                <AptibleLogo />
-              </div>
-            </div>
-            <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
-              <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-                <h1 className="text-lg font-semibold text-red mb-">
-                  <IconAlertTriangle
-                    className="inline -mt-1 mr-2"
-                    color="#AD1A1A"
-                    style={{ width: 21, height: 21 }}
-                  />
-                  {this.state.name}
-                </h1>
-                <p className="my-5">{this.state.message}</p>
-                <hr />
-                <div className="flex mt-4 -mb-6">
-                  <Button
-                    className="w-40 mb-4 flex"
-                    onClick={() => {
-                      history.back();
-                    }}
-                  >
-                    <span className="text-sm">Back</span>
-                  </Button>
-                  <Button
-                    className="w-40 ml-4 mb-4 flex"
-                    onClick={() => {
-                      location.href = "/login";
-                    }}
-                    variant="white"
-                  >
-                    <span className="text-sm">Login</span>
-                  </Button>
-                </div>
-              </div>
+function ErrorFallback({ error }: { error: Error | string }) {
+  const errorString = typeof error === "string" ? error : error.message;
+  return (
+    <div
+      className="flex-1 h-full bg-no-repeat bg-center bg-cover"
+      style={{
+        backgroundImage: "url(/background-pattern-v2.png)",
+      }}
+    >
+      <div className="min-h-full flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+        <div className="sm:mx-auto sm:w-full sm:max-w-md">
+          <div className="flex items-center justify-center">
+            <AptibleLogo />
+          </div>
+        </div>
+        <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+          <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+            <h1 className="text-lg font-semibold text-red mb-">
+              <IconAlertTriangle
+                className="inline -mt-1 mr-2"
+                color="#AD1A1A"
+                style={{ width: 21, height: 21 }}
+              />
+              Something's gone wrong
+            </h1>
+            <p className="my-5">{errorString}</p>
+            <hr />
+            <div className="flex mt-4 -mb-6">
+              <Button
+                className="w-40 mb-4 flex"
+                onClick={() => {
+                  history.back();
+                }}
+              >
+                <span className="text-sm">Back</span>
+              </Button>
+              <Button
+                className="w-40 ml-4 mb-4 flex"
+                onClick={() => {
+                  location.href = "/login";
+                }}
+                variant="white"
+              >
+                <span className="text-sm">Login</span>
+              </Button>
             </div>
           </div>
         </div>
-      );
-    }
-
-    return this.props.children;
-  }
+      </div>
+    </div>
+  );
 }
+
+export const ErrorBoundary = ({
+  children,
+}: { children?: React.ReactNode }): ReactElement => {
+  return (
+    <SentryErrorBoundary fallback={({ error }: { error: Error }) => (
+      <ErrorFallback error={error} />
+    )}>
+      {children}
+    </SentryErrorBoundary>
+  );
+};

--- a/src/ui/shared/error-boundary.tsx
+++ b/src/ui/shared/error-boundary.tsx
@@ -66,9 +66,11 @@ export const ErrorBoundary = ({
   children,
 }: { children?: React.ReactNode }): ReactElement => {
   return (
-    <SentryErrorBoundary fallback={({ error }: { error: Error }) => (
-      <ErrorFallback error={error} />
-    )}>
+    <SentryErrorBoundary
+      fallback={({ error }: { error: Error }) => (
+        <ErrorFallback error={error} />
+      )}
+    >
       {children}
     </SentryErrorBoundary>
   );

--- a/src/vite.d.ts
+++ b/src/vite.d.ts
@@ -11,5 +11,5 @@ interface ImportMetaEnv {
   VITE_AUTH_URL: string;
   VITE_BILLING_URL: string;
   VITE_DEBUG: string;
-  SENTRY_DSN: string;
+  VITE_SENTRY_DSN: string;
 }

--- a/src/vite.d.ts
+++ b/src/vite.d.ts
@@ -11,4 +11,5 @@ interface ImportMetaEnv {
   VITE_AUTH_URL: string;
   VITE_BILLING_URL: string;
   VITE_DEBUG: string;
+  SENTRY_DSN: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,6 +792,86 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry-internal/tracing@npm:7.47.0":
+  version: 7.47.0
+  resolution: "@sentry-internal/tracing@npm:7.47.0"
+  dependencies:
+    "@sentry/core": 7.47.0
+    "@sentry/types": 7.47.0
+    "@sentry/utils": 7.47.0
+    tslib: ^1.9.3
+  checksum: 46cb6cdd5b64841acd7b38cdde156e15dcf2c225ccd36219ea5796b7ebad34a3c0db1f4c7545e1fec1a1e5897d4368003b1101845404bcd1c27a21c09784cbd3
+  languageName: node
+  linkType: hard
+
+"@sentry/browser@npm:7.47.0":
+  version: 7.47.0
+  resolution: "@sentry/browser@npm:7.47.0"
+  dependencies:
+    "@sentry-internal/tracing": 7.47.0
+    "@sentry/core": 7.47.0
+    "@sentry/replay": 7.47.0
+    "@sentry/types": 7.47.0
+    "@sentry/utils": 7.47.0
+    tslib: ^1.9.3
+  checksum: fdceac3a68195b4fcc58ab9d7907009cb73350646314100853ed56f4f2f6e00b2916c35037ea055c3d583accdf2356ed0690b59bf63038043b85e737a38382dc
+  languageName: node
+  linkType: hard
+
+"@sentry/core@npm:7.47.0":
+  version: 7.47.0
+  resolution: "@sentry/core@npm:7.47.0"
+  dependencies:
+    "@sentry/types": 7.47.0
+    "@sentry/utils": 7.47.0
+    tslib: ^1.9.3
+  checksum: 1cfd41020e5707c7e142dbb7c99118a264bcc5fa64fc06f1e51d8c6166dea0a50fd5896ce5287a4805d088257dc3757cc53ab4f5092166cd759ffeeea1cd8d2e
+  languageName: node
+  linkType: hard
+
+"@sentry/react@npm:^7.47.0":
+  version: 7.47.0
+  resolution: "@sentry/react@npm:7.47.0"
+  dependencies:
+    "@sentry/browser": 7.47.0
+    "@sentry/types": 7.47.0
+    "@sentry/utils": 7.47.0
+    hoist-non-react-statics: ^3.3.2
+    tslib: ^1.9.3
+  peerDependencies:
+    react: 15.x || 16.x || 17.x || 18.x
+  checksum: 7e42c91c48cf84e36d20433a1b28bf03c801ebed67ccd18e40de279c3a800e8f0818b4af9b9f40471070636a0aa1f58a77610383908f780e0b98efe8eb6c6ebd
+  languageName: node
+  linkType: hard
+
+"@sentry/replay@npm:7.47.0":
+  version: 7.47.0
+  resolution: "@sentry/replay@npm:7.47.0"
+  dependencies:
+    "@sentry/core": 7.47.0
+    "@sentry/types": 7.47.0
+    "@sentry/utils": 7.47.0
+  checksum: e4f69a6b698bd38eda4bd16275987d69948ded1dc34253eb804e3b6d09be675fa3c0fcfb85fbfef02c2e863eb80b7148da18b0dd1a7dadaab4353a315733e931
+  languageName: node
+  linkType: hard
+
+"@sentry/types@npm:7.47.0":
+  version: 7.47.0
+  resolution: "@sentry/types@npm:7.47.0"
+  checksum: 42f1f58bebb2689d609ebc614a04462cb15f749d304dcadc2c93b851ecb88a20d59853b01f22b91f37c7cfb41ed7d0992843043ada7a7592ea1043191092e350
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:7.47.0":
+  version: 7.47.0
+  resolution: "@sentry/utils@npm:7.47.0"
+  dependencies:
+    "@sentry/types": 7.47.0
+    tslib: ^1.9.3
+  checksum: d37d6299ef28c7ce32b1af7644f59ab5a5fd7a8155e97b3758c87d11a4b2cb406d4e3d2b260afcd200dadef99582f92b08ef6b89543f11611d2e034b3940d7b3
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.24.1":
   version: 0.24.51
   resolution: "@sinclair/typebox@npm:0.24.51"
@@ -1643,6 +1723,7 @@ __metadata:
   dependencies:
     "@github/webauthn-json": ^2.1.1
     "@reduxjs/toolkit": ^1.9.1
+    "@sentry/react": ^7.47.0
     "@tailwindcss/forms": ^0.5.3
     "@tailwindcss/line-clamp": ^0.4.2
     "@tailwindcss/typography": ^0.5.9
@@ -4755,6 +4836,13 @@ __metadata:
   bin:
     tsconfck: bin/tsconfck.js
   checksum: bc914042b2f5e1f9d7bbadd05b74031f32e2f1757061743d70d86d17dda0734d838e67abb0105b81db67c30b66496e5d408cbe216bb43b3d567a181b0448ddc1
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^1.9.3":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There is one outstanding issue for us to review:

* [x] the wrapped container with `Sentry.ErrorBoundary` equivalent ALWAYS renders children it seems (so the fallback never gets rendered), maybe I have an issue in local setup

---

can see them in sentry itself:

![image](https://user-images.githubusercontent.com/2961973/231185602-eff8e74f-3cf9-450b-b578-e4b3352126d2.png)


saga-query error forced (note log):

![image](https://user-images.githubusercontent.com/2961973/231185561-bd8040d9-239c-40d2-83d0-4295b19e1e0f.png)
