### PR TITLE
Make Metrics Table Responsive

### DIFF
--- a/src/ui/pages/app-detail-service.tsx
+++ b/src/ui/pages/app-detail-service.tsx
@@ -37,7 +37,7 @@ export function AppDetailServicePage() {
   return (
     <LoadResources query={query} isEmpty={false}>
       {containers.map((container) => (
-        <div className="my-4">
+        <div className="my-2">
           <ContainerMetricsDataTable
             key={container.id}
             container={container}

--- a/src/ui/pages/db-detail-metrics.tsx
+++ b/src/ui/pages/db-detail-metrics.tsx
@@ -35,7 +35,7 @@ export function DatabaseMetricsPage() {
   return (
     <LoadResources query={query} isEmpty={false}>
       {containers.map((container) => (
-        <div className="my-4">
+        <div className="my-2">
           <ContainerMetricsDataTable
             key={container.id}
             container={container}

--- a/src/ui/shared/container-metrics-table.tsx
+++ b/src/ui/shared/container-metrics-table.tsx
@@ -65,7 +65,9 @@ export const ContainerMetricsDataTable = ({
     tableRows.push(
       <tr className="hover:bg-gray-50" key={`${i}`}>
         {columnHeaders.map((columnHeader) => (
-          <Td className="text-gray-900" key={`${i}-${columnHeader}`}>{resultantData[columnHeader][i]}</Td>
+          <Td className="text-gray-900" key={`${i}-${columnHeader}`}>
+            {resultantData[columnHeader][i]}
+          </Td>
         ))}
       </tr>,
     );

--- a/src/ui/shared/container-metrics-table.tsx
+++ b/src/ui/shared/container-metrics-table.tsx
@@ -63,9 +63,9 @@ export const ContainerMetricsDataTable = ({
   const tableRows = [];
   for (let i = 0; i < Object.values(resultantData)[0].length; i += 1) {
     tableRows.push(
-      <tr key={`${i}`}>
+      <tr className="hover:bg-gray-50" key={`${i}`}>
         {columnHeaders.map((columnHeader) => (
-          <Td key={`${i}-${columnHeader}`}>{resultantData[columnHeader][i]}</Td>
+          <Td className="text-gray-900" key={`${i}-${columnHeader}`}>{resultantData[columnHeader][i]}</Td>
         ))}
       </tr>,
     );

--- a/src/ui/shared/container-metrics-table.tsx
+++ b/src/ui/shared/container-metrics-table.tsx
@@ -72,7 +72,7 @@ export const ContainerMetricsDataTable = ({
   }
 
   return (
-    <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 rounded-lg my-4 mx-4 sm:my-auto sm:mx-auto">
+    <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 rounded-lg lg:w-full w-[calc(100vw-7.5rem)]">
       <table className="min-w-full divide-y divide-gray-300">
         <TableHead headers={columnHeaders} />
         <tbody className="divide-y divide-gray-200 bg-white">{tableRows}</tbody>


### PR DESCRIPTION
Make metrics table responsive

BEFORE
• Does NOT scroll horizontally
<img width="841" alt="Screen Shot 2023-07-11 at 2 15 45 PM" src="https://github.com/aptible/app-ui/assets/4295811/155921f4-a401-4c73-9d2d-e43f61bf0f9f">

AFTER
• Scrolls horizontally
• Cells are easier to read
• Add TROW hover state to boost legibility in sea of data
<img width="822" alt="Screen Shot 2023-07-11 at 2 21 51 PM" src="https://github.com/aptible/app-ui/assets/4295811/33b98412-8393-4e9d-a785-c8b70ca3ed36">

