### PR TITLE
tighten-org-chooser-spacing-jc

### DIFF
--- a/src/ui/shared/application-sidebar.tsx
+++ b/src/ui/shared/application-sidebar.tsx
@@ -77,7 +77,7 @@ export const ApplicationSidebar = () => {
         </div>
 
         {collapsed ? null : (
-          <div className="mt-5 px-4">
+          <div className="mt-5 px-3">
             <OrgPicker />
           </div>
         )}

--- a/src/ui/shared/org-picker.tsx
+++ b/src/ui/shared/org-picker.tsx
@@ -11,8 +11,8 @@ export const OrgPicker = () => {
   return (
     <div
       className={cn([
-        "border-2 border-black-100 bg-white rounded-lg",
-        "p-2.5",
+        "border border-gray-200 bg-white rounded-lg",
+        "px-2 py-1",
         "flex items-center",
       ])}
     >


### PR DESCRIPTION
• Tighten Org Chooser Spacing
• Made Org Chooser the same width as our selected nav items

BEFORE
<img width="460" alt="Screen Shot 2023-06-23 at 10 44 54 AM" src="https://github.com/aptible/app-ui/assets/4295811/203803e6-5e59-4217-be1d-c988bc734de7">

AFTER
<img width="393" alt="Screen Shot 2023-06-23 at 10 55 34 AM" src="https://github.com/aptible/app-ui/assets/4295811/b80507fc-873c-43b4-94ca-4bfb459158ee">
