### PR TITLE
Change-Login-Link-jc

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -652,11 +652,6 @@ export const appRoutes: RouteObject[] = [
   },
 
   {
-    path: routes.SIGNUP_PATH,
-    element: <SignupPage />,
-  },
-
-  {
     path: routes.SSO_ORG_FAILURE_PATH,
     element: <UnauthRequired />,
     children: [

--- a/src/ui/pages/login.tsx
+++ b/src/ui/pages/login.tsx
@@ -19,7 +19,6 @@ import {
   acceptInvitationWithCodeUrl,
   forgotPassUrl,
   homeUrl,
-  signupUrl,
 } from "@app/routes";
 import { validEmail } from "@app/string-utils";
 
@@ -102,9 +101,9 @@ export const LoginPage = () => {
         <div className="max-w-2xl">
           <p>
             Don't have an account?{" "}
-            <Link to={signupUrl()} className="font-medium">
+            <a href={`https://dashboard.aptible.com/signup`} className="font-medium">
               Sign up
-            </Link>
+            </a>
           </p>
         </div>
       </div>

--- a/src/ui/pages/login.tsx
+++ b/src/ui/pages/login.tsx
@@ -101,7 +101,10 @@ export const LoginPage = () => {
         <div className="max-w-2xl">
           <p>
             Don't have an account?{" "}
-            <a href={`https://dashboard.aptible.com/signup`} className="font-medium">
+            <a
+              href={"https://dashboard.aptible.com/signup"}
+              className="font-medium"
+            >
               Sign up
             </a>
           </p>

--- a/src/ui/pages/login.tsx
+++ b/src/ui/pages/login.tsx
@@ -103,9 +103,9 @@ export const LoginPage = () => {
         <div className="max-w-2xl">
           <p>
             Don't have an account?{" "}
-            <ExternalLink href={`${legacyUrl}/signup`} className="font-medium">
+            <Link to={`${legacyUrl}/signup`} className="font-medium">
               Sign up
-            </ExternalLink>
+            </Link>
           </p>
         </div>
       </div>

--- a/src/ui/pages/login.tsx
+++ b/src/ui/pages/login.tsx
@@ -1,9 +1,9 @@
+import { selectLegacyDashboardUrl } from "@app/env";
 import { useLoaderSuccess } from "@app/fx";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router";
 import { Link } from "react-router-dom";
-import { selectLegacyDashboardUrl } from "@app/env";
 
 import {
   login,

--- a/src/ui/pages/login.tsx
+++ b/src/ui/pages/login.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router";
 import { Link } from "react-router-dom";
+import { selectLegacyDashboardUrl } from "@app/env";
 
 import {
   login,
@@ -94,6 +95,7 @@ export const LoginPage = () => {
   }, [isOtpError]);
 
   const isOtpRequired = loader.message === "OtpTokenRequired";
+  const legacyUrl = useSelector(selectLegacyDashboardUrl);
   return (
     <HeroBgLayout width={500}>
       <h1 className={`${tokens.type.h1} text-center`}>Log In</h1>
@@ -101,12 +103,9 @@ export const LoginPage = () => {
         <div className="max-w-2xl">
           <p>
             Don't have an account?{" "}
-            <a
-              href={"https://dashboard.aptible.com/signup"}
-              className="font-medium"
-            >
+            <ExternalLink href={`${legacyUrl}/signup`} className="font-medium">
               Sign up
-            </a>
+            </ExternalLink>
           </p>
         </div>
       </div>


### PR DESCRIPTION
**Quickfix so we don't have to spend more time on Sign Up flow bugs** 
• On the Login Page, point the sign up link to https://dashboard.aptible.com/signup

<img width="972" alt="Screen Shot 2023-07-12 at 9 52 43 AM" src="https://github.com/aptible/app-ui/assets/4295811/c72b33d5-4274-4caf-b2f7-a2a121831921">
