### PR TITLE
Float Logs Button Right

### DIFF
--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -119,7 +119,10 @@ const OpActionsCell = ({ op }: OpCellProps) => {
   return (
     <Td>
       <div>
-        <Link to={operationDetailUrl(op.id)} className="hover:no-underline flex justify-end mr-4">
+        <Link
+          to={operationDetailUrl(op.id)}
+          className="hover:no-underline flex justify-end mr-4"
+        >
           <Button variant="white" color="white" size="sm" className="px-0">
             Logs
           </Button>

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -119,7 +119,7 @@ const OpActionsCell = ({ op }: OpCellProps) => {
   return (
     <Td>
       <div>
-        <Link to={operationDetailUrl(op.id)} className="hover:no-underline">
+        <Link to={operationDetailUrl(op.id)} className="hover:no-underline flex justify-end mr-4">
           <Button variant="white" color="white" size="sm" className="px-0">
             Logs
           </Button>
@@ -221,6 +221,7 @@ function ActivityTable({
       header={resourceHeaderTitleBar()}
       tableHeader={
         <TableHead
+          rightAlignedFinalCol
           headers={[
             "Resource",
             "Status",


### PR DESCRIPTION
Properly Float Logs button right

BEFORE
<img width="180" alt="Screen Shot 2023-07-14 at 10 33 10 AM" src="https://github.com/aptible/app-ui/assets/4295811/570c895f-0012-493c-a91f-110243d7539e">


AFTER
<img width="190" alt="Screen Shot 2023-07-14 at 10 29 30 AM" src="https://github.com/aptible/app-ui/assets/4295811/4d024927-7e6c-4cca-8a8a-452d91ebba12">
