### PR TITLE
fix: corrected error boundary behavior for common cases

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -3,32 +3,30 @@ import { StrictMode } from "react";
 import { Provider, useSelector } from "react-redux";
 
 import type { AppState } from "@app/types";
-import { ModalPortal } from "@app/ui";
+import { ModalPortal, StandaloneErrorBoundary } from "@app/ui";
 
 import { ftuxRouter, router } from "./router";
 import { selectOrigin } from "@app/env";
-import { ErrorBoundary } from "@app/ui/shared/error-boundary";
 import { RouterProvider } from "react-router";
 
 const AppRouter = () => {
   const origin = useSelector(selectOrigin);
   return (
     <div className="h-full w-full">
-      <ModalPortal />
+      <StandaloneErrorBoundary>
+        <ModalPortal />
+      </StandaloneErrorBoundary>
       <RouterProvider router={origin === "nextgen" ? router : ftuxRouter} />
     </div>
   );
 };
 
 export const App = ({ store }: { store: Store<AppState> }) => {
-  // ErrorBoundary is set here if there are errors in the router and/or provider
   return (
     <StrictMode>
-      <ErrorBoundary>
-        <Provider store={store}>
-          <AppRouter />
-        </Provider>
-      </ErrorBoundary>
+      <Provider store={store}>
+        <AppRouter />
+      </Provider>
     </StrictMode>
   );
 };

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -54,6 +54,7 @@ import {
   TeamPage,
   VerifyEmailPage,
 } from "@app/ui";
+import { ReactRouterErrorElement } from "@app/ui/shared/error-boundary";
 
 const ftuxRoutes: RouteObject[] = [
   {
@@ -460,5 +461,10 @@ const appRoutes: RouteObject[] = [
   },
 ];
 
-export const ftuxRouter = createBrowserRouter(ftuxRoutes);
-export const router = createBrowserRouter(appRoutes);
+const errorPatch = (appRoute: RouteObject) => ({
+  ...appRoute,
+  errorElement: <ReactRouterErrorElement />,
+});
+
+export const ftuxRouter = createBrowserRouter(ftuxRoutes.map(errorPatch));
+export const router = createBrowserRouter(appRoutes.map(errorPatch));

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,3 +1,3 @@
 export * from "./pages";
 export * from "./layouts";
-export { Loading, ModalPortal } from "./shared";
+export { Loading, ModalPortal, StandaloneErrorBoundary } from "./shared";

--- a/src/ui/shared/index.ts
+++ b/src/ui/shared/index.ts
@@ -33,3 +33,4 @@ export * from "./modal-portal";
 export * from "./icons";
 export * from "./box";
 export * from "./pre-code";
+export * from "./error-boundary";


### PR DESCRIPTION
It works for simulated errors (not shown, but reports to sentry):

<img width="967" alt="image" src="https://user-images.githubusercontent.com/2961973/231763764-d152a84c-cc27-4ae0-b4f2-627492dc79e4.png">

It renders:

<img width="1179" alt="image" src="https://user-images.githubusercontent.com/2961973/231763639-cd41db7a-b4c5-4eb2-9356-b1cdab68a0cb.png">

It does properly send on boundary:

<img width="630" alt="image" src="https://user-images.githubusercontent.com/2961973/231763536-f98db4b0-815d-493c-baff-da7cb2c7e60e.png">
