### PR TITLE
chore: updated use verified required which is glitchy as heck on pagereload without this change

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -45,6 +45,14 @@ const authHandlers = [
     }
     return res(ctx.json({ _embedded: { organizations: [testOrg] } }));
   }),
+
+  rest.get(`${testEnv.authUrl}/users/:userId`, (req, res, ctx) => {
+    if (!isValidToken(req)) {
+      return res(ctx.status(401));
+    }
+
+    return res(ctx.json(testUser));
+  }),
   rest.post(`${testEnv.authUrl}/users`, (req, res, ctx) => {
     return res(ctx.json(testUser));
   }),

--- a/src/ui/hooks/use-verified-required.ts
+++ b/src/ui/hooks/use-verified-required.ts
@@ -2,14 +2,13 @@ import { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router";
 
-import { fetchCurrentToken } from "@app/auth";
+import { useCurrentUser } from "./use-current-user";
 import { selectEnv } from "@app/env";
 import { verifyEmailRequestUrl } from "@app/routes";
 import { selectCurrentUser } from "@app/users";
-import { useLoader } from "saga-query/react";
 
 export const useVerifiedRequired = () => {
-  const loader = useLoader(fetchCurrentToken);
+  const user = useCurrentUser();
   const config = useSelector(selectEnv);
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -19,12 +18,19 @@ export const useVerifiedRequired = () => {
     // allow users to log out if they are presently logged in to come back to this page
     // only allow this for nextgen app
     if (
-      !loader.isLoading &&
+      !user.isLoading &&
+      !user.isInitialLoading &&
       !verified &&
       pathname !== "/logout" &&
       config.origin === "nextgen"
     ) {
       navigate(verifyEmailRequestUrl());
     }
-  }, [config.origin, loader.isLoading, pathname, verified]);
+  }, [
+    config.origin,
+    user.isLoading,
+    user.isInitialLoading,
+    pathname,
+    verified,
+  ]);
 };

--- a/src/ui/layouts/auth-required.test.tsx
+++ b/src/ui/layouts/auth-required.test.tsx
@@ -16,6 +16,14 @@ const LoginMock = () => {
 const VerifyMock = () => {
   return <div>Simulated verify</div>;
 };
+const mockUnverifiedUser = {
+  users: [
+    {
+      ...testUser,
+      verified: false,
+    },
+  ],
+};
 
 describe("AuthRequired", () => {
   it("should allow child to render without a redirect when current token active", async () => {
@@ -81,18 +89,14 @@ describe("AuthRequired", () => {
         (req, res, ctx) => {
           return res(
             ctx.json({
-              _embedded: {
-                users: [
-                  {
-                    ...testUser,
-                    verified: false,
-                  },
-                ],
-              },
+              _embedded: mockUnverifiedUser,
             }),
           );
         },
       ),
+      rest.get(`${testEnv.authUrl}/users/:userId`, (req, res, ctx) => {
+        return res(ctx.json(mockUnverifiedUser));
+      }),
     );
     render(
       <TestProvider>


### PR DESCRIPTION
Caught on nextgen-sbx-main.

If you go to a page and reload with a verified email, you will get punted to root as the current user won't be loaded in time. Using this ensures that the user is always loaded on boot.

Verified in local and updated unit tests.