### PR TITLE
chore: added layout-level permissions guards (pending tests)

### DIFF
--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -28,7 +28,7 @@ import {
   tokens,
 } from "../shared";
 
-import { usePoller } from "../hooks";
+import { usePermsRequired, usePoller } from "../hooks";
 import { useInterval } from "../hooks/use-interval";
 import { ActiveOperationNotice } from "../shared/active-operation-notice";
 import { DetailPageLayout } from "./detail-page";
@@ -110,6 +110,11 @@ function AppPageHeader() {
   const crumbs = [
     { name: environment.handle, to: environmentResourcelUrl(environment.id) },
   ];
+
+  usePermsRequired({
+    envId: app.environmentId,
+    scope: "read",
+  });
 
   const poller = useMemo(() => pollAppOperations({ id }), [id]);
   const cancel = useMemo(() => cancelAppOpsPoll(), []);

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -30,7 +30,7 @@ import {
   tokens,
 } from "../shared";
 
-import { usePoller } from "../hooks";
+import { usePermsRequired, usePoller } from "../hooks";
 import { useInterval } from "../hooks/use-interval";
 import { ActiveOperationNotice } from "../shared/active-operation-notice";
 import { DetailPageLayout } from "./detail-page";
@@ -141,6 +141,11 @@ function DatabasePageHeader() {
   const crumbs = [
     { name: environment.handle, to: environmentResourcelUrl(environment.id) },
   ];
+
+  usePermsRequired({
+    envId: database.environmentId,
+    scope: "read",
+  });
 
   const poller = useMemo(() => pollDatabaseOperations({ id }), [id]);
   const cancel = useMemo(() => cancelDatabaseOpsPoll(), []);

--- a/src/ui/layouts/environment-detail-layout.tsx
+++ b/src/ui/layouts/environment-detail-layout.tsx
@@ -12,6 +12,7 @@ import {
   tokens,
 } from "../shared";
 
+import { usePermsRequired } from "../hooks";
 import { DetailPageLayout } from "./detail-page";
 import {
   fetchEnvironmentById,
@@ -127,6 +128,11 @@ function EnvironmentPageHeader(): React.ReactElement {
     selectEndpointsByEnvironmentId(s, { envId: environment.id }),
   );
   const crumbs = [{ name: stack.name, to: environmentsUrl() }];
+
+  usePermsRequired({
+    envId: id,
+    scope: "read",
+  });
 
   const tabs = [
     { name: "Resources", href: `/environments/${id}/resources` },

--- a/src/ui/layouts/op-detail-layout.tsx
+++ b/src/ui/layouts/op-detail-layout.tsx
@@ -13,6 +13,7 @@ import type { AppState, DeployOperation } from "@app/types";
 
 import { Box, DetailPageHeaderView, OpStatus, tokens } from "../shared";
 
+import { usePermsRequired } from "../hooks";
 import { DetailPageLayout } from "./detail-page";
 import cn from "classnames";
 
@@ -71,6 +72,11 @@ const opDetailBox = ({ op }: { op: DeployOperation }): React.ReactElement => {
 function OpPageHeader() {
   const { id = "" } = useParams();
   const op = useSelector((s: AppState) => selectOperationById(s, { id }));
+
+  usePermsRequired({
+    envId: op.environmentId,
+    scope: "read",
+  });
 
   return (
     <DetailPageHeaderView


### PR DESCRIPTION
Todo

- [ ] unit tests that reflect some of the redirection behavior for each of these (i think one per layout page is sufficient probably as a cursory guard test wise)
- [ ] deprovision and rename buttons need to be using the createButtonPermission func

---

This is very clear for:

* databases
* apps
* environments

---

Operations are less clear, not all operations have an account id (I think?), so this might not work as desired. Similarly, operations list is already pre-filtered on the backend (activity pages), so I won't be adding it there.