### PR TITLE
chore: added date formats for reuse

### DIFF
--- a/index.css
+++ b/index.css
@@ -27,9 +27,18 @@ html, body, #app {
 .tooltip-inner {
   display: none;
   transform: translate(0%, -110%);
-  width: max-content;
 }
 
 .tooltip:hover .tooltip-inner {
   display: inline;
+}
+
+.tooltip-long-wrapper .tooltip-inner {
+  width: max-content;
+}
+
+@media (max-width: 720px) {
+  .tooltip-long-wrapper .tooltip-inner {
+    width: 60vw;
+  }
 }

--- a/index.css
+++ b/index.css
@@ -27,6 +27,7 @@ html, body, #app {
 .tooltip-inner {
   display: none;
   transform: translate(0%, -110%);
+  width: max-content;
 }
 
 .tooltip:hover .tooltip-inner {

--- a/index.css
+++ b/index.css
@@ -33,12 +33,3 @@ html, body, #app {
   display: inline;
 }
 
-.tooltip-long-wrapper .tooltip-inner {
-  width: max-content;
-}
-
-@media (max-width: 720px) {
-  .tooltip-long-wrapper .tooltip-inner {
-    width: 60vw;
-  }
-}

--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -1,4 +1,5 @@
 import {
+  addMinutes,
   format,
   formatDistanceStrict,
   formatDistanceToNowStrict,
@@ -74,6 +75,10 @@ export const timeBetween = ({
       formatDistance,
     },
   });
