### PR TITLE
feat: added stack pages

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -67,7 +67,6 @@ import {
   SsoLoginPage,
   StackDetailEnvironmentsPage,
   StackDetailLayout,
-  StackDetailPage,
   StackDetailVpcPeeringPage,
   StackDetailVpnTunnelsPage,
   StacksPage,
@@ -287,9 +286,6 @@ export const appRoutes: RouteObject[] = [
             children: [
               {
                 index: true,
-                element: <StackDetailPage />,
-              },
-              {
                 path: routes.STACK_DETAIL_ENVS_PATH,
                 element: <StackDetailEnvironmentsPage />,
               },

--- a/src/deploy/environment/index.ts
+++ b/src/deploy/environment/index.ts
@@ -236,6 +236,26 @@ export const selectEnvironmentsForTableSearch = createSelector(
   },
 );
 
+export const selectEnvironmentsForTableSearchByStackId = createSelector(
+  selectEnvironmentsByOrgAsList,
+  (_: AppState, props: { search: string }) => props.search.toLocaleLowerCase(),
+  (_: AppState, props: { stackId?: string }) => props.stackId || "",
+  (envs, search, stackId): DeployEnvironment[] => {
+    if (search === "") {
+      return envs;
+    }
+
+    return envs
+      .filter((env) => {
+        const handleMatch =
+          env.handle.toLocaleLowerCase().includes(search) &&
+          env.stackId === stackId;
+        return handleMatch;
+      })
+      .sort((a, b) => a.handle.localeCompare(b.handle));
+  },
+);
+
 export const selectEnvironmentsByStack = createSelector(
   selectEnvironmentsAsList,
   (_: AppState, p: { stackId: string }) => p.stackId,

--- a/src/deploy/environment/index.ts
+++ b/src/deploy/environment/index.ts
@@ -236,6 +236,16 @@ export const selectEnvironmentsForTableSearch = createSelector(
   },
 );
 
+export const selectEnvironmentsByStackId = createSelector(
+  selectEnvironmentsAsList,
+  (_: AppState, props: { stackId: string }) => props.stackId,
+  (envs, stackId) => {
+    return envs
+      .filter((env) => env.stackId === stackId)
+      .sort((a, b) => a.id.localeCompare(b.id));
+  },
+);
+
 export const selectEnvironmentsForTableSearchByStackId = createSelector(
   selectEnvironmentsByOrgAsList,
   (_: AppState, props: { search: string }) => props.search.toLocaleLowerCase(),
@@ -247,10 +257,10 @@ export const selectEnvironmentsForTableSearchByStackId = createSelector(
 
     return envs
       .filter((env) => {
-        const handleMatch =
+        return (
           env.handle.toLocaleLowerCase().includes(search) &&
-          env.stackId === stackId;
-        return handleMatch;
+          env.stackId === stackId
+        );
       })
       .sort((a, b) => a.handle.localeCompare(b.handle));
   },

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -18,3 +18,5 @@ export * from "./activity";
 export * from "./permission";
 export * from "./release";
 export * from "./container";
+export * from "./vpc_peer";
+export * from "./vpn_tunnel";

--- a/src/deploy/state.ts
+++ b/src/deploy/state.ts
@@ -27,6 +27,8 @@ import {
 import { releaseEntities, releaseReducers } from "./release";
 import { serviceEntities, serviceReducers } from "./service";
 import { stackEntities, stackReducers } from "./stack";
+import { vpcPeerEntities, vpcPeerReducers } from "./vpc_peer";
+import { vpnTunnelEntities, vpnTunnelReducers } from "./vpn_tunnel";
 
 const allReducers: any[] = [
   appReducers,
@@ -46,6 +48,8 @@ const allReducers: any[] = [
   permissionReducers,
   releaseReducers,
   containerReducers,
+  vpcPeerReducers,
+  vpnTunnelReducers,
 ];
 
 const rootReducer = combineReducers(
@@ -76,4 +80,6 @@ export const entities = {
   ...permissionEntities,
   ...releaseEntities,
   ...containerEntities,
+  ...vpcPeerEntities,
+  ...vpnTunnelEntities,
 };

--- a/src/deploy/vpc_peer/index.ts
+++ b/src/deploy/vpc_peer/index.ts
@@ -1,0 +1,104 @@
+import { selectDeploy } from "../slice";
+import { defaultEntity, extractIdFromLink } from "@app/hal";
+import {
+  createReducerMap,
+  createTable,
+  mustSelectEntity,
+} from "@app/slice-helpers";
+import { AppState, DeployVpcPeer, LinkResponse } from "@app/types";
+import { createSelector } from "@reduxjs/toolkit";
+
+export interface DeployVpcPeerResponse {
+  id: number;
+  connection_id: string;
+  connection_status: string;
+  description: string;
+  peer_account_id: string;
+  peer_vpc_id: string;
+  created_at: string;
+  updated_at: string;
+  _links: {
+    stack: LinkResponse;
+  };
+  _type: "vpc_peer";
+}
+
+export const defaultVpcPeerResponse = (
+  s: Partial<DeployVpcPeerResponse> = {},
+): DeployVpcPeerResponse => {
+  const now = new Date().toISOString();
+  return {
+    id: 1,
+    connection_id: "",
+    connection_status: "",
+    description: "",
+    peer_account_id: "",
+    peer_vpc_id: "",
+    created_at: now,
+    updated_at: now,
+    _links: { stack: { href: "" } },
+    _type: "vpc_peer",
+    ...s,
+  };
+};
+
+export const deserializeDeployVpcPeer = (
+  payload: DeployVpcPeerResponse,
+): DeployVpcPeer => {
+  return {
+    id: `${payload.id}`,
+    connectionId: payload.connection_id,
+    connectionStatus: payload.connection_status,
+    description: payload.description,
+    peerAccountId: payload.peer_account_id,
+    peerVpcId: payload.peer_vpc_id,
+    createdAt: payload.created_at,
+    updatedAt: payload.updated_at,
+    stackId: extractIdFromLink(payload._links.stack),
+  };
+};
+
+export const defaultDeployVpcPeer = (
+  s: Partial<DeployVpcPeer> = {},
+): DeployVpcPeer => {
+  const now = new Date().toISOString();
+  return {
+    id: "",
+    connectionId: "",
+    connectionStatus: "",
+    description: "",
+    peerAccountId: "",
+    peerVpcId: "",
+    createdAt: now,
+    updatedAt: now,
+    stackId: "",
+    ...s,
+  };
+};
+
+export const DEPLOY_VPC_PEER_NAME = "vpc_peers";
+const slice = createTable<DeployVpcPeer>({
+  name: DEPLOY_VPC_PEER_NAME,
+});
+const { add: addDeployVpcPeer } = slice.actions;
+const selectors = slice.getSelectors(
+  (s: AppState) => selectDeploy(s)[DEPLOY_VPC_PEER_NAME],
+);
+const initVpcPeer = defaultDeployVpcPeer;
+const must = mustSelectEntity(initVpcPeer);
+export const selectVpcPeerById = must(selectors.selectById);
+export const { selectTable: selectVpcPeers } = selectors;
+export const selectVpcPeersAsList = createSelector(
+  selectors.selectTableAsList,
+  (vpcPeers) => vpcPeers.sort((a, b) => a.id.localeCompare(b.id)),
+);
+
+export const vpcPeerReducers = createReducerMap(slice);
+
+export const vpcPeerEntities = {
+  stack: defaultEntity({
+    id: "vpc_peer",
+    deserialize: deserializeDeployVpcPeer,
+    save: addDeployVpcPeer,
+  }),
+};

--- a/src/deploy/vpc_peer/index.ts
+++ b/src/deploy/vpc_peer/index.ts
@@ -5,6 +5,7 @@ import {
   createTable,
   mustSelectEntity,
 } from "@app/slice-helpers";
+import { api } from "@app/api";
 import { AppState, DeployVpcPeer, LinkResponse } from "@app/types";
 import { createSelector } from "@reduxjs/toolkit";
 
@@ -92,11 +93,22 @@ export const selectVpcPeersAsList = createSelector(
   selectors.selectTableAsList,
   (vpcPeers) => vpcPeers.sort((a, b) => a.id.localeCompare(b.id)),
 );
+export const selectVpcPeersByStackId = createSelector(
+  selectVpcPeersAsList,
+  (_: AppState, props: { stackId: string }) => props.stackId,
+  (vpcPeers, stackId) => {
+    return vpcPeers.filter((vpcPeer) => vpcPeer.stackId === stackId);
+  },
+);
+
+export const fetchVpcPeersByStackId = api.get<{ id: string }>(
+  "/stacks/:id/vpc_peers",
+);
 
 export const vpcPeerReducers = createReducerMap(slice);
 
 export const vpcPeerEntities = {
-  vpc_peers: defaultEntity({
+  vpc_peer: defaultEntity({
     id: "vpc_peer",
     deserialize: deserializeDeployVpcPeer,
     save: addDeployVpcPeer,

--- a/src/deploy/vpc_peer/index.ts
+++ b/src/deploy/vpc_peer/index.ts
@@ -96,7 +96,7 @@ export const selectVpcPeersAsList = createSelector(
 export const vpcPeerReducers = createReducerMap(slice);
 
 export const vpcPeerEntities = {
-  stack: defaultEntity({
+  vpc_peers: defaultEntity({
     id: "vpc_peer",
     deserialize: deserializeDeployVpcPeer,
     save: addDeployVpcPeer,

--- a/src/deploy/vpc_peer/index.ts
+++ b/src/deploy/vpc_peer/index.ts
@@ -1,11 +1,11 @@
 import { selectDeploy } from "../slice";
+import { api } from "@app/api";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import {
   createReducerMap,
   createTable,
   mustSelectEntity,
 } from "@app/slice-helpers";
-import { api } from "@app/api";
 import { AppState, DeployVpcPeer, LinkResponse } from "@app/types";
 import { createSelector } from "@reduxjs/toolkit";
 

--- a/src/deploy/vpn_tunnel/index.ts
+++ b/src/deploy/vpn_tunnel/index.ts
@@ -1,0 +1,132 @@
+import { selectDeploy } from "../slice";
+import { defaultEntity, extractIdFromLink } from "@app/hal";
+import {
+  createReducerMap,
+  createTable,
+  mustSelectEntity,
+} from "@app/slice-helpers";
+import { AppState, DeployVpnTunnel, LinkResponse } from "@app/types";
+import { createSelector } from "@reduxjs/toolkit";
+
+export interface DeployVpnTunnelResponse {
+  id: number;
+  handle: string;
+  phase_1_alg: string;
+  phase_1_dh_group: string;
+  phase_1_lifetime: string;
+  phase_2_alg: string;
+  phase_2_dh_group: string;
+  phase_2_lifetime: string;
+  perfect_forward_secrecy: string;
+  our_gateway: string;
+  our_networks: string;
+  peer_gateway: string;
+  peer_networks: string;
+  created_at: string;
+  updated_at: string;
+  _links: {
+    stack: LinkResponse;
+  };
+  _type: "vpn_tunnel";
+}
+
+export const defaultVpnTunnelResponse = (
+  s: Partial<DeployVpnTunnelResponse> = {},
+): DeployVpnTunnelResponse => {
+  const now = new Date().toISOString();
+  return {
+    id: 1,
+    handle: "",
+    phase_1_alg: "",
+    phase_1_dh_group: "",
+    phase_1_lifetime: "",
+    phase_2_alg: "",
+    phase_2_dh_group: "",
+    phase_2_lifetime: "",
+    perfect_forward_secrecy: "",
+    our_gateway: "",
+    our_networks: "",
+    peer_gateway: "",
+    peer_networks: "",
+    created_at: now,
+    updated_at: now,
+    _links: { stack: { href: "" } },
+    _type: "vpn_tunnel",
+    ...s,
+  };
+};
+
+export const deserializeDeployVpnTunnel = (
+  payload: DeployVpnTunnelResponse,
+): DeployVpnTunnel => {
+  return {
+    id: `${payload.id}`,
+    handle: payload.handle,
+    phase1Alg: payload.phase_1_alg,
+    phase1DhGroup: payload.phase_1_dh_group,
+    phase1Lifetime: payload.phase_1_lifetime,
+    phase2Alg: payload.phase_2_alg,
+    phase2DhGroup: payload.phase_2_dh_group,
+    phase2Lifetime: payload.phase_2_lifetime,
+    ourGateway: payload.our_gateway,
+    ourNetworks: payload.our_networks,
+    peerGateway: payload.peer_gateway,
+    peerNetworks: payload.peer_networks,
+    perfectForwardSecrecy: payload.perfect_forward_secrecy,
+    createdAt: payload.created_at,
+    updatedAt: payload.updated_at,
+    stackId: extractIdFromLink(payload._links.stack),
+  };
+};
+
+export const defaultDeployVpnTunnel = (
+  s: Partial<DeployVpnTunnel> = {},
+): DeployVpnTunnel => {
+  const now = new Date().toISOString();
+  return {
+    id: "",
+    handle: "",
+    phase1Alg: "",
+    phase1DhGroup: "",
+    phase1Lifetime: "",
+    phase2Alg: "",
+    phase2DhGroup: "",
+    phase2Lifetime: "",
+    ourGateway: "",
+    ourNetworks: "",
+    peerGateway: "",
+    peerNetworks: "",
+    perfectForwardSecrecy: "",
+    createdAt: now,
+    updatedAt: now,
+    stackId: "",
+    ...s,
+  };
+};
+
+export const DEPLOY_VPN_TUNNEL_NAME = "vpn_tunnels";
+const slice = createTable<DeployVpnTunnel>({
+  name: DEPLOY_VPN_TUNNEL_NAME,
+});
+const { add: addDeployVpnTunnel } = slice.actions;
+const selectors = slice.getSelectors(
+  (s: AppState) => selectDeploy(s)[DEPLOY_VPN_TUNNEL_NAME],
+);
+const initVpnTunnel = defaultDeployVpnTunnel;
+const must = mustSelectEntity(initVpnTunnel);
+export const selectVpnTunnelById = must(selectors.selectById);
+export const { selectTable: selectVpnTunnel } = selectors;
+export const selectVpnTunnelsAsList = createSelector(
+  selectors.selectTableAsList,
+  (vpnTunnels) => vpnTunnels.sort((a, b) => a.handle.localeCompare(b.handle)),
+);
+
+export const vpnTunnelReducers = createReducerMap(slice);
+
+export const vpnTunnelEntities = {
+  stack: defaultEntity({
+    id: "vpn_tunnel",
+    deserialize: deserializeDeployVpnTunnel,
+    save: addDeployVpnTunnel,
+  }),
+};

--- a/src/deploy/vpn_tunnel/index.ts
+++ b/src/deploy/vpn_tunnel/index.ts
@@ -124,7 +124,7 @@ export const selectVpnTunnelsAsList = createSelector(
 export const vpnTunnelReducers = createReducerMap(slice);
 
 export const vpnTunnelEntities = {
-  stack: defaultEntity({
+  vpn_tunnels: defaultEntity({
     id: "vpn_tunnel",
     deserialize: deserializeDeployVpnTunnel,
     save: addDeployVpnTunnel,

--- a/src/deploy/vpn_tunnel/index.ts
+++ b/src/deploy/vpn_tunnel/index.ts
@@ -19,9 +19,9 @@ export interface DeployVpnTunnelResponse {
   phase_2_lifetime: string;
   perfect_forward_secrecy: string;
   our_gateway: string;
-  our_networks: string;
+  our_networks: string[];
   peer_gateway: string;
-  peer_networks: string;
+  peer_networks: string[];
   created_at: string;
   updated_at: string;
   _links: {
@@ -45,9 +45,9 @@ export const defaultVpnTunnelResponse = (
     phase_2_lifetime: "",
     perfect_forward_secrecy: "",
     our_gateway: "",
-    our_networks: "",
+    our_networks: [],
     peer_gateway: "",
-    peer_networks: "",
+    peer_networks: [],
     created_at: now,
     updated_at: now,
     _links: { stack: { href: "" } },
@@ -93,9 +93,9 @@ export const defaultDeployVpnTunnel = (
     phase2DhGroup: "",
     phase2Lifetime: "",
     ourGateway: "",
-    ourNetworks: "",
+    ourNetworks: [],
     peerGateway: "",
-    peerNetworks: "",
+    peerNetworks: [],
     perfectForwardSecrecy: "",
     createdAt: now,
     updatedAt: now,

--- a/src/deploy/vpn_tunnel/index.ts
+++ b/src/deploy/vpn_tunnel/index.ts
@@ -1,5 +1,5 @@
-import { api } from "@app/api";
 import { selectDeploy } from "../slice";
+import { api } from "@app/api";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import {
   createReducerMap,

--- a/src/deploy/vpn_tunnel/index.ts
+++ b/src/deploy/vpn_tunnel/index.ts
@@ -1,3 +1,4 @@
+import { api } from "@app/api";
 import { selectDeploy } from "../slice";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import {
@@ -119,6 +120,17 @@ export const { selectTable: selectVpnTunnel } = selectors;
 export const selectVpnTunnelsAsList = createSelector(
   selectors.selectTableAsList,
   (vpnTunnels) => vpnTunnels.sort((a, b) => a.handle.localeCompare(b.handle)),
+);
+export const selectVpnTunnelByStackId = createSelector(
+  selectVpnTunnelsAsList,
+  (_: AppState, props: { stackId: string }) => props.stackId,
+  (vpnTunnels, stackId) => {
+    return vpnTunnels.filter((vpnTunnel) => vpnTunnel.stackId === stackId);
+  },
+);
+
+export const fetchVpnTunnelsByStackId = api.get<{ id: string }>(
+  "/stacks/:id/vpn_tunnels",
 );
 
 export const vpnTunnelReducers = createReducerMap(slice);

--- a/src/deploy/vpn_tunnel/index.ts
+++ b/src/deploy/vpn_tunnel/index.ts
@@ -124,7 +124,7 @@ export const selectVpnTunnelsAsList = createSelector(
 export const vpnTunnelReducers = createReducerMap(slice);
 
 export const vpnTunnelEntities = {
-  vpn_tunnels: defaultEntity({
+  vpn_tunnel: defaultEntity({
     id: "vpn_tunnel",
     deserialize: deserializeDeployVpnTunnel,
     save: addDeployVpnTunnel,

--- a/src/hal/index.ts
+++ b/src/hal/index.ts
@@ -50,6 +50,10 @@ function transformResourceName(name: string | undefined | null): ResourceType {
       return "release";
     case "containers":
       return "container";
+    case "vpc_peers":
+      return "vpc_peer";
+    case "vpn_tunnels":
+      return "vpn_tunnel";
     default:
       return "unknown";
   }

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -422,3 +422,34 @@ export interface DeployContainer extends Timestamps {
   updatedAt: string;
   releaseId: string;
 }
+
+export interface DeployVpcPeer extends Timestamps {
+  id: string;
+  connectionId: string;
+  connectionStatus: string;
+  createdAt: string;
+  description: string;
+  peerAccountId: string;
+  peerVpcId: string;
+  stackId: string;
+  updatedAt: string;
+}
+
+export interface DeployVpnTunnel extends Timestamps {
+  id: string;
+  createdAt: string;
+  handle: string;
+  phase1Alg: string;
+  phase1DhGroup: string;
+  phase1Lifetime: string;
+  phase2Alg: string;
+  phase2DhGroup: string;
+  phase2Lifetime: string;
+  perfectForwardSecrecy: string;
+  ourGateway: string;
+  ourNetworks: string[];
+  peerGateway: string;
+  peerNetworks: string[];
+  stackId: string;
+  updatedAt: string;
+}

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -148,6 +148,8 @@ export type ResourceType =
   | "active_plan"
   | "release"
   | "container"
+  | "vpc_peer"
+  | "vpn_tunnel"
   | "unknown";
 
 // https://github.com/aptible/deploy-api/blob/3b197beaa5bcbbed991c1eac73d5c99a4fdf8f95/app/models/operation.rb#L54

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -18,6 +18,8 @@ import type {
   DeployService,
   DeployServiceDefinition,
   DeployStack,
+  DeployVpcPeer,
+  DeployVpnTunnel,
   Permission,
   Timestamps,
 } from "./deploy";
@@ -124,6 +126,8 @@ export interface DeployState {
   permissions: MapEntity<Permission>;
   releases: MapEntity<DeployRelease>;
   containers: MapEntity<DeployContainer>;
+  vpc_peers: MapEntity<DeployVpcPeer>;
+  vpn_tunnels: MapEntity<DeployVpnTunnel>;
 }
 
 export interface AppState extends QueryState {

--- a/src/ui/pages/index.ts
+++ b/src/ui/pages/index.ts
@@ -50,4 +50,3 @@ export * from "./stacks";
 export * from "./stack-detail-environments";
 export * from "./stack-detail-vpn-tunnels";
 export * from "./stack-detail-vpc-peering";
-export * from "./stack-detail";

--- a/src/ui/pages/logout.test.tsx
+++ b/src/ui/pages/logout.test.tsx
@@ -79,6 +79,8 @@ describe("LogoutPage", () => {
         stacks: {},
         releases: {},
         containers: {},
+        vpc_peers: {},
+        vpn_tunnels: {},
       });
     });
   });

--- a/src/ui/pages/stack-detail-environments.tsx
+++ b/src/ui/pages/stack-detail-environments.tsx
@@ -1,6 +1,13 @@
+import { DetailPageSections, EnvironmentListByStack } from "../shared";
 import { useParams } from "react-router";
 
 export const StackDetailEnvironmentsPage = () => {
   const { id = "" } = useParams();
-  return <div>Stack detail environments {id}</div>;
+  return (
+    <div className="mb-4">
+      <DetailPageSections>
+        <EnvironmentListByStack stackId={id} />
+      </DetailPageSections>
+    </div>
+  );
 };

--- a/src/ui/pages/stack-detail-vpc-peering.tsx
+++ b/src/ui/pages/stack-detail-vpc-peering.tsx
@@ -1,6 +1,120 @@
+import { useQuery } from "@app/fx";
 import { useParams } from "react-router";
+
+import type { AppState, DeployVpcPeer } from "@app/types";
+
+import {
+  LoadResources,
+  Pill,
+  ResourceListView,
+  TableHead,
+  Td,
+  pillStyles,
+  tokens,
+} from "../shared";
+import { EmptyResourcesTable } from "../shared/empty-resources-table";
+import { fetchVpcPeersByStackId, selectVpcPeersByStackId } from "@app/deploy";
+import { useSelector } from "react-redux";
+import { capitalize } from "@app/string-utils";
+
+const VPCPeerStatusPill = ({
+  vpcPeer,
+}: {
+  vpcPeer: DeployVpcPeer;
+}) => {
+  return (
+    <Pill
+      className={
+        vpcPeer.connectionStatus === "active"
+          ? pillStyles.success
+          : pillStyles.error
+      }
+    >
+      {capitalize(vpcPeer.connectionStatus)}
+    </Pill>
+  );
+};
+
+const VpcPeerPrimaryCell = ({ vpcPeer }: { vpcPeer: DeployVpcPeer }) => {
+  return (
+    <Td className="flex-1">
+      <div className="flex">
+        <p className="leading-4">
+          <VPCPeerStatusPill vpcPeer={vpcPeer} />
+        </p>
+      </div>
+    </Td>
+  );
+};
+
+const VpcPeerHandle = ({ vpcPeer }: { vpcPeer: DeployVpcPeer }) => {
+  return (
+    <Td className="flex-1">
+      <div className="flex">
+        <p className="leading-4">
+          <span className={tokens.type.darker}>{vpcPeer.connectionId}</span>
+        </p>
+      </div>
+    </Td>
+  );
+};
+
+const VpcPeerDescription = ({ vpcPeer }: { vpcPeer: DeployVpcPeer }) => {
+  return (
+    <Td className="flex-1">
+      <div className="flex">
+        <p className="leading-4">
+          <span className={tokens.type.darker}>{vpcPeer.description}</span>
+        </p>
+      </div>
+    </Td>
+  );
+};
+
+const vpcPeersHeaders = ["Status", "VPC Peer", "Description"];
 
 export const StackDetailVpcPeeringPage = () => {
   const { id = "" } = useParams();
-  return <div>Stack detail vpc peering {id}</div>;
+  const query = useQuery(fetchVpcPeersByStackId({ id }));
+  const vpcPeers = useSelector((s: AppState) =>
+    selectVpcPeersByStackId(s, { stackId: id }),
+  );
+
+  return (
+    <LoadResources
+      empty={
+        <EmptyResourcesTable
+          headers={vpcPeersHeaders}
+          titleBar={
+            <p className="flex text-gray-500 text-base mb-4">
+              {vpcPeers.length} VPC Peer
+              {vpcPeers.length !== 1 && "s"}
+            </p>
+          }
+        />
+      }
+      query={query}
+      isEmpty={vpcPeers.length === 0}
+    >
+      <ResourceListView
+        header={
+          <p className="flex text-gray-500 text-base mb-4">
+            {vpcPeers.length} VPC Peer{vpcPeers.length !== 1 && "s"}
+          </p>
+        }
+        tableHeader={<TableHead headers={vpcPeersHeaders} />}
+        tableBody={
+          <>
+            {vpcPeers.map((vpcPeer) => (
+              <tr key={vpcPeer.id}>
+                <VpcPeerPrimaryCell vpcPeer={vpcPeer} />
+                <VpcPeerHandle vpcPeer={vpcPeer} />
+                <VpcPeerDescription vpcPeer={vpcPeer} />
+              </tr>
+            ))}
+          </>
+        }
+      />
+    </LoadResources>
+  );
 };

--- a/src/ui/pages/stack-detail-vpc-peering.tsx
+++ b/src/ui/pages/stack-detail-vpc-peering.tsx
@@ -4,6 +4,10 @@ import { useParams } from "react-router";
 import type { AppState, DeployVpcPeer } from "@app/types";
 
 import {
+  Box,
+  Button,
+  ButtonLinkExternal,
+  IconExternalLink,
   LoadResources,
   Pill,
   ResourceListView,
@@ -16,6 +20,7 @@ import { EmptyResourcesTable } from "../shared/empty-resources-table";
 import { fetchVpcPeersByStackId, selectVpcPeersByStackId } from "@app/deploy";
 import { useSelector } from "react-redux";
 import { capitalize } from "@app/string-utils";
+import { Link } from "react-router-dom";
 
 const VPCPeerStatusPill = ({
   vpcPeer,
@@ -79,40 +84,62 @@ export const StackDetailVpcPeeringPage = () => {
   );
 
   return (
-    <LoadResources
-      empty={
-        <EmptyResourcesTable
-          headers={vpcPeersHeaders}
-          titleBar={
+    <div className="mb-4">
+      <Box className="mb-4">
+        <ButtonLinkExternal
+          href="https://www.aptible.com/docs/network-integrations"
+          className="relative float-right"
+          variant="white"
+          size="sm"
+        >
+          View Docs
+          <IconExternalLink className="inline ml-1 h-5 mt-0" />
+        </ButtonLinkExternal>
+        <p className="flex mb-4 text-gray-500 text-md">
+          Contact support to edit or add new VPC Peers.
+        </p>
+        <Link
+          className="hover:no-underline"
+          to="https://www.aptible.com/docs/support"
+        >
+          <Button className="font-semibold">Contact Support</Button>
+        </Link>
+      </Box>
+      <LoadResources
+        empty={
+          <EmptyResourcesTable
+            headers={vpcPeersHeaders}
+            titleBar={
+              <p className="flex text-gray-500 text-base mb-4">
+                {vpcPeers.length} VPC Peer
+                {vpcPeers.length !== 1 && "s"}
+              </p>
+            }
+          />
+        }
+        query={query}
+        isEmpty={vpcPeers.length === 0}
+      >
+        <ResourceListView
+          header={
             <p className="flex text-gray-500 text-base mb-4">
-              {vpcPeers.length} VPC Peer
-              {vpcPeers.length !== 1 && "s"}
+              {vpcPeers.length} VPC Peer{vpcPeers.length !== 1 && "s"}
             </p>
           }
+          tableHeader={<TableHead headers={vpcPeersHeaders} />}
+          tableBody={
+            <>
+              {vpcPeers.map((vpcPeer) => (
+                <tr key={vpcPeer.id}>
+                  <VpcPeerPrimaryCell vpcPeer={vpcPeer} />
+                  <VpcPeerHandle vpcPeer={vpcPeer} />
+                  <VpcPeerDescription vpcPeer={vpcPeer} />
+                </tr>
+              ))}
+            </>
+          }
         />
-      }
-      query={query}
-      isEmpty={vpcPeers.length === 0}
-    >
-      <ResourceListView
-        header={
-          <p className="flex text-gray-500 text-base mb-4">
-            {vpcPeers.length} VPC Peer{vpcPeers.length !== 1 && "s"}
-          </p>
-        }
-        tableHeader={<TableHead headers={vpcPeersHeaders} />}
-        tableBody={
-          <>
-            {vpcPeers.map((vpcPeer) => (
-              <tr key={vpcPeer.id}>
-                <VpcPeerPrimaryCell vpcPeer={vpcPeer} />
-                <VpcPeerHandle vpcPeer={vpcPeer} />
-                <VpcPeerDescription vpcPeer={vpcPeer} />
-              </tr>
-            ))}
-          </>
-        }
-      />
-    </LoadResources>
+      </LoadResources>
+    </div>
   );
 };

--- a/src/ui/pages/stack-detail-vpc-peering.tsx
+++ b/src/ui/pages/stack-detail-vpc-peering.tsx
@@ -18,8 +18,8 @@ import {
 } from "../shared";
 import { EmptyResourcesTable } from "../shared/empty-resources-table";
 import { fetchVpcPeersByStackId, selectVpcPeersByStackId } from "@app/deploy";
-import { useSelector } from "react-redux";
 import { capitalize } from "@app/string-utils";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 
 const VPCPeerStatusPill = ({

--- a/src/ui/pages/stack-detail-vpc-peering.tsx
+++ b/src/ui/pages/stack-detail-vpc-peering.tsx
@@ -39,9 +39,7 @@ const VpcPeerPrimaryCell = ({ vpcPeer }: { vpcPeer: DeployVpcPeer }) => {
   return (
     <Td className="flex-1">
       <div className="flex">
-        <p className="leading-4">
-          <VPCPeerStatusPill vpcPeer={vpcPeer} />
-        </p>
+        <VPCPeerStatusPill vpcPeer={vpcPeer} />
       </div>
     </Td>
   );

--- a/src/ui/pages/stack-detail-vpn-tunnels.tsx
+++ b/src/ui/pages/stack-detail-vpn-tunnels.tsx
@@ -8,13 +8,17 @@ import { useParams } from "react-router";
 import { useQuery } from "saga-query/react";
 import {
   Box,
+  Button,
+  ButtonLinkExternal,
   EmptyResourcesTable,
+  IconExternalLink,
   LoadResources,
   TableHead,
   Td,
   tokens,
 } from "../shared";
 import classNames from "classnames";
+import { Link } from "react-router-dom";
 
 export const StackDetailVpnTunnelsPage = () => {
   const { id = "" } = useParams();
@@ -25,6 +29,26 @@ export const StackDetailVpnTunnelsPage = () => {
 
   return (
     <div className="mb-4">
+      <Box className="mb-4">
+        <ButtonLinkExternal
+          href="https://www.aptible.com/docs/network-integrations"
+          className="relative float-right"
+          variant="white"
+          size="sm"
+        >
+          View Docs
+          <IconExternalLink className="inline ml-1 h-5 mt-0" />
+        </ButtonLinkExternal>
+        <p className="flex mb-4 text-gray-500 text-md">
+          Contact support to edit or add new VPN Tunnels.
+        </p>
+        <Link
+          className="hover:no-underline"
+          to="https://www.aptible.com/docs/support"
+        >
+          <Button className="font-semibold">Contact Support</Button>
+        </Link>
+      </Box>
       <LoadResources
         empty={
           <EmptyResourcesTable

--- a/src/ui/pages/stack-detail-vpn-tunnels.tsx
+++ b/src/ui/pages/stack-detail-vpn-tunnels.tsx
@@ -1,6 +1,148 @@
+import {
+  fetchVpnTunnelsByStackId,
+  selectVpnTunnelByStackId,
+} from "@app/deploy";
+import { AppState } from "@app/types";
+import { useSelector } from "react-redux";
 import { useParams } from "react-router";
+import { useQuery } from "saga-query/react";
+import {
+  Box,
+  EmptyResourcesTable,
+  LoadResources,
+  TableHead,
+  Td,
+  tokens,
+} from "../shared";
+import classNames from "classnames";
 
 export const StackDetailVpnTunnelsPage = () => {
   const { id = "" } = useParams();
-  return <div>Stack detail vpn tunnels {id}</div>;
+  const query = useQuery(fetchVpnTunnelsByStackId({ id }));
+  const vpnTunnels = useSelector((s: AppState) =>
+    selectVpnTunnelByStackId(s, { stackId: id }),
+  );
+
+  return (
+    <div className="mb-4">
+      <LoadResources
+        empty={
+          <EmptyResourcesTable
+            headers={[]}
+            titleBar={
+              <p className="flex text-gray-500 text-base mb-4">
+                {vpnTunnels.length} VPN Tunnel
+                {vpnTunnels.length !== 1 && "s"}
+              </p>
+            }
+          />
+        }
+        query={query}
+        isEmpty={vpnTunnels.length === 0}
+      >
+        <p className="flex text-gray-500 text-base mb-4">
+          {vpnTunnels.length} VPN Tunnel{vpnTunnels.length !== 1 && "s"}
+        </p>
+        {vpnTunnels.map((vpnTunnel) => (
+          <Box key={vpnTunnel.id} className="mt-4">
+            <h1 className={classNames(tokens.type.h4, "block")}>
+              {vpnTunnel.handle}
+            </h1>
+            <p className="flex text-gray-500 text-base my-4">Gateways</p>
+            <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 rounded-lg my-4 mx-4 sm:my-auto sm:mx-auto">
+              <table className="min-w-full divide-y divide-gray-300">
+                <TableHead headers={["Gateway", "IP Address"]} />
+                <tbody className="divide-y divide-gray-200 bg-white">
+                  <tr>
+                    <Td>Deploy Gateway</Td>
+                    <Td>{vpnTunnel.ourGateway}</Td>
+                  </tr>
+                  <tr>
+                    <Td>Peer Gateway</Td>
+                    <Td>{vpnTunnel.peerGateway}</Td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="flex text-gray-500 text-base my-4">Attributes</p>
+            <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 rounded-lg my-4 mx-4 sm:my-auto sm:mx-auto">
+              <table className="min-w-full divide-y divide-gray-300">
+                <TableHead headers={["IKE Phase", "Parameter", "Value"]} />
+                <tbody className="divide-y divide-gray-200 bg-white">
+                  <tr>
+                    <Td>Phase 1</Td>
+                    <Td>Algorithm</Td>
+                    <Td>{vpnTunnel.phase1Alg}</Td>
+                  </tr>
+                  <tr>
+                    <Td>Phase 1</Td>
+                    <Td>Lifetime</Td>
+                    <Td>{vpnTunnel.phase1Lifetime}</Td>
+                  </tr>
+                  <tr>
+                    <Td>Phase 1</Td>
+                    <Td>DH Group</Td>
+                    <Td>{vpnTunnel.phase1DhGroup}</Td>
+                  </tr>
+                  <tr>
+                    <Td>Phase 2</Td>
+                    <Td>Algorithm</Td>
+                    <Td>{vpnTunnel.phase2Alg}</Td>
+                  </tr>
+                  <tr>
+                    <Td>Phase 2</Td>
+                    <Td>Lifetime</Td>
+                    <Td>{vpnTunnel.phase2Lifetime}</Td>
+                  </tr>
+                  <tr>
+                    <Td>Phase 2</Td>
+                    <Td>DH Group</Td>
+                    <Td>{vpnTunnel.phase2DhGroup}</Td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="flex text-gray-500 text-base my-4">Deploy Networks</p>
+            <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 rounded-lg my-4 mx-4 sm:my-auto sm:mx-auto">
+              <table className="min-w-full divide-y divide-gray-300">
+                <TableHead
+                  headers={[
+                    "Network (As visible by peer)",
+                    "Network (As routed by Aptible)",
+                  ]}
+                />
+                <tbody className="divide-y divide-gray-200 bg-white">
+                  {vpnTunnel.ourNetworks.map((ourNetwork) => (
+                    <tr key={ourNetwork}>
+                      <Td>{ourNetwork?.[0] || "N/A"}</Td>
+                      <Td>{ourNetwork?.[1] || "N/A"}</Td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="flex text-gray-500 text-base my-4">Peer Networks</p>
+            <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 rounded-lg my-4 mx-4 sm:my-auto sm:mx-auto">
+              <table className="min-w-full divide-y divide-gray-300">
+                <TableHead
+                  headers={[
+                    "Network (As visible by Aptible)",
+                    "Network (As routed to Aptible)",
+                  ]}
+                />
+                <tbody className="divide-y divide-gray-200 bg-white">
+                  {vpnTunnel.peerNetworks.map((peerNetwork) => (
+                    <tr key={peerNetwork}>
+                      <Td>{peerNetwork?.[0] || "N/A"}</Td>
+                      <Td>{peerNetwork?.[1] || "N/A"}</Td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Box>
+        ))}
+      </LoadResources>
+    </div>
+  );
 };

--- a/src/ui/pages/stack-detail-vpn-tunnels.tsx
+++ b/src/ui/pages/stack-detail-vpn-tunnels.tsx
@@ -1,12 +1,4 @@
 import {
-  fetchVpnTunnelsByStackId,
-  selectVpnTunnelByStackId,
-} from "@app/deploy";
-import { AppState } from "@app/types";
-import { useSelector } from "react-redux";
-import { useParams } from "react-router";
-import { useQuery } from "saga-query/react";
-import {
   Box,
   Button,
   ButtonLinkExternal,
@@ -17,8 +9,16 @@ import {
   Td,
   tokens,
 } from "../shared";
+import {
+  fetchVpnTunnelsByStackId,
+  selectVpnTunnelByStackId,
+} from "@app/deploy";
+import { AppState } from "@app/types";
 import classNames from "classnames";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router";
 import { Link } from "react-router-dom";
+import { useQuery } from "saga-query/react";
 
 export const StackDetailVpnTunnelsPage = () => {
   const { id = "" } = useParams();

--- a/src/ui/pages/stack-detail.tsx
+++ b/src/ui/pages/stack-detail.tsx
@@ -1,8 +1,0 @@
-import { Navigate, useParams } from "react-router";
-
-import { stackDetailEnvsUrl } from "@app/routes";
-
-export const StackDetailPage = () => {
-  const { id = "" } = useParams();
-  return <Navigate to={stackDetailEnvsUrl(id)} replace />;
-};

--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -22,7 +22,7 @@ import {
   Td,
   Tooltip,
 } from "../shared";
-import { stackDetailUrl } from "@app/routes";
+import { stackDetailEnvsUrl } from "@app/routes";
 import { capitalize } from "@app/string-utils";
 import { Link, useSearchParams } from "react-router-dom";
 
@@ -60,7 +60,7 @@ function StackListRow({ stack }: { stack: DeployStack }) {
             className="w-8 h-8 mr-2"
           />
           <Link
-            to={stackDetailUrl(stack.id)}
+            to={stackDetailEnvsUrl(stack.id)}
             className="text-black hover:text-indigo"
           >
             {stack.name}

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -6,7 +6,6 @@ import {
   selectDatabasesByEnvId,
   selectEnvironmentsByStackId,
   selectEnvironmentsForTableSearch,
-  selectEnvironmentsForTableSearchByStackId,
   selectStackById,
 } from "@app/deploy";
 import { useQuery } from "@app/fx";

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -4,6 +4,7 @@ import {
   fetchAllEnvironments,
   selectAppsByEnvId,
   selectDatabasesByEnvId,
+  selectEnvironmentsByStackId,
   selectEnvironmentsForTableSearch,
   selectEnvironmentsForTableSearchByStackId,
   selectStackById,
@@ -186,14 +187,11 @@ const environmentHeaders = [
 
 export function EnvironmentListByStack({ stackId }: { stackId: string }) {
   const query = useQuery(fetchAllEnvironments());
-  const [params, setParams] = useSearchParams();
+  const [params, _] = useSearchParams();
   const search = params.get("search") || "";
-  const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    setParams({ search: ev.currentTarget.value });
-  };
 
   const environments = useSelector((s: AppState) =>
-    selectEnvironmentsForTableSearchByStackId(s, { stackId, search }),
+    selectEnvironmentsByStackId(s, { stackId }),
   );
 
   return (

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -5,6 +5,7 @@ import {
   selectAppsByEnvId,
   selectDatabasesByEnvId,
   selectEnvironmentsForTableSearch,
+  selectEnvironmentsForTableSearchByStackId,
   selectStackById,
 } from "@app/deploy";
 import { useQuery } from "@app/fx";
@@ -117,6 +118,118 @@ const EnvironmentListRow = ({ environment }: EnvironmentCellProps) => {
   );
 };
 
+type HeaderTypes =
+  | {
+      resourceHeaderType: "title-bar";
+      onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+    }
+  | { resourceHeaderType: "simple-text"; onChange?: null };
+
+const EnvsResourceHeaderTitleBar = ({
+  envs,
+  resourceHeaderType = "title-bar",
+  search = "",
+  onChange,
+}: {
+  envs: DeployEnvironment[];
+  search?: string;
+} & HeaderTypes) => {
+  switch (resourceHeaderType) {
+    case "title-bar":
+      if (!onChange) {
+        return null;
+      }
+      return (
+        <ResourceHeader
+          title="Environments"
+          filterBar={
+            <div className="pt-1">
+              <InputSearch
+                placeholder="Search environments..."
+                search={search}
+                onChange={onChange}
+              />
+              <div className="flex">
+                <p className="flex text-gray-500 mt-4 text-base">
+                  {envs.length} Environment{envs.length !== 1 && "s"}
+                </p>
+                <div className="mt-4">
+                  <Tooltip
+                    fluid
+                    text="Environments are how you separate resources like staging and production."
+                  >
+                    <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
+                  </Tooltip>
+                </div>
+              </div>
+            </div>
+          }
+        />
+      );
+    case "simple-text":
+      return (
+        <p className="flex text-gray-500 text-base mb-4">
+          {envs.length} Environment{envs.length !== 1 && "s"}
+        </p>
+      );
+    default:
+      return null;
+  }
+};
+const environmentHeaders = [
+  "Environment",
+  "Stack",
+  "Last Deployed",
+  "Apps",
+  "Databases",
+];
+
+export function EnvironmentListByStack({ stackId }: { stackId: string }) {
+  const query = useQuery(fetchAllEnvironments());
+  const [params, setParams] = useSearchParams();
+  const search = params.get("search") || "";
+  const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    setParams({ search: ev.currentTarget.value });
+  };
+
+  const environments = useSelector((s: AppState) =>
+    selectEnvironmentsForTableSearchByStackId(s, { stackId, search }),
+  );
+
+  return (
+    <LoadResources
+      query={query}
+      isEmpty={environments.length === 0 && search === ""}
+    >
+      <ResourceListView
+        header={
+          <EnvsResourceHeaderTitleBar
+            envs={environments}
+            resourceHeaderType="simple-text"
+          />
+        }
+        tableHeader={
+          <TableHead
+            headers={environmentHeaders}
+            rightAlignedFinalCol
+            leftAlignedFirstCol
+            centerAlignedColIndices={[3, 4]}
+          />
+        }
+        tableBody={
+          <>
+            {environments.map((environment) => (
+              <EnvironmentListRow
+                environment={environment}
+                key={environment.id}
+              />
+            ))}
+          </>
+        }
+      />
+    </LoadResources>
+  );
+}
 export function EnvironmentList() {
   const query = useQuery(fetchAllEnvironments());
   const [params, setParams] = useSearchParams();
@@ -136,44 +249,16 @@ export function EnvironmentList() {
     >
       <ResourceListView
         header={
-          <ResourceHeader
-            title="Environments"
-            filterBar={
-              <div className="pt-1">
-                <>
-                  <InputSearch
-                    placeholder="Search environments..."
-                    search={search}
-                    onChange={onChange}
-                  />
-                  <div className="flex">
-                    <p className="flex text-gray-500 mt-4 text-base">
-                      {environments.length} Environment
-                      {environments.length !== 1 ? "s" : ""}
-                    </p>
-                    <div className="mt-4">
-                      <Tooltip
-                        fluid
-                        text="Environments are how you separate resources like staging and production."
-                      >
-                        <IconInfo className="h-5 mt-0.5 opacity-50 hover:opacity-100" />
-                      </Tooltip>
-                    </div>
-                  </div>
-                </>
-              </div>
-            }
+          <EnvsResourceHeaderTitleBar
+            envs={environments}
+            resourceHeaderType="title-bar"
+            search={search}
+            onChange={onChange}
           />
         }
         tableHeader={
           <TableHead
-            headers={[
-              "Environment",
-              "Stack",
-              "Last Deployed",
-              "Apps",
-              "Databases",
-            ]}
+            headers={environmentHeaders}
             rightAlignedFinalCol
             leftAlignedFirstCol
             centerAlignedColIndices={[3, 4]}


### PR DESCRIPTION
Fairly straightforward:

* stack detail environment list
* stack detail vpn tunnels
* stack detail vpc peers

basically ports current screens where possible:

vpn tunnels

<img width="1032" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/3b9c9b48-e73c-46e4-9ef1-9e4bc59b8bd1">

vpc peers

<img width="1033" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/370dd94f-577b-4122-9dd5-9a9737db51dc">

stack detail w/ env list:

<img width="1051" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/84dfa4cd-cceb-4a69-84cf-47d12de2be35">
