### PR TITLE
top-level-tooltips-jc

### DIFF
--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -14,13 +14,13 @@ import { AppState, DeployStack } from "@app/types";
 
 import { MenuWrappedPage } from "../layouts";
 import {
+  IconInfo,
   InputSearch,
   LoadResources,
   ResourceHeader,
   ResourceListView,
   TableHead,
   Td,
-  IconInfo,
   Tooltip,
 } from "../shared";
 import { stackDetailUrl } from "@app/routes";
@@ -108,7 +108,7 @@ function StackList() {
                   search={search}
                   onChange={onChange}
                 />
-               <div className="flex">
+                <div className="flex">
                   <p className="text-gray-500 mt-4 text-base">
                     {stacks.length} Stack{stacks.length !== 1 && "s"}
                   </p>

--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -108,10 +108,16 @@ function StackList() {
                   search={search}
                   onChange={onChange}
                 />
-               <p className="flex text-gray-500 mt-4 text-base">
-                  {stacks.length} Stack{stacks.length !== 1 && "s"}
-                   <Tooltip text="Stacks are collections of environments tied to virtualized infrastructure."><IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" /></Tooltip>
-                </p>
+               <div className="flex">
+                  <p className="text-gray-500 mt-4 text-base">
+                    {stacks.length} Stack{stacks.length !== 1 && "s"}
+                  </p>
+                  <div className="mt-4">
+                    <Tooltip text="Stacks represent the virtualized infrastructure where resources are deployed.">
+                      <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
+                    </Tooltip>
+                  </div>
+                </div>
               </div>
             }
           />

--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -20,6 +20,8 @@ import {
   ResourceListView,
   TableHead,
   Td,
+  IconInfo,
+  Tooltip,
 } from "../shared";
 import { stackDetailUrl } from "@app/routes";
 import { capitalize } from "@app/string-utils";
@@ -106,8 +108,9 @@ function StackList() {
                   search={search}
                   onChange={onChange}
                 />
-                <p className="flex text-gray-500 mt-4 text-base">
+               <p className="flex text-gray-500 mt-4 text-base">
                   {stacks.length} Stack{stacks.length !== 1 && "s"}
+                   <Tooltip text="Stacks are collections of environments tied to virtualized infrastructure."><IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" /></Tooltip>
                 </p>
               </div>
             }

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "./Tooltip";
+import { Tooltip } from "./tooltip";
 import { useLoader, useQuery } from "@app/fx";
 import { ReactElement, useMemo } from "react";
 import { useSelector } from "react-redux";

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -2,6 +2,7 @@ import { useLoader, useQuery } from "@app/fx";
 import { ReactElement, useMemo } from "react";
 import { useSelector } from "react-redux";
 import { Link, useSearchParams } from "react-router-dom";
+import { Tooltip } from "./Tooltip";
 
 import { prettyDateRelative } from "@app/date";
 import {
@@ -29,7 +30,7 @@ import type { AppState, ResourceType } from "@app/types";
 
 import { usePoller } from "../hooks/use-poller";
 import { Button } from "./button";
-import { IconRefresh } from "./icons";
+import { IconRefresh, IconInfo } from "./icons";
 import { InputSearch } from "./input";
 import { LoadResources } from "./load-resources";
 import { OpStatus } from "./op-status";
@@ -196,9 +197,16 @@ function ActivityTable({
                 </div>
               ) : null}
             </div>
-            <p className="flex text-gray-500 mt-4 text-base">
-              {ops.length} Operation{ops.length !== 1 ? "s" : ""}
-            </p>
+            <div className="flex">
+              <p className="flex text-gray-500 mt-4 text-base">
+                {ops.length} Operation{ops.length !== 1 ? "s" : ""}
+              </p>
+              <div className="mt-4">
+                  <Tooltip text="Operations show real-time changes to resources, such as Apps and Databases.">
+                    <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
+                  </Tooltip>
+                </div>
+            </div>
           </div>
         }
       />
@@ -261,7 +269,6 @@ export function ActivityByOrg({ orgId }: { orgId: string }) {
         isLoading={loader.isLoading}
         search={search}
         title="Activity"
-        description="Realtime dashboard of your organization's operations in the last week."
       />
     </LoadResources>
   );

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -1,8 +1,8 @@
+import { Tooltip } from "./Tooltip";
 import { useLoader, useQuery } from "@app/fx";
 import { ReactElement, useMemo } from "react";
 import { useSelector } from "react-redux";
 import { Link, useSearchParams } from "react-router-dom";
-import { Tooltip } from "./Tooltip";
 
 import { prettyDateRelative } from "@app/date";
 import {
@@ -30,7 +30,7 @@ import type { AppState, ResourceType } from "@app/types";
 
 import { usePoller } from "../hooks/use-poller";
 import { Button } from "./button";
-import { IconRefresh, IconInfo } from "./icons";
+import { IconInfo, IconRefresh } from "./icons";
 import { InputSearch } from "./input";
 import { LoadResources } from "./load-resources";
 import { OpStatus } from "./op-status";
@@ -202,10 +202,10 @@ function ActivityTable({
                 {ops.length} Operation{ops.length !== 1 ? "s" : ""}
               </p>
               <div className="mt-4">
-                  <Tooltip text="Operations show real-time changes to resources, such as Apps and Databases.">
-                    <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
-                  </Tooltip>
-                </div>
+                <Tooltip text="Operations show real-time changes to resources, such as Apps and Databases.">
+                  <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
+                </Tooltip>
+              </div>
             </div>
           </div>
         }

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -190,7 +190,7 @@ const AppsResourceHeaderTitleBar = ({
                   {apps.length} App{apps.length !== 1 && "s"}
                 </p>
                 <div className="mt-4">
-                  <Tooltip text="An app is how you deploy your code, scale services, and manage endpoints.">
+                  <Tooltip text="Apps are how you deploy your code, scale services, and manage endpoints.">
                     <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                   </Tooltip>
                 </div>

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -2,6 +2,8 @@ import { useLoader, useQuery } from "@app/fx";
 import { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
+import { IconInfo } from "../icons";
+import { Tooltip } from "../Tooltip";
 
 import { prettyDateRelative } from "@app/date";
 import {
@@ -183,9 +185,16 @@ const AppsResourceHeaderTitleBar = ({
                 search={search}
                 onChange={onChange}
               />
-              <p className="flex text-gray-500 mt-4 text-base">
-                {apps.length} App{apps.length !== 1 && "s"}
-              </p>
+              <div className="flex">
+                <p className="flex text-gray-500 mt-4 text-base">
+                  {apps.length} App{apps.length !== 1 && "s"}
+                </p>
+                <div className="mt-4">
+                  <Tooltip text="An app is how you deploy your code, scale services, and manage endpoints.">
+                    <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
+                  </Tooltip>
+                </div>
+              </div>
             </div>
           }
         />

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -1,5 +1,5 @@
-import { Tooltip } from "../Tooltip";
 import { IconInfo } from "../icons";
+import { Tooltip } from "../tooltip";
 import { useLoader, useQuery } from "@app/fx";
 import { useState } from "react";
 import { useSelector } from "react-redux";

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -1,9 +1,9 @@
+import { Tooltip } from "../Tooltip";
+import { IconInfo } from "../icons";
 import { useLoader, useQuery } from "@app/fx";
 import { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-import { IconInfo } from "../icons";
-import { Tooltip } from "../Tooltip";
 
 import { prettyDateRelative } from "@app/date";
 import {

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -2,6 +2,8 @@ import { useQuery } from "@app/fx";
 import { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
+import { IconInfo } from "../icons";
+import { Tooltip } from "../Tooltip";
 
 import { prettyDateRelative } from "@app/date";
 import {
@@ -108,9 +110,16 @@ const DbsResourceHeaderTitleBar = ({
                 search={search}
                 onChange={onChange}
               />
-              <p className="flex text-gray-500 mt-4 text-base">
-                {dbs.length} Database{dbs.length !== 1 && "s"}
-              </p>
+              <div className="flex">
+                <p className="flex text-gray-500 mt-4 text-base">
+                  {dbs.length} Database{dbs.length !== 1 && "s"}
+                </p>
+                <div className="mt-4">
+                  <Tooltip text="Databases provide data persistence and are automatically configured and managed.">
+                    <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
+                  </Tooltip>
+                </div>
+              </div>
             </div>
           }
         />

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -1,5 +1,5 @@
-import { Tooltip } from "../Tooltip";
 import { IconInfo } from "../icons";
+import { Tooltip } from "../tooltip";
 import { useQuery } from "@app/fx";
 import { useState } from "react";
 import { useSelector } from "react-redux";

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -1,9 +1,9 @@
+import { Tooltip } from "../Tooltip";
+import { IconInfo } from "../icons";
 import { useQuery } from "@app/fx";
 import { useState } from "react";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-import { IconInfo } from "../icons";
-import { Tooltip } from "../Tooltip";
 
 import { prettyDateRelative } from "@app/date";
 import {

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -152,7 +152,7 @@ export function EnvironmentList() {
                       {environments.length !== 1 ? "s" : ""}
                     </p>
                     <div className="mt-4">
-                      <Tooltip text="An environment is how you separate resources like staging and production.">
+                      <Tooltip text="Environments are how you separate resources like staging and production.">
                         <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                       </Tooltip>
                     </div>

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -1,5 +1,5 @@
-import { Tooltip } from "../Tooltip";
 import { IconInfo } from "../icons";
+import { Tooltip } from "../tooltip";
 import {
   fetchAllEnvironments,
   selectAppsByEnvId,

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -1,7 +1,5 @@
-import { useQuery } from "@app/fx";
-import { Link } from "react-router-dom";
-import { IconInfo } from "../icons";
 import { Tooltip } from "../Tooltip";
+import { IconInfo } from "../icons";
 import {
   fetchAllEnvironments,
   selectAppsByEnvId,
@@ -9,8 +7,10 @@ import {
   selectEnvironmentsForTableSearch,
   selectStackById,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import { environmentAppsUrl } from "@app/routes";
 import type { AppState, DeployEnvironment } from "@app/types";
+import { Link } from "react-router-dom";
 
 import { InputSearch } from "../input";
 import { LoadResources } from "../load-resources";

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@app/fx";
 import { Link } from "react-router-dom";
-
+import { IconInfo } from "../icons";
+import { Tooltip } from "../Tooltip";
 import {
   fetchAllEnvironments,
   selectAppsByEnvId,
@@ -145,10 +146,17 @@ export function EnvironmentList() {
                     search={search}
                     onChange={onChange}
                   />
-                  <p className="flex text-gray-500 mt-4 text-base">
-                    {environments.length} Environment
-                    {environments.length !== 1 ? "s" : ""}
-                  </p>
+                  <div className="flex">
+                    <p className="flex text-gray-500 mt-4 text-base">
+                      {environments.length} Environment
+                      {environments.length !== 1 ? "s" : ""}
+                    </p>
+                    <div className="mt-4">
+                      <Tooltip text="An environment is how you separate resources like staging and production.">
+                        <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
+                      </Tooltip>
+                    </div>
+                  </div>
                 </>
               </div>
             }

--- a/src/ui/shared/tooltip.tsx
+++ b/src/ui/shared/tooltip.tsx
@@ -16,7 +16,7 @@ export const Tooltip = ({
           "absolute",
           "rounded-md",
           "px-3 py-2",
-          "max-w-xs",
+          "w-96",
           "bg-black text-white",
         ])}
       >


### PR DESCRIPTION
Add top level page tooltips for Stacks, Environments, Apps, Databases, and Activity pages.


https://github.com/aptible/app-ui/assets/4295811/0ef4b447-3c70-45e6-8ac3-c2d871900027

