### PR TITLE
fix: updated stack links and breadcrumbs on env

### DIFF
--- a/src/ui/layouts/environment-detail-layout.tsx
+++ b/src/ui/layouts/environment-detail-layout.tsx
@@ -146,7 +146,7 @@ function EnvironmentPageHeader(): React.ReactElement {
   const endpoints = useSelector((s: AppState) =>
     selectEndpointsByEnvironmentId(s, { envId: environment.id }),
   );
-  const crumbs = [{ name: stack.name, to: stackDetailEnvsUrl(id) }];
+  const crumbs = [{ name: stack.name, to: stackDetailEnvsUrl(stack.id) }];
 
   const tabs: TabItem[] = [
     { name: "Apps", href: `/environments/${id}/apps` },

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -9,7 +9,7 @@ import {
   selectStackById,
 } from "@app/deploy";
 import { useQuery } from "@app/fx";
-import { environmentAppsUrl } from "@app/routes";
+import { environmentAppsUrl, stackDetailEnvsUrl } from "@app/routes";
 import type { AppState, DeployEnvironment } from "@app/types";
 import { Link, useSearchParams } from "react-router-dom";
 
@@ -96,7 +96,14 @@ const EnvironmentStackCell = ({ environment }: EnvironmentCellProps) => {
   return (
     <Td className="2xl:flex-cell-md sm:flex-cell-sm">
       <div>
-        <div className="text-black">{stack.name}</div>
+        <div className="text-black">
+          <Link
+            to={stackDetailEnvsUrl(stack.id)}
+            className={tokens.type["table link"]}
+          >
+            {stack.name}
+          </Link>
+        </div>
         <div className={tokens.type["normal lighter"]}>
           {stack.organizationId ? "Dedicated Stack " : "Shared Stack "}(
           {stack.region})


### PR DESCRIPTION
Link to stack:
<img width="432" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/9ed48fec-3fd2-4504-b9cb-57f35e7218b8">


<img width="427" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/e26df961-74a2-47f7-bf37-885aadc63bc3">
