### PR TITLE
Fix Broken Link

### DIFF
--- a/src/ui/shared/application-sidebar.tsx
+++ b/src/ui/shared/application-sidebar.tsx
@@ -132,7 +132,7 @@ export const ApplicationSidebar = () => {
             </a>
             <a
               className="text-gray-500 hover:text-indigo px-3"
-              href="https://aptible.com/cli"
+              href="https://www.aptible.com/docs/cli"
             >
               INSTALL CLI
             </a>


### PR DESCRIPTION
Make Install CLI link go to the proper page — https://www.aptible.com/docs/cli

Before it went to a 404