### PR TITLE
Update Plans page

### DIFF
--- a/src/ui/shared/plan.tsx
+++ b/src/ui/shared/plan.tsx
@@ -109,7 +109,7 @@ const BulletListForPlan = ({
       <>
         <PlanCostBlock plan={plan} precedingPlan={precedingPlan} />
         <div className="flex">
-          <div className="flex-1"></div>
+          <div className="flex-1" />
           <div className="flex-1 text-center font-semibold">Includes</div>
           <div className="flex-1 text-center font-semibold">Available</div>
         </div>
@@ -129,7 +129,10 @@ const BulletListForPlan = ({
           <div className="flex-1 text-center">1</div>
         </div>
         <ul>
-          <IconLi>Deploy on Shared Stacks (Networking and Compute shared with other Aptible customers)</IconLi>
+          <IconLi>
+            Deploy on Shared Stacks (Networking and Compute shared with other
+            Aptible customers)
+          </IconLi>
           <IconLi>Deploy in US East (N. Virginia)</IconLi>
         </ul>
       </>
@@ -139,7 +142,7 @@ const BulletListForPlan = ({
       <>
         <PlanCostBlock plan={plan} precedingPlan={precedingPlan} />
         <div className="flex">
-          <div className="flex-1"></div>
+          <div className="flex-1" />
           <div className="flex-1 text-center font-semibold">Includes</div>
           <div className="flex-1 text-center font-semibold">Available</div>
         </div>
@@ -160,7 +163,9 @@ const BulletListForPlan = ({
         </div>
         <ul>
           <IconLi>15% discount on included resources</IconLi>
-          <IconLi>Up to 2 concurrent SSH Sessions for temporary container access</IconLi>
+          <IconLi>
+            Up to 2 concurrent SSH Sessions for temporary container access
+          </IconLi>
           <IconLi>Deploy in 1 region (of your choice)</IconLi>
           <IconLi>Support: Choose from Standard or Premium</IconLi>
           <IconLi>Dedicated Stacks (Isolated Tenancy) Available</IconLi>
@@ -173,7 +178,7 @@ const BulletListForPlan = ({
       <>
         <PlanCostBlock plan={plan} precedingPlan={precedingPlan} />
         <div className="flex">
-          <div className="flex-1"></div>
+          <div className="flex-1" />
           <div className="flex-1 text-center font-semibold">Includes</div>
           <div className="flex-1 text-center font-semibold">Available</div>
         </div>
@@ -194,7 +199,9 @@ const BulletListForPlan = ({
         </div>
         <ul>
           <IconLi>20% discount on included resources</IconLi>
-          <IconLi>Up to 3 concurrent SSH Sessions for temporary container access</IconLi>
+          <IconLi>
+            Up to 3 concurrent SSH Sessions for temporary container access
+          </IconLi>
           <IconLi>Support: Choose from Standard or Premium</IconLi>
           <IconLi>Dedicated Stacks (Isolated Tenancy) Available</IconLi>
           <IconLi>Available HIPAA BAA</IconLi>
@@ -206,34 +213,45 @@ const BulletListForPlan = ({
       <>
         <PlanCostBlock plan={plan} precedingPlan={precedingPlan} />
         <div className="flex">
-            <div className="flex-1"></div>
-            <div className="flex-1 text-center font-semibold">Includes</div>
-            <div className="flex-1 text-center font-semibold">Available</div>
-          </div>
-          <div className="flex">
-            <div className="flex-1">Compute</div>
-            <div className="flex-1 text-center">Custom</div>
-            <div className="flex-1 text-center">Unlimited</div>
-          </div>
-          <div className="flex">
-            <div className="flex-1">DB Storage</div>
-            <div className="flex-1 text-center">Custom</div>
-            <div className="flex-1 text-center">Unlimited</div>
-          </div>
-          <div className="flex">
-            <div className="flex-1">Endpoints</div>
-            <div className="flex-1 text-center">Custom</div>
-            <div className="flex-1 text-center">Unlimited</div>
+          <div className="flex-1" />
+          <div className="flex-1 text-center font-semibold">Includes</div>
+          <div className="flex-1 text-center font-semibold">Available</div>
         </div>
-      <ul>
-        <IconLi>No limits on available Compute, Database Storage, or Endpoints</IconLi>
-        <IconLi>Deploy in 15+ Regions</IconLi>
-        <IconLi>99.95% Uptime SLA</IconLi>
-        <IconLi>Advanced Networking Features such as IPsec VPNs and VPC Peering</IconLi>
-        <IconLi>Available HITRUST Inheritance and Security & Compliance Dashboard</IconLi>
-        <IconLi>Support: Choose from Standard, Premium, Enterprise (24/7 Support)</IconLi>
-        <IconLi>Custom pricing and payment options with annual commitments and payments</IconLi>
-      </ul>
+        <div className="flex">
+          <div className="flex-1">Compute</div>
+          <div className="flex-1 text-center">Custom</div>
+          <div className="flex-1 text-center">Unlimited</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">DB Storage</div>
+          <div className="flex-1 text-center">Custom</div>
+          <div className="flex-1 text-center">Unlimited</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">Endpoints</div>
+          <div className="flex-1 text-center">Custom</div>
+          <div className="flex-1 text-center">Unlimited</div>
+        </div>
+        <ul>
+          <IconLi>
+            No limits on available Compute, Database Storage, or Endpoints
+          </IconLi>
+          <IconLi>Deploy in 15+ Regions</IconLi>
+          <IconLi>99.95% Uptime SLA</IconLi>
+          <IconLi>
+            Advanced Networking Features such as IPsec VPNs and VPC Peering
+          </IconLi>
+          <IconLi>
+            Available HITRUST Inheritance and Security & Compliance Dashboard
+          </IconLi>
+          <IconLi>
+            Support: Choose from Standard, Premium, Enterprise (24/7 Support)
+          </IconLi>
+          <IconLi>
+            Custom pricing and payment options with annual commitments and
+            payments
+          </IconLi>
+        </ul>
       </>
     );
   }

--- a/src/ui/shared/plan.tsx
+++ b/src/ui/shared/plan.tsx
@@ -9,18 +9,10 @@ import { useDispatch } from "react-redux";
 
 const descriptionTextForPlan = (planName: PlanName): string =>
   ({
-    starter: "Begin the search for product-market fit",
-    growth: "Start growing your user base",
+    starter: "Deploy your first few resources",
+    growth: "Begin the search for product-market fit",
     scale: "Scale your product and business",
     enterprise: "Meet the highest requirements for security and reliability",
-  })[planName];
-
-const discountForPlan = (planName: PlanName): string =>
-  ({
-    starter: "",
-    growth: "15% Off included resources",
-    scale: "20% Off included resources",
-    enterprise: "",
   })[planName];
 
 const PlanButton = ({
@@ -73,7 +65,7 @@ const PlanCostBlock = ({
   precedingPlan?: DeployPlan;
 }): ReactElement => {
   return (
-    <div className="flex justify-between mb-4">
+    <div className="flex justify-between mb-2">
       <div>
         <p>Starts at</p>
         <h3 className={tokens.type.h4}>
@@ -116,17 +108,28 @@ const BulletListForPlan = ({
     return (
       <>
         <PlanCostBlock plan={plan} precedingPlan={precedingPlan} />
+        <div className="flex">
+          <div className="flex-1"></div>
+          <div className="flex-1 text-center font-semibold">Includes</div>
+          <div className="flex-1 text-center font-semibold">Available</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">Compute</div>
+          <div className="flex-1 text-center">-</div>
+          <div className="flex-1 text-center">3 GB</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">DB Storage</div>
+          <div className="flex-1 text-center">-</div>
+          <div className="flex-1 text-center">20 GB</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">Endpoints</div>
+          <div className="flex-1 text-center">-</div>
+          <div className="flex-1 text-center">1</div>
+        </div>
         <ul>
-          <IconLi>
-            Up to {plan.containerMemoryLimit / 1024}GB RAM for Compute (App &
-            Database Containers)
-          </IconLi>
-          <IconLi>Up to {plan.diskLimit}GB Database Storage</IconLi>
-          <IconLi>Up to {plan.vhostLimit} Endpoint (Load Balancer)</IconLi>
-          <IconLi>
-            Deploy on Shared stacks (Networking and Compute shared with other
-            Aptible customers)
-          </IconLi>
+          <IconLi>Deploy on Shared Stacks (Networking and Compute shared with other Aptible customers)</IconLi>
           <IconLi>Deploy in US East (N. Virginia)</IconLi>
         </ul>
       </>
@@ -135,26 +138,33 @@ const BulletListForPlan = ({
     return (
       <>
         <PlanCostBlock plan={plan} precedingPlan={precedingPlan} />
-        <p className="font-semibold text-sm">Everything in Starter, plus:</p>
+        <div className="flex">
+          <div className="flex-1"></div>
+          <div className="flex-1 text-center font-semibold">Includes</div>
+          <div className="flex-1 text-center font-semibold">Available</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">Compute</div>
+          <div className="flex-1 text-center">3 GB</div>
+          <div className="flex-1 text-center">11 GB</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">DB Storage</div>
+          <div className="flex-1 text-center">10 GB</div>
+          <div className="flex-1 text-center">60 GB</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">Endpoints</div>
+          <div className="flex-1 text-center">1</div>
+          <div className="flex-1 text-center">3</div>
+        </div>
         <ul>
-          <IconLi>{discountForPlan(plan.name)}</IconLi>
-          <IconLi>
-            Up to {plan.containerMemoryLimit / 1024}GB RAM for Compute (App &
-            Database Containers), {plan.includedContainerMb / 1024}GB included
-          </IconLi>
-          <IconLi>
-            Up to {plan.diskLimit}GB Database Storage, {plan.includedDiskGb}GB
-            included
-          </IconLi>
-          <IconLi>
-            Up to {plan.vhostLimit} Endpoints (Load Balancers),{" "}
-            {plan.includedVhosts} included
-          </IconLi>
-          <IconLi>
-            Up to {plan.ephemeralSessionLimit} concurrent SSH Sessions for
-            temporary container access
-          </IconLi>
-          <IconLi>3 business hour support response times available</IconLi>
+          <IconLi>15% discount on included resources</IconLi>
+          <IconLi>Up to 2 concurrent SSH Sessions for temporary container access</IconLi>
+          <IconLi>Deploy in 1 region (of your choice)</IconLi>
+          <IconLi>Support: Choose from Standard or Premium</IconLi>
+          <IconLi>Dedicated Stacks (Isolated Tenancy) Available</IconLi>
+          <IconLi>Available HIPAA BAA</IconLi>
         </ul>
       </>
     );
@@ -162,25 +172,30 @@ const BulletListForPlan = ({
     return (
       <>
         <PlanCostBlock plan={plan} precedingPlan={precedingPlan} />
-        <p className="font-semibold text-sm">Everything in Growth, plus:</p>
+        <div className="flex">
+          <div className="flex-1"></div>
+          <div className="flex-1 text-center font-semibold">Includes</div>
+          <div className="flex-1 text-center font-semibold">Available</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">Compute</div>
+          <div className="flex-1 text-center">10 GB</div>
+          <div className="flex-1 text-center">40 GB</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">DB Storage</div>
+          <div className="flex-1 text-center">100 GB</div>
+          <div className="flex-1 text-center">200 GB</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">Endpoints</div>
+          <div className="flex-1 text-center">4</div>
+          <div className="flex-1 text-center">20</div>
+        </div>
         <ul>
-          <IconLi>{discountForPlan(plan.name)}</IconLi>
-          <IconLi>
-            Up to {plan.containerMemoryLimit / 1024}GB RAM for Compute (App &
-            Database Containers), {plan.includedContainerMb / 1024}GB included
-          </IconLi>
-          <IconLi>
-            Up to {plan.diskLimit}GB Database Storage, {plan.includedDiskGb}GB
-            included
-          </IconLi>
-          <IconLi>
-            Up to {plan.vhostLimit} Endpoints (Load Balancers),{" "}
-            {plan.includedVhosts} included
-          </IconLi>
-          <IconLi>
-            Up to {plan.ephemeralSessionLimit} concurrent SSH Sessions for
-            temporary container access
-          </IconLi>
+          <IconLi>20% discount on included resources</IconLi>
+          <IconLi>Up to 3 concurrent SSH Sessions for temporary container access</IconLi>
+          <IconLi>Support: Choose from Standard or Premium</IconLi>
           <IconLi>Dedicated Stacks (Isolated Tenancy) Available</IconLi>
           <IconLi>Available HIPAA BAA</IconLi>
         </ul>
@@ -188,19 +203,38 @@ const BulletListForPlan = ({
     );
   } else {
     return (
+      <>
+        <PlanCostBlock plan={plan} precedingPlan={precedingPlan} />
+        <div className="flex">
+            <div className="flex-1"></div>
+            <div className="flex-1 text-center font-semibold">Includes</div>
+            <div className="flex-1 text-center font-semibold">Available</div>
+          </div>
+          <div className="flex">
+            <div className="flex-1">Compute</div>
+            <div className="flex-1 text-center">Custom</div>
+            <div className="flex-1 text-center">Unlimited</div>
+          </div>
+          <div className="flex">
+            <div className="flex-1">DB Storage</div>
+            <div className="flex-1 text-center">Custom</div>
+            <div className="flex-1 text-center">Unlimited</div>
+          </div>
+          <div className="flex">
+            <div className="flex-1">Endpoints</div>
+            <div className="flex-1 text-center">Custom</div>
+            <div className="flex-1 text-center">Unlimited</div>
+        </div>
       <ul>
+        <IconLi>No limits on available Compute, Database Storage, or Endpoints</IconLi>
         <IconLi>Deploy in 15+ Regions</IconLi>
-        <IconLi>99.95% Up-time SLA</IconLi>
-        <IconLi>
-          Advanced Networking Features such as IPsec VPNs and VPC Peering
-        </IconLi>
-        <IconLi>HITRUST Inheritance and Security & Compliance Dashboard</IconLi>
-        <IconLi>24/7 Support Response Times Available</IconLi>
-        <IconLi>
-          Custom pricing and payment options with annual commitments and
-          payments
-        </IconLi>
+        <IconLi>99.95% Uptime SLA</IconLi>
+        <IconLi>Advanced Networking Features such as IPsec VPNs and VPC Peering</IconLi>
+        <IconLi>Available HITRUST Inheritance and Security & Compliance Dashboard</IconLi>
+        <IconLi>Support: Choose from Standard, Premium, Enterprise (24/7 Support)</IconLi>
+        <IconLi>Custom pricing and payment options with annual commitments and payments</IconLi>
       </ul>
+      </>
     );
   }
 };
@@ -242,7 +276,7 @@ const PlanCard = ({
   // don't forget helper text on growth/scale/enterprise only (not on starter)
   return (
     <div
-      className={`w-full rounded-lg overflow-hidden bg-white pt-14 px-0 mx-0 border ${borderColor} relative sm:mt-4`}
+      className={`w-full rounded-lg overflow-hidden bg-white pt-14 px-0 mx-0 border ${borderColor} relative mt-4`}
     >
       <div className="mb-8 mx-4" style={{ height: 135, minWidth: 225 }}>
         <div style={{ height: 95 }}>
@@ -302,7 +336,7 @@ export const Plans = ({
   }
 
   return (
-    <div className="md:flex md:flex-row md:justify-between gap-4 mt-4">
+    <div className="grid lg:grid-cols-4 md:grid-cols-2 grid-cols-1 gap-4 lg:mx-0 mx-10 mt-4">
       {plans.map((plan, idx) => (
         <PlanCard
           key={plan.id}


### PR DESCRIPTION
Update Plans Page

<img width="1338" alt="Screen Shot 2023-07-14 at 4 35 01 PM" src="https://github.com/aptible/app-ui/assets/4295811/391da147-8e67-4e7d-81f0-b47965877cd0">

I can't fix this bug though:

These 2 lines of code are preventing the page from displaying at 100% width properly. They live on the hero-bg file instead of the plans file. I dont wanna mess up any of the existing hero-bg pages (FTUX).

`<div style="width: 1200px;">`
<img width="1073" alt="Screen Shot 2023-07-14 at 4 35 50 PM" src="https://github.com/aptible/app-ui/assets/4295811/27e665d8-9cde-4197-ac73-9757f6d3553f">

`<div class "flex justifv-center container">`
<img width="1073" alt="Screen Shot 2023-07-14 at 4 35 59 PM" src="https://github.com/aptible/app-ui/assets/4295811/a3e90ed5-d07d-4568-9d37-3339446efec8">

Here's the desired end state

<img width="1073" alt="Screen Shot 2023-07-14 at 4 36 03 PM" src="https://github.com/aptible/app-ui/assets/4295811/c2669d34-e165-4a8f-8045-334d565b3939">


