### PR TITLE
chore: updated cookie consent to work regardless of subdomain

### DIFF
--- a/src/ui/shared/cookie-notice.tsx
+++ b/src/ui/shared/cookie-notice.tsx
@@ -24,7 +24,10 @@ export const writeCookie = (
   expiresAt.setDate(expiresAt.getDate() + expiresInDays);
 
   let cookieString = `${name}=${value}; expires=${expiresAt.toUTCString()}; `;
-  cookieString += `domain=.${window.location.host}; path=/; SameSite=Lax`;
+  cookieString += `domain=.${window.location.hostname
+    .split(".")
+    .slice(-2)
+    .join(".")}; path=/; SameSite=Lax`;
 
   if (!import.meta.env.PROD) {
     log("writing cookie", cookieString);

--- a/src/ui/shared/cookie-notice.tsx
+++ b/src/ui/shared/cookie-notice.tsx
@@ -24,10 +24,8 @@ export const writeCookie = (
   expiresAt.setDate(expiresAt.getDate() + expiresInDays);
 
   let cookieString = `${name}=${value}; expires=${expiresAt.toUTCString()}; `;
-  cookieString += `domain=.${window.location.hostname
-    .split(".")
-    .slice(-2)
-    .join(".")}; path=/; SameSite=Lax`;
+  const baseDomain = window.location.hostname.split(".").slice(-2).join(".");
+  cookieString += `domain=.${baseDomain}; path=/; SameSite=Lax`;
 
   if (!import.meta.env.PROD) {
     log("writing cookie", cookieString);


### PR DESCRIPTION
Caught as the production cookie doesn't read off `.aptible.com`, but rather `app.aptible.com`:

<img width="1486" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/3219cb9e-5c86-47f6-a15c-a0ea50988764">


---

This should work in all situations without errors

<img width="327" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/64830128-5844-494a-bcea-5ce770c945bc">

including invalid domains

<img width="309" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/99c9a2bf-25ee-4703-b84e-9aaeab2d20da">

or other setups

<img width="475" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/913b7e97-d756-4ae6-a270-db12a8bc2559">

