### PR TITLE
fix(ftux): settings page should always try to deploy an app

### DIFF
--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -1185,18 +1185,11 @@ export const CreateProjectGitSettingsPage = () => {
         const img = dbImages.find((i) => i.id === db.databaseImageId);
         if (!img) return;
         const env = envList.find((e) => e.value === `{{${db.handle}}}`);
-        // If we didn't detect an env var for the database then we probably
-        // lost it.  Try to recover by adding an env var
-        if (!env) {
-          const envFin = envList.find((e) => e.key === "DATABASE_URL");
-          if (!envFin) {
-            setEnvs(`${envs}\nDATABASE_URL_TMP={{${db.handle}}}`);
-          }
-        }
+        if (!env) return;
         dbDispatch({
           type: "add",
           payload: {
-            env: env?.key.replace("_TMP", "") || "DATABASE_URL",
+            env: env.key.replace("_TMP", ""),
             id: `${createId()}`,
             imgId: img.id,
             name: db.handle,
@@ -2010,7 +2003,7 @@ const ProjectBox = ({
           <div>
             <h4 className={tokens.type.h4}>{env.handle}</h4>
             <p className="text-black-500 text-sm">
-              {hasDeployEndpoint(vhost) ? (
+              {hasDeployEndpoint(vhost) && vhost.status === "provisioned" ? (
                 <a
                   href={`https://${vhost.virtualDomain}`}
                   target="_blank"

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -271,13 +271,11 @@ export const CreateProjectFromAppSetupPage = () => {
 
     if (hasDeployOperation(deployOp)) {
       navigate(createProjectGitStatusUrl(app.id));
-      return;
     } else if (hasDeployOperation(scanOp) && scanOp.status === "succeeded") {
       navigate(createProjectGitSettingsUrl(app.id));
-      return;
+    } else {
+      navigate(createProjectGitPushUrl(appId));
     }
-
-    navigate(createProjectGitPushUrl(appId));
   }, [env.id, app.id, appOps, deployOp, scanOp]);
 
   return <Loading text={`Detecting app ${app.handle} status ...`} />;


### PR DESCRIPTION
I discovered a bug where sometimes we wouldn't try to deploy the App from the settings page.

I also removed some assumptions about existing databases that was janky and error-prone.

I also made it so a user cannot see endpoint until vhost provision completes.