+};
+
+export const formatDateToUTC = (dateStr = "") => {
+  return new Date(dateStr).toISOString();
 };
 
 export const prettyEnglishDate = (dateStr = "") => {

--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -1,5 +1,4 @@
 import {
-  addMinutes,
   format,
   formatDistanceStrict,
   formatDistanceToNowStrict,

--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -1,4 +1,5 @@
 import {
+  addMinutes,
   format,
   formatDistanceStrict,
   formatDistanceToNowStrict,

--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -112,7 +112,7 @@ function StackList() {
                   <p className="text-gray-500 mt-4 text-base">
                     {stacks.length} Stack{stacks.length !== 1 && "s"}
                   </p>
-                  <div className="mt-4">
+                  <div className="mt-4 tooltip-long-wrapper">
                     <Tooltip text="Stacks represent the virtualized infrastructure where resources are deployed.">
                       <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                     </Tooltip>

--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -112,8 +112,11 @@ function StackList() {
                   <p className="text-gray-500 mt-4 text-base">
                     {stacks.length} Stack{stacks.length !== 1 && "s"}
                   </p>
-                  <div className="mt-4 tooltip-long-wrapper">
-                    <Tooltip text="Stacks represent the virtualized infrastructure where resources are deployed.">
+                  <div className="mt-4">
+                    <Tooltip
+                      fluid
+                      text="Stacks represent the virtualized infrastructure where resources are deployed."
+                    >
                       <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                     </Tooltip>
                   </div>

--- a/src/ui/pages/styles.tsx
+++ b/src/ui/pages/styles.tsx
@@ -65,6 +65,8 @@ import {
   pillStyles,
   tokens,
 } from "../shared";
+import { DateText } from "../shared/date-text";
+import { dateFromToday } from "@app/date";
 import {
   defaultDeployApp,
   defaultDeployDatabase,
@@ -667,6 +669,23 @@ const Secrets = () => {
   );
 };
 
+const Dates = () => {
+  return (
+    <div className="flex flex-col gap-3">
+      <h1 id="dates" className={tokens.type.h1}>
+        Dates
+      </h1>
+      <DateText date={new Date()} />
+      <DateText date={new Date()} format="pretty-english" />
+      <DateText date={new Date()} format="pretty-english-date-relative" />
+      <span className="flex">
+        <DateText date={dateFromToday(-10)} format="time-ago" />{" "}
+        <strong className="ml-2">(Hover the date)</strong>
+      </span>
+    </div>
+  );
+};
+
 export const StylesPage = () => (
   <div className="px-4 py-4">
     <StylesWrapper navigation={<StylesNavigation />}>
@@ -683,6 +702,7 @@ export const StylesPage = () => (
       <Info />
       <DetailBoxes />
       <Secrets />
+      <Dates />
     </StylesWrapper>
   </div>
 );

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -201,7 +201,7 @@ function ActivityTable({
               <p className="flex text-gray-500 mt-4 text-base">
                 {ops.length} Operation{ops.length !== 1 ? "s" : ""}
               </p>
-              <div className="mt-4">
+              <div className="mt-4 tooltip-long-wrapper">
                 <Tooltip text="Operations show real-time changes to resources, such as Apps and Databases.">
                   <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                 </Tooltip>

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -201,8 +201,11 @@ function ActivityTable({
               <p className="flex text-gray-500 mt-4 text-base">
                 {ops.length} Operation{ops.length !== 1 ? "s" : ""}
               </p>
-              <div className="mt-4 tooltip-long-wrapper">
-                <Tooltip text="Operations show real-time changes to resources, such as Apps and Databases.">
+              <div className="mt-4">
+                <Tooltip
+                  fluid
+                  text="Operations show real-time changes to resources, such as Apps and Databases."
+                >
                   <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                 </Tooltip>
               </div>

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -189,7 +189,7 @@ const AppsResourceHeaderTitleBar = ({
                 <p className="flex text-gray-500 mt-4 text-base">
                   {apps.length} App{apps.length !== 1 && "s"}
                 </p>
-                <div className="mt-4">
+                <div className="mt-4 tooltip-long-wrapper">
                   <Tooltip text="Apps are how you deploy your code, scale services, and manage endpoints.">
                     <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                   </Tooltip>

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -189,8 +189,11 @@ const AppsResourceHeaderTitleBar = ({
                 <p className="flex text-gray-500 mt-4 text-base">
                   {apps.length} App{apps.length !== 1 && "s"}
                 </p>
-                <div className="mt-4 tooltip-long-wrapper">
-                  <Tooltip text="Apps are how you deploy your code, scale services, and manage endpoints.">
+                <div className="mt-4">
+                  <Tooltip
+                    fluid
+                    text="Apps are how you deploy your code, scale services, and manage endpoints."
+                  >
                     <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                   </Tooltip>
                 </div>

--- a/src/ui/shared/date-text.tsx
+++ b/src/ui/shared/date-text.tsx
@@ -1,0 +1,42 @@
+import { Tooltip } from "./tooltip";
+import {
+  formatDateToUTC,
+  prettyDateRelative,
+  prettyEnglishDate,
+  timeAgo,
+} from "@app/date";
+
+export const DateText = ({
+  date,
+  format = "utc-format",
+}: {
+  date: Date | string;
+  format?:
+    | "utc-format"
+    | "pretty-english"
+    | "pretty-english-date-relative"
+    | "time-ago";
+}) => {
+  if (format === "utc-format") {
+    return <span>{formatDateToUTC(date.toString())}</span>;
+  }
+  if (format === "pretty-english") {
+    return (
+      <Tooltip text={formatDateToUTC(date.toString())}>
+        <span>{prettyEnglishDate(date.toString())}</span>
+      </Tooltip>
+    );
+  }
+  if (format === "pretty-english-date-relative") {
+    return (
+      <Tooltip text={formatDateToUTC(date.toString())}>
+        <span>{prettyDateRelative(date.toString())}</span>
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip text={formatDateToUTC(date.toString())}>
+      <span>{timeAgo(date.toString())}</span>
+    </Tooltip>
+  );
+};

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -114,7 +114,7 @@ const DbsResourceHeaderTitleBar = ({
                 <p className="flex text-gray-500 mt-4 text-base">
                   {dbs.length} Database{dbs.length !== 1 && "s"}
                 </p>
-                <div className="mt-4">
+                <div className="mt-4 tooltip-long-wrapper">
                   <Tooltip text="Databases provide data persistence and are automatically configured and managed.">
                     <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                   </Tooltip>

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -114,8 +114,11 @@ const DbsResourceHeaderTitleBar = ({
                 <p className="flex text-gray-500 mt-4 text-base">
                   {dbs.length} Database{dbs.length !== 1 && "s"}
                 </p>
-                <div className="mt-4 tooltip-long-wrapper">
-                  <Tooltip text="Databases provide data persistence and are automatically configured and managed.">
+                <div className="mt-4">
+                  <Tooltip
+                    fluid
+                    text="Databases provide data persistence and are automatically configured and managed."
+                  >
                     <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                   </Tooltip>
                 </div>

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -151,8 +151,11 @@ export function EnvironmentList() {
                       {environments.length} Environment
                       {environments.length !== 1 ? "s" : ""}
                     </p>
-                    <div className="mt-4 tooltip-long-wrapper">
-                      <Tooltip text="Environments are how you separate resources like staging and production.">
+                    <div className="mt-4">
+                      <Tooltip
+                        fluid
+                        text="Environments are how you separate resources like staging and production."
+                      >
                         <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                       </Tooltip>
                     </div>

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -151,7 +151,7 @@ export function EnvironmentList() {
                       {environments.length} Environment
                       {environments.length !== 1 ? "s" : ""}
                     </p>
-                    <div className="mt-4">
+                    <div className="mt-4 tooltip-long-wrapper">
                       <Tooltip text="Environments are how you separate resources like staging and production.">
                         <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
                       </Tooltip>

--- a/src/ui/shared/tooltip.tsx
+++ b/src/ui/shared/tooltip.tsx
@@ -2,9 +2,15 @@ import cn from "classnames";
 
 export const Tooltip = ({
   autoSizeWidth = false,
+  fluid,
   children,
   text,
-}: { autoSizeWidth?: boolean; children: React.ReactNode; text: string }) => {
+}: {
+  autoSizeWidth?: boolean;
+  fluid?: boolean;
+  children: React.ReactNode;
+  text: string;
+}) => {
   return (
     <div className="relative tooltip">
       <div className="cursor-pointer">{children}</div>
@@ -19,6 +25,7 @@ export const Tooltip = ({
           "px-3 py-2",
           "bg-black text-white",
           autoSizeWidth ? "w-96" : "",
+          fluid ? "w-[60vw] md:w-max" : "",
         ])}
       >
         {text}

--- a/src/ui/shared/tooltip.tsx
+++ b/src/ui/shared/tooltip.tsx
@@ -1,9 +1,10 @@
 import cn from "classnames";
 
 export const Tooltip = ({
+  autoSizeWidth = false,
   children,
   text,
-}: { children: React.ReactNode; text: string }) => {
+}: { autoSizeWidth?: boolean; children: React.ReactNode; text: string }) => {
   return (
     <div className="relative tooltip">
       <div className="cursor-pointer">{children}</div>
@@ -16,8 +17,8 @@ export const Tooltip = ({
           "absolute",
           "rounded-md",
           "px-3 py-2",
-          "w-96",
           "bg-black text-white",
+          autoSizeWidth ? "w-96" : "",
         ])}
       >
         {text}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,14 +5921,14 @@ __metadata:
   linkType: hard
 
 "tough-cookie@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "tough-cookie@npm:4.1.2"
+  version: 4.1.3
+  resolution: "tough-cookie@npm:4.1.3"
   dependencies:
     psl: ^1.1.33
     punycode: ^2.1.1
     universalify: ^0.2.0
     url-parse: ^1.5.3
-  checksum: a7359e9a3e875121a84d6ba40cc184dec5784af84f67f3a56d1d2ae39b87c0e004e6ba7c7331f9622a7d2c88609032473488b28fe9f59a1fec115674589de39a
+  checksum: c9226afff36492a52118432611af083d1d8493a53ff41ec4ea48e5b583aec744b989e4280bcf476c910ec1525a89a4a0f1cae81c08b18fb2ec3a9b3a72b91dcc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,14 +5921,14 @@ __metadata:
   linkType: hard
 
 "tough-cookie@npm:^4.1.2":
-  version: 4.1.3
-  resolution: "tough-cookie@npm:4.1.3"
+  version: 4.1.2
+  resolution: "tough-cookie@npm:4.1.2"
   dependencies:
     psl: ^1.1.33
     punycode: ^2.1.1
     universalify: ^0.2.0
     url-parse: ^1.5.3
-  checksum: c9226afff36492a52118432611af083d1d8493a53ff41ec4ea48e5b583aec744b989e4280bcf476c910ec1525a89a4a0f1cae81c08b18fb2ec3a9b3a72b91dcc
+  checksum: a7359e9a3e875121a84d6ba40cc184dec5784af84f67f3a56d1d2ae39b87c0e004e6ba7c7331f9622a7d2c88609032473488b28fe9f59a1fec115674589de39a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Full format (in UTC):

<img width="280" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/0392aa26-70a4-4c7d-a275-27a306f5066b">

Example tooltip:

<img width="298" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/1152f1b7-2afe-41f4-a17b-dd5746e8f87f">

---

We can use these as needed in various places