### PR TITLE
Add-Border-to-Onboarding-Boxes-jc

### DIFF
--- a/src/ui/pages/elevate.tsx
+++ b/src/ui/pages/elevate.tsx
@@ -72,8 +72,8 @@ export const ElevatePage = () => {
       </div>
 
       <div className="mt-8">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          <form className="space-y-6" onSubmit={onSubmit}>
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-black-100">
+          <form className="space-y-4" onSubmit={onSubmit}>
             <BannerMessages className="my-2" {...loader} />
             <FormGroup label="Email" htmlFor="input-email">
               <Input

--- a/src/ui/pages/forgot-pass.tsx
+++ b/src/ui/pages/forgot-pass.tsx
@@ -29,7 +29,7 @@ export const ForgotPassPage = () => {
     <HeroBgLayout>
       <div className="text-center">
         <h1 className={`${tokens.type.h1} text-center`}>Reset your password</h1>
-        <p className="mt-6 text-gray-600">
+        <p className="mt-6 text-gray-600 mb-4">
           Check your email for reset instructions or go back to{" "}
           <Link to={loginUrl()}>Log In</Link>.
         </p>

--- a/src/ui/pages/login.tsx
+++ b/src/ui/pages/login.tsx
@@ -110,8 +110,8 @@ export const LoginPage = () => {
       </div>
 
       <div className="mt-8">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
-          <form className="space-y-6" onSubmit={onSubmit}>
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-black-100">
+          <form className="space-y-4" onSubmit={onSubmit}>
             {isOtpRequired ? (
               <BannerMessages
                 className="my-2"
@@ -163,7 +163,7 @@ export const LoginPage = () => {
                 htmlFor="input-2fa"
                 description={
                   <p>
-                    Read our 2fa{" "}
+                    Read our 2FA{" "}
                     <ExternalLink
                       href="https://www.aptible.com/docs/password-authentication#2-factor-authentication-2fa"
                       variant="info"

--- a/src/ui/pages/signup.tsx
+++ b/src/ui/pages/signup.tsx
@@ -162,8 +162,8 @@ export const SignupPage = () => {
       </div>
 
       <div className="mt-8">
-        <div className="bg-white py-6 px-6 shadow sm:rounded-lg sm:px-10">
-          <form className="space-y-6" onSubmit={onSubmitForm}>
+        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-black-100">
+          <form className="space-y-4" onSubmit={onSubmitForm}>
             <FormGroup label="Name" htmlFor="name">
               <Input
                 id="name"

--- a/src/ui/pages/verify-email.tsx
+++ b/src/ui/pages/verify-email.tsx
@@ -66,11 +66,11 @@ export const VerifyEmailPage = () => {
 
   return (
     <HeroBgLayout>
-      <h2 className="mt-6 text-center text-4xl font-bold text-gray-900">
+      <h2 className="mt-6 text-center text-3xl font-semibold text-gray-900">
         Check your Email
       </h2>
       <div className="flex text-center items-center justify-center mt-4">
-        <div className="max-w-2xl">
+        <div className="max-w-2xl mb-8">
           {verifyEmailLoader.isError ? (
             <>
               <p className="text-h3 text-gray-500 leading-normal">


### PR DESCRIPTION
Add border to all onboarding container boxes
• Slight margin & padding tweaks to save some space

**BEFORE**
<img width="1077" alt="Screen Shot 2023-07-06 at 7 39 39 PM" src="https://github.com/aptible/app-ui/assets/4295811/3eb66125-295f-4755-b764-941edf0dae6e">


**AFTER**
<img width="823" alt="Screen Shot 2023-07-06 at 7 46 03 PM" src="https://github.com/aptible/app-ui/assets/4295811/be999364-5a1f-4bb9-8246-34bead8b88fe">

Add more margin above box to be consistent
<img width="734" alt="Screen Shot 2023-07-06 at 7 49 15 PM" src="https://github.com/aptible/app-ui/assets/4295811/c8a15642-c885-447f-a7f7-0129278b521b">

Add border to box
<img width="1001" alt="Screen Shot 2023-07-06 at 8 08 39 PM" src="https://github.com/aptible/app-ui/assets/4295811/afc811f5-e166-4fb8-b6f0-b2543506b23a">

Add border to box
<img width="885" alt="Screen Shot 2023-07-06 at 8 08 45 PM" src="https://github.com/aptible/app-ui/assets/4295811/62466f50-c56e-4800-b09b-afaedc54a472">


