### PR TITLE
chore: more granular error messages 

### DIFF
--- a/src/deploy/code-scan-result/index.ts
+++ b/src/deploy/code-scan-result/index.ts
@@ -9,7 +9,7 @@ export interface DeployCodeScanResponse {
   dockerfile_data?: string;
   procfile_present: boolean;
   procfile_data?: string;
-  languages_detected?: string[];
+  languages_detected: string[];
   _links: {
     app: LinkResponse;
     operation: LinkResponse;

--- a/src/deploy/code-scan-result/index.ts
+++ b/src/deploy/code-scan-result/index.ts
@@ -23,11 +23,11 @@ export const defaultCodeScanResponse = (
   return {
     id: 0,
     aptible_yml_present: false,
-    aptible_yml_data: '',
+    aptible_yml_data: "",
     dockerfile_present: false,
-    dockerfile_data: '',
+    dockerfile_data: "",
     procfile_present: false,
-    procfile_data: '',
+    procfile_data: "",
     languages_detected: [],
     _links: {
       app: { href: "" },

--- a/src/deploy/code-scan-result/index.ts
+++ b/src/deploy/code-scan-result/index.ts
@@ -4,8 +4,12 @@ import { LinkResponse } from "@app/types";
 export interface DeployCodeScanResponse {
   id: number;
   aptible_yml_present: boolean;
+  aptible_yml_data?: string;
   dockerfile_present: boolean;
+  dockerfile_data?: string;
   procfile_present: boolean;
+  procfile_data?: string;
+  languages_detected?: string[];
   _links: {
     app: LinkResponse;
     operation: LinkResponse;
@@ -19,8 +23,12 @@ export const defaultCodeScanResponse = (
   return {
     id: 0,
     aptible_yml_present: false,
+    aptible_yml_data: '',
     dockerfile_present: false,
+    dockerfile_data: '',
     procfile_present: false,
+    procfile_data: '',
+    languages_detected: [],
     _links: {
       app: { href: "" },
       operation: { href: "" },

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -1106,20 +1106,60 @@ const CodeScanInfo = ({
     );
   }
 
-  return (
-    <Banner variant="info">
+  const commonHelpText = (
+    <>
       <span>
-        Your code is missing a Dockerfile to deploy. We will try to generate one
-        for you. We recommend adding a{" "}
-      </span>
-      <ExternalLink
-        href="https://www.aptible.com/docs/dockerfile"
-        variant="info"
-      >
-        Dockerfile
-      </ExternalLink>
+          We recommend adding a{" "}
+          </span>
+          <ExternalLink
+            href="https://www.aptible.com/docs/dockerfile"
+            variant="info"
+          >
+            Dockerfile
+          </ExternalLink>
       <span> to your repo, commit it, and push your code.</span>
-    </Banner>
+    </>
+  )
+
+  if (codeScan.languages_detected?.includes("python")) {
+    return (
+      <Banner variant="info">
+        <div className="ml-2">
+          <p>
+            <strong>We have detected a Python application that does not contain a Dockerfile.</strong>
+          </p>
+          <p className="my-2">
+            There will need to be a <pre className="inline">requirements.txt</pre> and/or{" "}
+            <pre className="inline">pyproject.toml</pre> in the root directory of your app
+            We suggest ensuring the following:
+          </p>
+          <ul className="list-disc ml-4 my-2">
+            <li>If a Django project, we will run: <pre className="inline">python manage.py migrate && 
+              gunicorn $DJANGO_PROJECT_NAME.wsgi</pre>.</li>
+            <li>Otherwise, if pyproject.toml is found, we will run 
+              <pre className="inline">python -m $MODULE_NAME</pre>.
+            </li>
+            <li>
+              Finally, if above two conditions are not met, a <pre className="inline">main.py</pre> 
+              must be present in the root directory of your application for us to continue.
+            </li>
+          </ul>
+          <p>{commonHelpText}</p>
+        </div>
+      </Banner>
+    );
+  }
+
+  return (
+    <>
+      <Banner variant="info">
+      <p>
+        Your code is missing a Dockerfile to deploy. We will try to generate one
+        for you. {" "}
+        {commonHelpText}
+      </p>
+      </Banner>
+    </>
   );
 };
 

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -1108,40 +1108,50 @@ const CodeScanInfo = ({
 
   const commonHelpText = (
     <>
-      <span>
-          We recommend adding a{" "}
-          </span>
-          <ExternalLink
-            href="https://www.aptible.com/docs/dockerfile"
-            variant="info"
-          >
-            Dockerfile
-          </ExternalLink>
+      <span>We recommend adding a </span>
+      <ExternalLink
+        href="https://www.aptible.com/docs/dockerfile"
+        variant="info"
+      >
+        Dockerfile
+      </ExternalLink>
       <span> to your repo, commit it, and push your code.</span>
     </>
-  )
+  );
 
   if (codeScan.languages_detected?.includes("python")) {
     return (
       <Banner variant="info">
         <div className="ml-2">
           <p>
-            <strong>We have detected a Python application that does not contain a Dockerfile.</strong>
+            <strong>
+              We have detected a Python application that does not contain a
+              Dockerfile.
+            </strong>
           </p>
           <p className="my-2">
-            There will need to be a <pre className="inline">requirements.txt</pre> and/or{" "}
-            <pre className="inline">pyproject.toml</pre> in the root directory of your app
-            We suggest ensuring the following:
+            There will need to be a{" "}
+            <pre className="inline">requirements.txt</pre> and/or{" "}
+            <pre className="inline">pyproject.toml</pre> in the root directory
+            of your app We suggest ensuring the following:
           </p>
           <ul className="list-disc ml-4 my-2">
-            <li>If a Django project, we will run: <pre className="inline">python manage.py migrate && 
-              gunicorn $DJANGO_PROJECT_NAME.wsgi</pre>.</li>
-            <li>Otherwise, if pyproject.toml is found, we will run 
+            <li>
+              If a Django project, we will run:{" "}
+              <pre className="inline">
+                python manage.py migrate && gunicorn $DJANGO_PROJECT_NAME.wsgi
+              </pre>
+              .
+            </li>
+            <li>
+              Otherwise, if pyproject.toml is found, we will run
               <pre className="inline">python -m $MODULE_NAME</pre>.
             </li>
             <li>
-              Finally, if above two conditions are not met, a <pre className="inline">main.py</pre> 
-              must be present in the root directory of your application for us to continue.
+              Finally, if above two conditions are not met, a{" "}
+              <pre className="inline">main.py</pre>
+              must be present in the root directory of your application for us
+              to continue.
             </li>
           </ul>
           <p>{commonHelpText}</p>
@@ -1153,11 +1163,10 @@ const CodeScanInfo = ({
   return (
     <>
       <Banner variant="info">
-      <p>
-        Your code is missing a Dockerfile to deploy. We will try to generate one
-        for you. {" "}
-        {commonHelpText}
-      </p>
+        <p>
+          Your code is missing a Dockerfile to deploy. We will try to generate
+          one for you. {commonHelpText}
+        </p>
       </Banner>
     </>
   );

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -1133,7 +1133,7 @@ const CodeScanInfo = ({
             There will need to be a{" "}
             <pre className="inline">requirements.txt</pre> and/or{" "}
             <pre className="inline">pyproject.toml</pre> in the root directory
-            of your app We suggest ensuring the following:
+            of your app. We suggest ensuring the following:
           </p>
           <ul className="list-disc ml-4 my-2">
             <li>

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -1163,7 +1163,7 @@ const CodeScanInfo = ({
     </>
   );
 
-  if (codeScan.languages_detected?.includes("python")) {
+  if (codeScan.languages_detected.includes("python")) {
     return (
       <>
         <Banner variant="info">

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -1134,17 +1134,19 @@ const CodeScanInfo = ({
   if (!codeScan) return null;
   if (codeScan.dockerfile_present) {
     return (
-      <Banner variant="info">
-        <span>Your code has a </span>
-        <ExternalLink
-          href="https://www.aptible.com/docs/dockerfile"
-          variant="info"
-        >
-          Dockerfile
-        </ExternalLink>
-        <span> and will be used to build your Aptible app image.</span>
+      <>
+        <Banner variant="info">
+          <span>Your code has a </span>
+          <ExternalLink
+            href="https://www.aptible.com/docs/dockerfile"
+            variant="info"
+          >
+            Dockerfile
+          </ExternalLink>
+          <span> and will be used to build your Aptible app image.</span>
+        </Banner>
         <DockerfileDataView dockerfileData={codeScan.dockerfile_data} />
-      </Banner>
+      </>
     );
   }
 
@@ -1163,42 +1165,44 @@ const CodeScanInfo = ({
 
   if (codeScan.languages_detected?.includes("python")) {
     return (
-      <Banner variant="info">
-        <div className="ml-2">
-          <p>
-            <strong>
-              We have detected a Python application that does not contain a
-              Dockerfile.
-            </strong>
-          </p>
-          <p className="my-2">
-            There will need to be a{" "}
-            <pre className="inline">requirements.txt</pre> and/or{" "}
-            <pre className="inline">pyproject.toml</pre> in the root directory
-            of your app. We suggest ensuring the following:
-          </p>
-          <ul className="list-disc ml-4 my-2">
-            <li>
-              If a Django project, we will run:{" "}
-              <pre className="inline">
-                python manage.py migrate && gunicorn $DJANGO_PROJECT_NAME.wsgi
-              </pre>
+      <>
+        <Banner variant="info">
+          <div className="ml-2">
+            <p>
+              We have detected a Python application that does not contain a{" "}
+              <ExternalLink
+                href="https://www.aptible.com/docs/dockerfile"
+                variant="info"
+              >
+                Dockerfile
+              </ExternalLink>
               .
-            </li>
-            <li>
-              Otherwise, if pyproject.toml is found, we will run
-              <pre className="inline">python -m $MODULE_NAME</pre>.
-            </li>
-            <li>
-              Finally, if above two conditions are not met, a{" "}
-              <pre className="inline">main.py</pre>
-              must be present in the root directory of your application for us
-              to continue.
-            </li>
-          </ul>
-          <p>{commonHelpText}</p>
-        </div>
-      </Banner>
+            </p>
+          </div>
+        </Banner>
+        <p className="my-4">
+          There will need to be a requirements.txt and/or pyproject.toml in the
+          root directory of your app. We suggest ensuring the following:
+        </p>
+        <p className="my-4">
+          If a Django project, we will run:{" "}
+          <span className="bg-gray-200 font-mono">
+            python manage.py migrate && gunicorn $PROJECT.wsgi
+          </span>
+          .
+        </p>
+        <p className="my-4">
+          Otherwise, if pyproject.toml is found, we will run{" "}
+          <span className="bg-gray-200 font-mono">python -m $MODULE_NAME</span>.
+        </p>
+        <p className="my-4">
+          Finally, if above two conditions are not met, a main.py must be
+          present in the root directory of your application for us to continue.
+        </p>
+        <p className="my-4">
+          <strong>{commonHelpText}</strong>
+        </p>
+      </>
     );
   }
 

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -1085,6 +1085,47 @@ const DatabaseSelectorForm = ({
   );
 };
 
+const DockerfileDataView = ({
+  dockerfileData,
+}: { dockerfileData: string | undefined }) => {
+  const [isOpen, setOpen] = useState(false);
+
+  if (!dockerfileData) {
+    return null;
+  }
+
+  const segments = dockerfileData.split("\n").map((line) => ({
+    text: `${line}\n`,
+    className: line?.[0] === "#" ? "text-white" : "text-lime",
+  }));
+
+  return (
+    <div>
+      <div className="py-4 flex justify-between items-center">
+        <div className="flex flex-1">
+          <div
+            className="font-semibold flex items-center cursor-pointer"
+            onClick={() => setOpen(!isOpen)}
+            onKeyUp={() => setOpen(!isOpen)}
+          >
+            {isOpen ? (
+              <IconChevronUp variant="sm" />
+            ) : (
+              <IconChevronDown variant="sm" />
+            )}
+            <p className="ml-2">View scanned Dockerfile:</p>
+          </div>
+        </div>
+      </div>
+      {isOpen ? (
+        <div className="pb-4">
+          <PreCode allowCopy segments={segments} />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
 const CodeScanInfo = ({
   codeScan,
 }: {
@@ -1102,6 +1143,7 @@ const CodeScanInfo = ({
           Dockerfile
         </ExternalLink>
         <span> and will be used to build your Aptible app image.</span>
+        <DockerfileDataView dockerfileData={codeScan.dockerfile_data} />
       </Banner>
     );
   }


### PR DESCRIPTION
If codescan result is python, we show the following for users that might run into common python issues with builder:

<img width="791" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/a95d7e2a-0ee3-41ca-a390-b59c2e80246f">


---

- [x] consolidate items


QA on view Dockerfile if avail

• Banner
• Toggle Control Label (Hide Dockerfile | Show Dockerfile)
• Code Snippet
• Divider line

![image](https://github.com/aptible/app-ui/assets/2961973/2e9c72ef-9d53-485e-8cac-f8e36335ea9f)

![image](https://github.com/aptible/app-ui/assets/2961973/32bfc3ca-f121-470a-964a-665a380d1aaf)
