### PR TITLE
Banner Margin Tweak and Darken Queued Status

### DIFF
--- a/src/ui/shared/active-operation-notice.tsx
+++ b/src/ui/shared/active-operation-notice.tsx
@@ -17,7 +17,7 @@ const BannerWrapper = ({
   children,
 }: {
   children?: React.ReactNode;
-}) => <div className="m-4">{children}</div>;
+}) => <div className="mb-4">{children}</div>;
 
 const operationStatusToBannerStatus = (
   operationStatus: OperationStatus,

--- a/src/ui/shared/op-status.tsx
+++ b/src/ui/shared/op-status.tsx
@@ -48,7 +48,7 @@ export const OpStatus = ({ status }: Pick<DeployOperation, "status">) => {
   const str = createReadableStatus(status);
 
   if (status === "queued") {
-    return <span className="font-semibold text-gray-300">{str}</span>;
+    return <span className="font-semibold text-gray-400">{str}</span>;
   }
 
   if (status === "succeeded") {


### PR DESCRIPTION
Make Banner Margin-Bottom Only

**Before**
<img width="1209" alt="Screen Shot 2023-07-05 at 2 02 44 PM" src="https://github.com/aptible/app-ui/assets/4295811/8a4bcc69-fe6f-49fc-a446-b96130f3dd58">

**After**
<img width="1084" alt="Screen Shot 2023-07-05 at 2 03 03 PM" src="https://github.com/aptible/app-ui/assets/4295811/69f363e6-34e8-4c87-a0e2-793e6c7cf38f">

Make Queued Status text color a bit darker

**Before**
<img width="358" alt="Screen Shot 2023-07-05 at 2 31 22 PM" src="https://github.com/aptible/app-ui/assets/4295811/3aaaf9b2-30af-4e44-9f0d-cc4323bc97b3">

**After**
<img width="332" alt="Screen Shot 2023-07-05 at 2 31 26 PM" src="https://github.com/aptible/app-ui/assets/4295811/4b842b11-0e97-41c3-b4f5-43330cd7d38b">

