### PR TITLE
fix: `afterEach` cleanup for `@testing-library`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "typescript": "^5.0.4",
     "vite": "^4.3.7",
     "vite-tsconfig-paths": "^4.2.0",
-    "vitest": "^0.31.0"
+    "vitest": "^0.31.0",
+    "whatwg-fetch": "^3.6.2"
   }
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,6 @@
+// https://github.com/vitest-dev/vitest/issues/3077#issuecomment-1484093141
+import "whatwg-fetch";
+
 import { server } from "@app/mocks";
 import matchers, {
   TestingLibraryMatchers,
@@ -14,7 +17,7 @@ declare module "vitest" {
 expect.extend(matchers);
 
 // Establish API mocking before all tests.
-beforeAll(() => server.listen());
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 
 // Reset any request handlers that we may add during the tests,
 // so they don't affect other tests.

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,7 @@ import { server } from "@app/mocks";
 import matchers, {
   TestingLibraryMatchers,
 } from "@testing-library/jest-dom/matchers";
+import { cleanup } from "@testing-library/react";
 import { expect } from "vitest";
 
 declare module "vitest" {
@@ -17,7 +18,10 @@ beforeAll(() => server.listen());
 
 // Reset any request handlers that we may add during the tests,
 // so they don't affect other tests.
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  cleanup();
+});
 
 // Clean up after the tests are finished.
 afterAll(() => server.close());

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -23,6 +23,7 @@ beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 // so they don't affect other tests.
 afterEach(() => {
   server.resetHandlers();
+  // https://testing-library.com/docs/react-testing-library/api/#cleanup
   cleanup();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,6 +2188,7 @@ __metadata:
     vite: ^4.3.7
     vite-tsconfig-paths: ^4.2.0
     vitest: ^0.31.0
+    whatwg-fetch: ^3.6.2
   languageName: unknown
   linkType: soft
 
@@ -6351,6 +6352,13 @@ __metadata:
   dependencies:
     iconv-lite: 0.6.3
   checksum: 7087810c410aa9b689cbd6af8773341a53cdc1f3aae2a882c163bd5522ec8ca4cdfc269aef417a5792f411807d5d77d50df4c24e3abb00bb60192858a40cc675
+  languageName: node
+  linkType: hard
+
+"whatwg-fetch@npm:^3.6.2":
+  version: 3.6.2
+  resolution: "whatwg-fetch@npm:3.6.2"
+  checksum: ee976b7249e7791edb0d0a62cd806b29006ad7ec3a3d89145921ad8c00a3a67e4be8f3fb3ec6bc7b58498724fd568d11aeeeea1f7827e7e1e5eae6c8a275afed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See: https://testing-library.com/docs/react-testing-library/api/#cleanup