### PR TITLE
chore: enable tuna for prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
           build-args: |
             VITE_SENTRY_DSN=${{ secrets.PROD_SENTRY_DSN }}
             VITE_ORIGIN=app
+            VITE_TUNA_ENABLED=true
   deploy:
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
to enable the flag in prod with a clean revert if this behaves strangely for any reason