### PR TITLE
fix: dont send local storage token to /current_token

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -34,6 +34,7 @@ export type DeployApiCtx<P = any, S = any> = ApiCtx<P, S, { message: string }>;
 export interface AuthApiCtx<P = any, S = any>
   extends ApiCtx<P, S, AuthApiError> {
   elevated: boolean;
+  noToken: boolean;
 }
 
 export function* elevetatedMdw(ctx: AuthApiCtx, next: Next): ApiGen {
@@ -63,7 +64,12 @@ function* getApiBaseUrl(endpoint: EndpointUrl): ApiGen<string> {
   return env.apiUrl;
 }
 
-function* tokenMdw(ctx: ApiCtx, next: Next): ApiGen {
+function* tokenMdw(ctx: ApiCtx & { noToken?: boolean }, next: Next): ApiGen {
+  if (ctx.noToken) {
+    yield next();
+    return;
+  }
+
   const token = yield* select(selectAccessToken);
   if (!token) {
     yield next();

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -28,6 +28,7 @@ function saveToken(ctx: AuthApiCtx<any, TokenSuccessResponse>) {
 export const fetchCurrentToken = authApi.get<never, TokenSuccessResponse>(
   "/current_token",
   function* onFetchToken(ctx, next) {
+    ctx.noToken = true;
     yield next();
     if (!ctx.json.ok) {
       yield put(resetToken());


### PR DESCRIPTION
# What?

We were always sending `localStorage.token` to `/current_token` and `auth-api` would return that token ... even if the `session_token` had a more recent one.

This ensures we never send `/current_token` the token stored in local storage.

- [current_token_id](https://github.com/aptible/auth-api/blob/c26e460bd13d7f1d9ab8f814d50ee4d772305512/app/controllers/application_controller.rb#L10)
- [current_token](https://github.com/aptible/fridge/blob/38fadfb6b515fdf29d8e537412a8a32424bedddd/lib/fridge/rails_helpers.rb#L22)
- [session_token](https://github.com/aptible/fridge/blob/38fadfb6b515fdf29d8e537412a8a32424bedddd/lib/fridge/rails_helpers.rb#L43)