### PR TITLE
chore: minor tests/fixes for email verification and end to end tests

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -216,12 +216,12 @@ export const ftuxRoutes: RouteObject[] = [
   },
 
   {
-    path: routes.VERIFY_EMAIL_REQUEST_PATH,
+    path: routes.VERIFY_EMAIL_PATH,
     element: <VerifyEmailPage />,
   },
 
   {
-    path: routes.VERIFY_EMAIL_PATH,
+    path: routes.VERIFY_EMAIL_REQUEST_PATH,
     element: <VerifyEmailPage />,
   },
 

--- a/src/auth/verify-email.ts
+++ b/src/auth/verify-email.ts
@@ -27,7 +27,7 @@ interface ResendVerification {
 }
 
 export const resendVerification = authApi.post<ResendVerification>(
-  "/users/:userId/email_verification_challenge",
+  "/users/:userId/email_verification_challenges",
   function* onResendVerification(
     ctx: AuthApiCtx<any, ResendVerification>,
     next,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -69,6 +69,16 @@ const authHandlers = [
 
     return res(ctx.json({ _embedded: { ssh_keys: [testSshKey] } }));
   }),
+  rest.post(
+    `${testEnv.authUrl}/users/:userId/email_verification_challenges`,
+    (req, res, ctx) => {
+      if (!isValidToken(req)) {
+        return res(ctx.status(401));
+      }
+
+      return res(ctx.status(204));
+    },
+  ),
   rest.post(`${testEnv.authUrl}/password/resets/new`, (req, res, ctx) => {
     if (!isValidToken(req)) {
       return res(ctx.status(401));

--- a/src/test/index.tsx
+++ b/src/test/index.tsx
@@ -59,7 +59,10 @@ export const setupAppIntegrationTest = (
   const router = createMemoryRouter(routes, { initialEntries: initEntries });
   const { store } = setupTestStore({
     ...initState,
-    env: testEnv,
+    env: {
+      ...testEnv,
+      ...initState.env,
+    },
   });
   store.dispatch(bootup());
   store.dispatch({ type: REHYDRATE });
@@ -88,7 +91,10 @@ export const setupIntegrationTest = (
 ) => {
   const { store } = setupTestStore({
     ...initState,
-    env: testEnv,
+    env: {
+      ...testEnv,
+      ...initState.env,
+    },
   });
   store.dispatch(bootup());
   store.dispatch({ type: REHYDRATE });

--- a/src/ui/hooks/use-verified-required.ts
+++ b/src/ui/hooks/use-verified-required.ts
@@ -2,25 +2,29 @@ import { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router";
 
+import { fetchCurrentToken } from "@app/auth";
 import { selectEnv } from "@app/env";
 import { verifyEmailRequestUrl } from "@app/routes";
-import { selectJWTToken } from "@app/token";
+import { selectCurrentUser } from "@app/users";
+import { useLoader } from "saga-query/react";
 
 export const useVerifiedRequired = () => {
+  const loader = useLoader(fetchCurrentToken);
   const config = useSelector(selectEnv);
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const { verified } = useSelector(selectJWTToken);
+  const { verified } = useSelector(selectCurrentUser);
 
   useEffect(() => {
     // allow users to log out if they are presently logged in to come back to this page
     // only allow this for nextgen app
     if (
+      !loader.isLoading &&
       !verified &&
-      !["/logout"].includes(pathname) &&
+      pathname !== "/logout" &&
       config.origin === "nextgen"
     ) {
       navigate(verifyEmailRequestUrl());
     }
-  }, [config.origin, pathname, verified]);
+  }, [config.origin, loader.isLoading, pathname, verified]);
 };

--- a/src/ui/hooks/use-verified-required.ts
+++ b/src/ui/hooks/use-verified-required.ts
@@ -1,17 +1,26 @@
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
+import { selectEnv } from "@app/env";
 import { verifyEmailRequestUrl } from "@app/routes";
 import { selectJWTToken } from "@app/token";
 
 export const useVerifiedRequired = () => {
+  const config = useSelector(selectEnv);
   const navigate = useNavigate();
-  const user = useSelector(selectJWTToken);
+  const { pathname } = useLocation();
+  const { verified } = useSelector(selectJWTToken);
 
   useEffect(() => {
-    if (!user.verified) {
+    // allow users to log out if they are presently logged in to come back to this page
+    // only allow this for nextgen app
+    if (
+      !verified &&
+      !["/logout"].includes(pathname) &&
+      config.origin === "nextgen"
+    ) {
       navigate(verifyEmailRequestUrl());
     }
-  }, [user.verified]);
+  }, [config.origin, pathname, verified]);
 };

--- a/src/ui/layouts/auth-required.test.tsx
+++ b/src/ui/layouts/auth-required.test.tsx
@@ -100,6 +100,7 @@ describe("AuthRequired", () => {
         <h1>Test element</h1>
       </TestProvider>,
     );
+    await waitForElementToBeRemoved(() => screen.queryByText("loading ..."));
     await screen.findByText("Simulated verify");
     expect(screen.queryByText("Test element")).not.toBeInTheDocument();
   });

--- a/src/ui/layouts/auth-required.test.tsx
+++ b/src/ui/layouts/auth-required.test.tsx
@@ -1,0 +1,107 @@
+import { AuthRequired } from "./auth-required";
+
+import { server, testEnv, testUser } from "@app/mocks";
+import { loginUrl, verifyEmailRequestUrl } from "@app/routes";
+import { setupIntegrationTest } from "@app/test";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import { rest } from "msw";
+
+const LoginMock = () => {
+  return <div>Simulated login</div>;
+};
+const VerifyMock = () => {
+  return <div>Simulated verify</div>;
+};
+
+describe("AuthRequired", () => {
+  it("should allow child to render without a redirect when current token active", async () => {
+    const { TestProvider } = setupIntegrationTest({
+      path: "/mock",
+      initEntries: ["/mock"],
+    });
+    render(
+      <TestProvider>
+        <AuthRequired />
+        <h1>Test element</h1>
+      </TestProvider>,
+    );
+    await waitForElementToBeRemoved(() => screen.queryByText("loading ..."));
+    expect(screen.queryByText("Test element")).toBeInTheDocument();
+  });
+  it("should redirect when current token expired", async () => {
+    const { TestProvider } = setupIntegrationTest({
+      path: "/mock",
+      initEntries: ["/mock"],
+      additionalRoutes: [
+        {
+          path: loginUrl(),
+          element: <LoginMock />,
+        },
+      ],
+    });
+    server.use(
+      rest.get(`${testEnv.authUrl}/current_token`, (_, res, ctx) => {
+        return res(ctx.status(200));
+      }),
+    );
+    render(
+      <TestProvider>
+        <AuthRequired />
+        <h1>Test element</h1>
+      </TestProvider>,
+    );
+    await waitForElementToBeRemoved(() => screen.queryByText("loading ..."));
+    await screen.findByText("Simulated login");
+    expect(screen.queryByText("Test element")).not.toBeInTheDocument();
+  });
+  it("should redirect when current token expired", async () => {
+    const { TestProvider } = setupIntegrationTest({
+      path: "/mock",
+      initEntries: ["/mock"],
+      initState: {
+        env: {
+          ...testEnv,
+          origin: "nextgen",
+        },
+      },
+      additionalRoutes: [
+        {
+          path: verifyEmailRequestUrl(),
+          element: <VerifyMock />,
+        },
+      ],
+    });
+    server.use(
+      rest.get(
+        `${testEnv.authUrl}/organizations/:orgId/users`,
+        (req, res, ctx) => {
+          return res(
+            ctx.json({
+              _embedded: {
+                users: [
+                  {
+                    ...testUser,
+                    verified: false,
+                  },
+                ],
+              },
+            }),
+          );
+        },
+      ),
+    );
+    render(
+      <TestProvider>
+        <AuthRequired />
+        <h1>Test element</h1>
+      </TestProvider>,
+    );
+    await waitForElementToBeRemoved(() => screen.queryByText("loading ..."));
+    await screen.findByText("Simulated verify");
+    expect(screen.queryByText("Test element")).not.toBeInTheDocument();
+  });
+});

--- a/src/ui/layouts/auth-required.test.tsx
+++ b/src/ui/layouts/auth-required.test.tsx
@@ -58,7 +58,7 @@ describe("AuthRequired", () => {
     await screen.findByText("Simulated login");
     expect(screen.queryByText("Test element")).not.toBeInTheDocument();
   });
-  it("should redirect when current token expired", async () => {
+  it("should redirect when user is not yet verified", async () => {
     const { TestProvider } = setupIntegrationTest({
       path: "/mock",
       initEntries: ["/mock"],

--- a/src/ui/layouts/auth-required.test.tsx
+++ b/src/ui/layouts/auth-required.test.tsx
@@ -100,7 +100,6 @@ describe("AuthRequired", () => {
         <h1>Test element</h1>
       </TestProvider>,
     );
-    await waitForElementToBeRemoved(() => screen.queryByText("loading ..."));
     await screen.findByText("Simulated verify");
     expect(screen.queryByText("Test element")).not.toBeInTheDocument();
   });

--- a/src/ui/layouts/auth-required.tsx
+++ b/src/ui/layouts/auth-required.tsx
@@ -6,14 +6,16 @@ import { useLoader } from "saga-query/react";
 import { fetchCurrentToken } from "@app/auth";
 import { selectEnv } from "@app/env";
 import { setRedirectPath } from "@app/redirect-path";
-import { loginUrl } from "@app/routes";
+import { loginUrl, verifyEmailRequestUrl } from "@app/routes";
 import { selectIsUserAuthenticated } from "@app/token";
 
 import { Loading } from "../shared";
+import { selectCurrentUser } from "@app/users";
 
 export const AuthRequired = () => {
   const loader = useLoader(fetchCurrentToken);
   const isAuthenticated = useSelector(selectIsUserAuthenticated);
+  const { verified } = useSelector(selectCurrentUser);
   const config = useSelector(selectEnv);
   const location = useLocation();
   const dispatch = useDispatch();
@@ -36,6 +38,9 @@ export const AuthRequired = () => {
       // WARNING - this should be temporary
       // if environment featureflag for dashboard.aptible.com, we will redirect to dashboard for login
       window.location.href = config.legacyDashboardUrl;
+    } else if (authed && !verified && config.origin === "nextgen") {
+      // if nextgen and not verified they must verify before they can proceed
+      navigate(verifyEmailRequestUrl());
     } else if (!authed) {
       navigate(loginUrl());
     }

--- a/src/ui/pages/verify-email.test.tsx
+++ b/src/ui/pages/verify-email.test.tsx
@@ -2,12 +2,24 @@ import { VerifyEmailPage } from "./verify-email";
 
 import { server, testEnv } from "@app/mocks";
 import { setupIntegrationTest } from "@app/test";
-import { render, screen } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import { rest } from "msw";
 
 describe("Verify email page", () => {
   it("the verify email page should render", async () => {
-    const { TestProvider } = setupIntegrationTest();
+    const { TestProvider } = setupIntegrationTest({
+      initState: {
+        env: {
+          ...testEnv,
+          origin: "nextgen",
+        },
+      },
+    });
     render(
       <TestProvider>
         <VerifyEmailPage />
@@ -15,23 +27,24 @@ describe("Verify email page", () => {
     );
     await screen.findByRole("button", { name: /Resend Verification Email/ });
   });
-  it("the verify email page should render and redirect if verification succeeds", async () => {
-    const { TestProvider } = setupIntegrationTest();
+  it("the verify email page should render and resend verification successfully", async () => {
+    const { TestProvider } = setupIntegrationTest({
+      initState: {
+        env: {
+          ...testEnv,
+          origin: "nextgen",
+        },
+      },
+    });
     render(
       <TestProvider>
         <VerifyEmailPage />
       </TestProvider>,
     );
-    await screen.findByRole("button", { name: /Resend Verification Email/ });
-  });
-  it("the verify email page should render and remain if verification fails", async () => {
-    const { TestProvider } = setupIntegrationTest();
-    render(
-      <TestProvider>
-        <VerifyEmailPage />
-      </TestProvider>,
-    );
-    await screen.findByRole("button", { name: /Resend Verification Email/ });
+    const el = await screen.findByRole("button", {
+      name: /Resend Verification Email/,
+    });
+    await fireEvent.click(el);
   });
   it("the verify email page should properly fail", async () => {
     const { TestProvider } = setupIntegrationTest();
@@ -48,5 +61,42 @@ describe("Verify email page", () => {
     await screen.findByRole("button", { name: /Resend Verification Email/ });
     const errorText = await screen.queryByText("Failed to verify your email");
     expect(errorText).toBeDefined;
+  });
+  it("the verify email page should render and raise error if resend verification errors", async () => {
+    const { TestProvider } = setupIntegrationTest({
+      initState: {
+        env: {
+          ...testEnv,
+          origin: "nextgen",
+        },
+      },
+    });
+    render(
+      <TestProvider>
+        <VerifyEmailPage />
+      </TestProvider>,
+    );
+    server.use(
+      rest.post(
+        `${testEnv.authUrl}/users/:userId/email_verification_challenges`,
+        (_, res, ctx) => {
+          return res(
+            ctx.status(401),
+            ctx.set("Content-Type", "application/json"),
+            ctx.json({
+              code: 401,
+              exception_context: {},
+              error: "invalid_credentials",
+              message: "mock error message",
+            }),
+          );
+        },
+      ),
+    );
+    const el = await screen.findByRole("button", {
+      name: /Resend Verification Email/,
+    });
+    await fireEvent.click(el);
+    await screen.queryByText("mock error message");
   });
 });

--- a/src/ui/pages/verify-email.test.tsx
+++ b/src/ui/pages/verify-email.test.tsx
@@ -13,8 +13,25 @@ describe("Verify email page", () => {
         <VerifyEmailPage />
       </TestProvider>,
     );
-    const el = await screen.findByRole("button");
-    expect(el.textContent).toEqual("Resend Verification Email");
+    await screen.findByRole("button", { name: /Resend Verification Email/ });
+  });
+  it("the verify email page should render and redirect if verification succeeds", async () => {
+    const { TestProvider } = setupIntegrationTest();
+    render(
+      <TestProvider>
+        <VerifyEmailPage />
+      </TestProvider>,
+    );
+    await screen.findByRole("button", { name: /Resend Verification Email/ });
+  });
+  it("the verify email page should render and remain if verification fails", async () => {
+    const { TestProvider } = setupIntegrationTest();
+    render(
+      <TestProvider>
+        <VerifyEmailPage />
+      </TestProvider>,
+    );
+    await screen.findByRole("button", { name: /Resend Verification Email/ });
   });
   it("the verify email page should properly fail", async () => {
     const { TestProvider } = setupIntegrationTest();
@@ -28,9 +45,8 @@ describe("Verify email page", () => {
         return res(ctx.status(401));
       }),
     );
-    const el = await screen.findByRole("button");
+    await screen.findByRole("button", { name: /Resend Verification Email/ });
     const errorText = await screen.queryByText("Failed to verify your email");
     expect(errorText).toBeDefined;
-    expect(el.textContent).toEqual("Resend Verification Email");
   });
 });

--- a/src/ui/pages/verify-email.test.tsx
+++ b/src/ui/pages/verify-email.test.tsx
@@ -2,12 +2,7 @@ import { VerifyEmailPage } from "./verify-email";
 
 import { server, testEnv } from "@app/mocks";
 import { setupIntegrationTest } from "@app/test";
-import {
-  fireEvent,
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { rest } from "msw";
 
 describe("Verify email page", () => {

--- a/src/ui/pages/verify-email.tsx
+++ b/src/ui/pages/verify-email.tsx
@@ -37,7 +37,7 @@ export const VerifyEmailPage = () => {
         }),
       );
     }
-  }, [params.verificationId, params.verificationCode, userId]);
+  }, [params.verificationId, params.verificationCode, userId, verified]);
 
   useEffect(() => {
     if (loader.isLoading) {

--- a/src/ui/pages/verify-email.tsx
+++ b/src/ui/pages/verify-email.tsx
@@ -4,23 +4,26 @@ import { useNavigate, useParams } from "react-router";
 import { useLoader, useLoaderSuccess } from "saga-query/react";
 
 import { Box, Loading, ResendVerificationEmail } from "../shared";
-import { verifyEmail } from "@app/auth";
+import { fetchCurrentToken, verifyEmail } from "@app/auth";
 import { resetRedirectPath, selectRedirectPath } from "@app/redirect-path";
 import { homeUrl } from "@app/routes";
 import { selectJWTToken } from "@app/token";
 
 import { HeroBgLayout } from "../layouts";
+import { selectCurrentUser } from "@app/users";
 
 export const VerifyEmailPage = () => {
+  const loader = useLoader(fetchCurrentToken);
   const dispatch = useDispatch();
-  const user = useSelector(selectJWTToken);
+  const { id: userId, email } = useSelector(selectJWTToken);
+  const { verified } = useSelector(selectCurrentUser);
   const params = useParams();
   const navigate = useNavigate();
   const verifyEmailLoader = useLoader(verifyEmail);
   const redirectPath = useSelector(selectRedirectPath);
 
   useEffect(() => {
-    if (params.verificationCode && params.verificationId && user.id) {
+    if (params.verificationCode && params.verificationId && userId) {
       dispatch(
         verifyEmail({
           challengeId: params.verificationId,
@@ -28,7 +31,19 @@ export const VerifyEmailPage = () => {
         }),
       );
     }
-  }, [params.verificationId, params.verificationCode, user.id]);
+  }, [params.verificationId, params.verificationCode, userId]);
+
+  useEffect(() => {
+    if (loader.isLoading) {
+      return;
+    }
+
+    if (verified) {
+      // if already verified dump them back at root, no need
+      // to display this page at all
+      navigate(homeUrl());
+    }
+  }, [loader.isLoading, navigate, verified]);
 
   useLoaderSuccess(verifyEmailLoader, () => {
     navigate(redirectPath || homeUrl());
@@ -60,8 +75,8 @@ export const VerifyEmailPage = () => {
             </>
           ) : (
             <p className="text-h3 text-gray-500 leading-normal">
-              We've sent a verification link to {user.email}. Click the link in
-              the email to confirm your account.
+              We've sent a verification link to {email}. Click the link in the
+              email to confirm your account.
             </p>
           )}
         </div>

--- a/src/ui/pages/verify-email.tsx
+++ b/src/ui/pages/verify-email.tsx
@@ -3,10 +3,10 @@ import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
 import { useLoader, useLoaderSuccess } from "saga-query/react";
 
-import { Box, Loading, ResendVerificationEmail } from "../shared";
-import { fetchCurrentToken, verifyEmail } from "@app/auth";
+import { Box, Button, Loading, ResendVerificationEmail } from "../shared";
+import { fetchCurrentToken, logout, verifyEmail } from "@app/auth";
 import { resetRedirectPath, selectRedirectPath } from "@app/redirect-path";
-import { homeUrl } from "@app/routes";
+import { homeUrl, loginUrl } from "@app/routes";
 import { selectJWTToken } from "@app/token";
 
 import { HeroBgLayout } from "../layouts";
@@ -21,6 +21,12 @@ export const VerifyEmailPage = () => {
   const navigate = useNavigate();
   const verifyEmailLoader = useLoader(verifyEmail);
   const redirectPath = useSelector(selectRedirectPath);
+
+  const logoutSubmit = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    dispatch(logout());
+    navigate(loginUrl());
+  };
 
   useEffect(() => {
     if (params.verificationCode && params.verificationId && userId) {
@@ -83,6 +89,13 @@ export const VerifyEmailPage = () => {
       </div>
       <Box>
         <ResendVerificationEmail />
+        <Button
+          onClick={logoutSubmit}
+          className="font-semibold w-full mt-4"
+          variant="white"
+        >
+          Log Out
+        </Button>
       </Box>
     </HeroBgLayout>
   );

--- a/src/ui/shared/verify-email/resend-verification-email-form.tsx
+++ b/src/ui/shared/verify-email/resend-verification-email-form.tsx
@@ -4,19 +4,19 @@ import { useLoader } from "saga-query/react";
 
 import { resendVerification } from "@app/auth";
 import { selectOrigin } from "@app/env";
-import { selectJWTToken } from "@app/token";
 
 import { Button } from "../button";
+import { selectCurrentUserId } from "@app/users";
 
 export const ResendVerificationEmail = () => {
   const dispatch = useDispatch();
-  const user = useSelector(selectJWTToken);
+  const userId = useSelector(selectCurrentUserId);
   const origin = useSelector(selectOrigin);
   const resendVerificationLoader = useLoader(resendVerification);
 
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    dispatch(resendVerification({ userId: user.id, origin }));
+    dispatch(resendVerification({ userId, origin }));
   };
 
   useEffect(() => {

--- a/src/ui/shared/verify-email/resend-verification-email-form.tsx
+++ b/src/ui/shared/verify-email/resend-verification-email-form.tsx
@@ -32,6 +32,7 @@ export const ResendVerificationEmail = () => {
     <form onSubmit={onSubmit}>
       <div className="flex flex-col justify-between">
         <Button
+          className="semibold"
           isLoading={resendVerificationLoader.isLoading}
           disabled={resendVerificationLoader.isLoading}
           type="submit"


### PR DESCRIPTION
Fairly tedious, tested that when nextgen is enabled someone remains in nextgen without exiting.

Tested these flows on the email verification page (has 3 possible flows - tested manually, needing to write automated tests):

* email verification button clicked
* arrives with url params (should post and verify -> go home)
* already verified, redirect home

Tested these flows on the home page:

* Login
* Forced takeover of email verify
* Allow logout

sc-14708

---

Logout changes and ability to logout on :

<img width="670" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/491bd19b-c1a2-4260-a8d8-11bae4ac70ab">
