### PR TITLE
fix: added tuna patch for router loc changes

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -6,7 +6,6 @@ import type { AppState } from "@app/types";
 import { ModalPortal, StandaloneErrorBoundary } from "@app/ui";
 
 import { ftuxRouter, router } from "./router";
-import { Tuna } from "./tuna";
 import { selectOrigin } from "@app/env";
 import { CookieNotice } from "@app/ui/shared/cookie-notice";
 import { RouterProvider } from "react-router";
@@ -17,7 +16,6 @@ export const AppRouter = () => {
     <div className="h-full w-full">
       <StandaloneErrorBoundary>
         <ModalPortal />
-        <Tuna />
         <CookieNotice />
       </StandaloneErrorBoundary>
       <RouterProvider router={origin === "nextgen" ? router : ftuxRouter} />

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -56,11 +56,25 @@ import {
   VerifyEmailPage,
 } from "@app/ui";
 import { ReactRouterErrorElement } from "@app/ui/shared/error-boundary";
+import { Tuna } from "./tuna";
+
+const trackingPatch = (appRoute: RouteObject) => ({
+  ...appRoute,
+  element: (
+    <>
+      <Tuna />
+      {appRoute.element}
+    </>
+  ),
+});
 
 const errorPatch = (appRoute: RouteObject) => ({
   ...appRoute,
   errorElement: <ReactRouterErrorElement />,
 });
+
+const applyPatches = (appRoute: RouteObject) =>
+  errorPatch(trackingPatch(appRoute));
 
 export const ftuxRoutes: RouteObject[] = [
   {
@@ -193,7 +207,7 @@ export const ftuxRoutes: RouteObject[] = [
     path: "*",
     element: <NotFoundPage />,
   },
-].map(errorPatch);
+].map(applyPatches);
 
 export const appRoutes: RouteObject[] = [
   {
@@ -475,7 +489,7 @@ export const appRoutes: RouteObject[] = [
     path: "*",
     element: <NotFoundPage />,
   },
-].map(errorPatch);
+].map(applyPatches);
 
 export const ftuxRouter = createBrowserRouter(ftuxRoutes);
 export const router = createBrowserRouter(appRoutes);

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,5 +1,6 @@
 import { RouteObject, createBrowserRouter } from "react-router-dom";
 
+import { Tuna } from "./tuna";
 import * as routes from "@app/routes";
 import {
   AddSecurityKeyPage,
@@ -56,7 +57,6 @@ import {
   VerifyEmailPage,
 } from "@app/ui";
 import { ReactRouterErrorElement } from "@app/ui/shared/error-boundary";
-import { Tuna } from "./tuna";
 
 const trackingPatch = (appRoute: RouteObject) => ({
   ...appRoute,

--- a/src/app/tuna.tsx
+++ b/src/app/tuna.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useEffect } from "react";
+import { useLocation } from "react-router";
 
 export const Tuna = () => {
+  const loc = useLocation();
   useEffect(() => {
     if (!import.meta.env.PROD) {
       return;
@@ -14,6 +16,6 @@ export const Tuna = () => {
         w.aptible.event("pageview", null);
       }
     }
-  }, []);
+  }, [loc.pathname]);
   return null;
 };


### PR DESCRIPTION
This apparently doesn't change on dom router changes (which makes sense). 

We either need to introduce a shared layout or use a patch on every top level item in the router (I found that less intrusive)

---

Error component retained:

<img width="497" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/a4ccfa0c-d399-472f-b750-97048122044d">

---

on two navs:

<img width="931" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/fee6eccf-2183-4460-96bf-f522170ddd4f">