### PR TITLE
chore: filtered metrics by more args

### DIFF
--- a/src/deploy/container/index.ts
+++ b/src/deploy/container/index.ts
@@ -124,6 +124,18 @@ export const selectContainersByReleaseId = createSelector(
   },
 );
 
+export const selectContainersByReleaseIdByLayerType = createSelector(
+  selectContainerAsList,
+  (_: AppState, props: { releaseId: string }) => props.releaseId,
+  (_: AppState, props: { layers: string[] }) => props.layers,
+  (containers, releaseId, layers) => {
+    return containers.filter(
+      (container) =>
+        layers.includes(container.layer) && container.releaseId === releaseId,
+    );
+  },
+);
+
 export const fetchContainersByReleaseId = api.get<
   { releaseId: string },
   HalEmbedded<{ containers: DeployContainerResponse[] }>

--- a/src/ui/pages/app-detail-service.tsx
+++ b/src/ui/pages/app-detail-service.tsx
@@ -13,7 +13,7 @@ import { AppState, DeployContainer } from "@app/types";
 import { LoadResources, Loading, TableHead, Td } from "../shared";
 import {
   fetchContainersByReleaseId,
-  selectContainersByReleaseId,
+  selectContainersByReleaseIdByLayerType,
 } from "@app/deploy/container";
 import { fetchMetricTunnelForAppCpu } from "@app/metric-tunnel";
 import { useEffect } from "react";
@@ -104,7 +104,10 @@ export function AppDetailServicePage() {
   useQuery(fetchRelease({ id: service.currentReleaseId }));
   useQuery(fetchContainersByReleaseId({ releaseId: service.currentReleaseId }));
   const containers = useSelector((s: AppState) =>
-    selectContainersByReleaseId(s, { releaseId: service.currentReleaseId }),
+    selectContainersByReleaseIdByLayerType(s, {
+      layers: ["app", "database"],
+      releaseId: service.currentReleaseId,
+    }),
   );
 
   const dataToFetch = ["cpu_pct", "la", "memory_all"];


### PR DESCRIPTION
this fixes by only filtering on apps and database layers' containers

proof provided in slack thread