### PR TITLE
add operation note into activity and detail page, add id to type

### DIFF
--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -54,6 +54,7 @@ export interface DeployOperationResponse {
   user_email: string;
   user_name: string;
   env: string;
+  note: string;
   _links: {
     account: LinkResponse;
     code_scan_result: LinkResponse;
@@ -93,6 +94,7 @@ export const defaultOperationResponse = (
     user_name: "",
     user_email: "",
     env: "",
+    note: "",
     _links: {
       account: { href: "" },
       code_scan_result: { href: "" },
@@ -139,6 +141,7 @@ export const defaultDeployOperation = (
     userName: "unknown",
     userEmail: "",
     env: "",
+    note: "",
     ...op,
   };
 };
@@ -184,6 +187,7 @@ export const deserializeDeployOperation = (
     userEmail: payload.user_email,
     userName: payload.user_name,
     env: payload.env,
+    note: payload.note
   };
 };
 

--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -187,7 +187,7 @@ export const deserializeDeployOperation = (
     userEmail: payload.user_email,
     userName: payload.user_name,
     env: payload.env,
-    note: payload.note
+    note: payload.note,
   };
 };
 

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -210,6 +210,7 @@ export interface DeployOperation extends Timestamps {
   userEmail: string;
   userName: string;
   env: any;
+  note: any;
 }
 
 export interface DeployOperationResponse {

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -210,7 +210,7 @@ export interface DeployOperation extends Timestamps {
   userEmail: string;
   userName: string;
   env: any;
-  note: any;
+  note: string;
 }
 
 export interface DeployOperationResponse {

--- a/src/ui/layouts/op-detail-layout.tsx
+++ b/src/ui/layouts/op-detail-layout.tsx
@@ -29,7 +29,7 @@ const opDetailBox = ({ op }: { op: DeployOperation }) => {
         <div className="flex w-1/1">
           <div className="flex-col w-1/2">
             <div className="mt-4">
-              <h3 className="text-base font-semibold text-gray-900">Type</h3>
+              <h3 className="text-base font-semibold text-gray-900">Operation Type</h3>
               <p>{capitalize(op.type)}</p>
             </div>
             <div className="mt-4">
@@ -67,6 +67,12 @@ const opDetailBox = ({ op }: { op: DeployOperation }) => {
                 <a href={`mailto:${op.userEmail}`}>{op.userName}</a>
               </p>
             </div>
+            {op.note ? <div className="mt-4">
+              <h3 className="text-base font-semibold text-gray-900">Note</h3>
+              <p>
+                {op.note}
+              </p>
+            </div> : null}
           </div>
         </div>
       </Box>

--- a/src/ui/layouts/op-detail-layout.tsx
+++ b/src/ui/layouts/op-detail-layout.tsx
@@ -29,7 +29,9 @@ const opDetailBox = ({ op }: { op: DeployOperation }) => {
         <div className="flex w-1/1">
           <div className="flex-col w-1/2">
             <div className="mt-4">
-              <h3 className="text-base font-semibold text-gray-900">Operation Type</h3>
+              <h3 className="text-base font-semibold text-gray-900">
+                Operation Type
+              </h3>
               <p>{capitalize(op.type)}</p>
             </div>
             <div className="mt-4">
@@ -67,12 +69,12 @@ const opDetailBox = ({ op }: { op: DeployOperation }) => {
                 <a href={`mailto:${op.userEmail}`}>{op.userName}</a>
               </p>
             </div>
-            {op.note ? <div className="mt-4">
-              <h3 className="text-base font-semibold text-gray-900">Note</h3>
-              <p>
-                {op.note}
-              </p>
-            </div> : null}
+            {op.note ? (
+              <div className="mt-4">
+                <h3 className="text-base font-semibold text-gray-900">Note</h3>
+                <p>{op.note}</p>
+              </div>
+            ) : null}
           </div>
         </div>
       </Box>

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -169,7 +169,6 @@ function ActivityTable({
   description?: string;
 }) {
   const resourceHeaderTitleBar = (): ReactElement | undefined => {
-    console.log(ops);
     return (
       <ResourceHeader
         title={title}

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -66,6 +66,7 @@ const OpTypeCell = ({ op }: OpCellProps) => {
       >
         {capitalize(op.type)}
       </Link>
+      <div>ID: {op.id}</div>
     </Td>
   );
 };
@@ -122,7 +123,20 @@ const OpLastUpdatedCell = ({ op }: OpCellProps) => {
 };
 
 const OpUserCell = ({ op }: OpCellProps) => {
-  return <Td>{op.userName}</Td>;
+  if (!op.note) {
+    return (
+      <Td>
+        <div>{op.userName}</div>
+      </Td>
+    );
+  } else {
+    return (
+      <Td>
+        <div>{op.userName}</div>
+        <div>Note: {op.note}</div>
+      </Td>
+    );
+  }
 };
 
 const OpListRow = ({ op }: OpCellProps) => {
@@ -155,6 +169,7 @@ function ActivityTable({
   description?: string;
 }) {
   const resourceHeaderTitleBar = (): ReactElement | undefined => {
+    console.log(ops);
     return (
       <ResourceHeader
         title={title}

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -123,20 +123,12 @@ const OpLastUpdatedCell = ({ op }: OpCellProps) => {
 };
 
 const OpUserCell = ({ op }: OpCellProps) => {
-  if (!op.note) {
-    return (
-      <Td>
-        <div>{op.userName}</div>
-      </Td>
-    );
-  } else {
-    return (
-      <Td>
-        <div>{op.userName}</div>
-        <div>Note: {op.note}</div>
-      </Td>
-    );
-  }
+  return (
+    <Td>
+      <div>{op.userName}</div>
+      {op.note ? <div>Note: {op.note}</div> : null}
+    </Td>
+  );
 };
 
 const OpListRow = ({ op }: OpCellProps) => {


### PR DESCRIPTION
- add operation note to activity page and detail page
- add operation id to type

![image (2)](https://github.com/aptible/app-ui/assets/54414856/29681741-0076-44de-ba0e-148e1edb8aa7)
![image](https://github.com/aptible/app-ui/assets/54414856/7cce7359-913f-450b-940f-ba0a9ed325bb)


https://app.shortcut.com/aptible/story/14841/display-the-operation-note-field-in-resource-activity-views-when-populated