### PR TITLE
fix(ftux): origin can only be `nextgen` or `app`

### DIFF
--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -25,7 +25,7 @@ export interface Env {
   apiUrl: string;
   sentryDsn: string;
   legacyDashboardUrl: string;
-  origin: "nextgen" | "ftux";
+  origin: "nextgen" | "app";
 }
 
 export interface User {

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -161,7 +161,7 @@ export const CreateProjectLayout = ({
             <AptibleLogo />
           </Link>
           <div className="ml-4">
-            {origin === "ftux" ? (
+            {origin === "app" ? (
               <a href={legacyUrl} className="text-black-300">
                 Back to dashboard
               </a>
@@ -238,7 +238,7 @@ export const CreateProjectSetupPage = () => {
     ) {
       navigate(createProjectGitStatusUrl(app.id), { replace: true });
     } else {
-      if (origin === "ftux") {
+      if (origin === "app") {
         window.location.href = `${legacyUrl}/accounts/${env.id}/apps`;
       } else {
         navigate(appDetailUrl(app.id), { replace: true });
@@ -2204,7 +2204,7 @@ export const CreateProjectGitStatusPage = () => {
   };
 
   const viewProject = () => {
-    return origin === "ftux" ? (
+    return origin === "app" ? (
       <ButtonLinkExternal
         target="_blank"
         href={`${legacyUrl}/accounts/${envId}/apps`}

--- a/src/ui/shared/onboarding-link.tsx
+++ b/src/ui/shared/onboarding-link.tsx
@@ -20,7 +20,7 @@ export const OnboardingLink = ({ env }: { env: DeployEnvironment }) => {
   }
 
   if (env.onboardingStatus === "completed") {
-    if (origin === "ftux") {
+    if (origin === "app") {
       return (
         <a
           href={`${legacyUrl}/accounts/${env.id}/apps`}


### PR DESCRIPTION
The value of `origin` is important to `auth-api` so we want it to be the "final" value so we don't have to change it after the initial implementation.

Related: https://github.com/aptible/auth-api/pull/500