### PR TITLE
ftux deployments by app

### DIFF
--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -15,7 +15,11 @@ import type {
 import { createAction, createSelector } from "@reduxjs/toolkit";
 import { call, createThrottle, poll, select } from "saga-query";
 
-import { findEnvById, selectEnvironments } from "../environment";
+import {
+  findEnvById,
+  hasDeployEnvironment,
+  selectEnvironments,
+} from "../environment";
 import { deserializeImage } from "../image";
 import { deserializeDeployOperation, waitForOperation } from "../operation";
 import { selectDeploy } from "../slice";
@@ -162,6 +166,24 @@ export const selectAppsForTableSearch = createSelector(
         lastOpStatus !== "" && lastOpStatus.includes(search);
 
       return handleMatch || envMatch || opMatch || opStatusMatch || userMatch;
+    });
+  },
+);
+
+export const selectAppsByEnvOnboarding = createSelector(
+  selectEnvironments,
+  selectAppsAsList,
+  (envs, apps) => {
+    return apps.filter((app) => {
+      const env = findEnvById(envs, { id: app.environmentId });
+      if (!hasDeployEnvironment(env)) {
+        return false;
+      }
+      if (env.onboardingStatus === "unknown") {
+        return false;
+      }
+
+      return true;
     });
   },
 );

--- a/src/deploy/environment/index.ts
+++ b/src/deploy/environment/index.ts
@@ -133,10 +133,6 @@ export const selectEnvironmentByName = createSelector(
     return envs.find((e) => e.handle === handle) || initEnv;
   },
 );
-export const selectEnvironmentOnboarding = createSelector(
-  selectEnvironmentsAsList,
-  (envs) => envs.filter((env) => env.onboardingStatus !== "unknown"),
-);
 
 export const fetchEnvironmentById = api.get<{ id: string }>("/accounts/:id");
 

--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -273,6 +273,11 @@ export const fetchEnvOperations = api.get<EnvOpProps>(
   "/accounts/:envId/operations?page=:page",
 );
 
+export const fetchAllEnvOps = thunks.create<EnvIdProps>(
+  "fetch-all-env-ops",
+  combinePages(fetchEnvOperations, { max: 5 }),
+);
+
 export const cancelEnvOperationsPoll = createAction("cancel-env-ops-poll");
 export const pollEnvOperations = thunks.create<EnvIdProps>(
   "poll-env-operations",

--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -275,7 +275,7 @@ export const fetchEnvOperations = api.get<EnvOpProps>(
 
 export const fetchAllEnvOps = thunks.create<EnvIdProps>(
   "fetch-all-env-ops",
-  combinePages(fetchEnvOperations, { max: 5 }),
+  combinePages(fetchEnvOperations, { max: 10 }),
 );
 
 export const cancelEnvOperationsPoll = createAction("cancel-env-ops-poll");

--- a/src/ui/shared/onboarding-link.tsx
+++ b/src/ui/shared/onboarding-link.tsx
@@ -1,17 +1,16 @@
-import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
-import { hasDeployApp, selectFirstAppByEnvId } from "@app/deploy";
+import { hasDeployApp, selectEnvironmentById } from "@app/deploy";
 import { createProjectGitAppSetupUrl } from "@app/routes";
-import { AppState, DeployEnvironment } from "@app/types";
+import { AppState, DeployApp } from "@app/types";
 
 import { IconArrowRight } from "./icons";
+import { useSelector } from "react-redux";
 
-export const OnboardingLink = ({ env }: { env: DeployEnvironment }) => {
-  const app = useSelector((s: AppState) =>
-    selectFirstAppByEnvId(s, { envId: env.id }),
+export const OnboardingLink = ({ app }: { app: DeployApp }) => {
+  const env = useSelector((s: AppState) =>
+    selectEnvironmentById(s, { id: app.environmentId }),
   );
-
   if (!hasDeployApp(app)) {
     return <span>No apps found</span>;
   }

--- a/src/ui/shared/onboarding-link.tsx
+++ b/src/ui/shared/onboarding-link.tsx
@@ -2,7 +2,7 @@ import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 import { hasDeployApp, selectFirstAppByEnvId } from "@app/deploy";
-import { createProjectGitStatusUrl } from "@app/routes";
+import { createProjectGitAppSetupUrl } from "@app/routes";
 import { AppState, DeployEnvironment } from "@app/types";
 
 import { IconArrowRight } from "./icons";
@@ -17,7 +17,10 @@ export const OnboardingLink = ({ env }: { env: DeployEnvironment }) => {
   }
 
   return (
-    <Link to={createProjectGitStatusUrl(app.id)} className="flex items-center">
+    <Link
+      to={createProjectGitAppSetupUrl(app.id)}
+      className="flex items-center"
+    >
       {env.onboardingStatus === "completed" ? (
         <>
           View status <IconArrowRight variant="sm" color="#4361FF" />


### PR DESCRIPTION
Fixes:
- Deployments page now has same status pill as status page
- Deployments page now has correct "finish setup" link
- Deployments are listed by `App` instead of `Account`
- If there are 0 operations for an `Account` we resolve that status to `unknown` instead of `succeeded`

# BEFORE
<img width="775" alt="Screenshot 2023-05-06 at 3 24 51 PM" src="https://user-images.githubusercontent.com/1940365/236643066-b4ca2798-2cbf-4e9c-86ba-01a2210f230a.png">



# AFTER
<img width="813" alt="Screenshot 2023-05-06 at 3 24 55 PM" src="https://user-images.githubusercontent.com/1940365/236643048-dcd3b86a-9761-4a4b-9df4-05a2b2ee7feb.png">

