### PR TITLE
footer-mobile-tweaks-jc

### DIFF
--- a/src/ui/shared/footer.tsx
+++ b/src/ui/shared/footer.tsx
@@ -30,7 +30,7 @@ export const Footer = () => {
           <a
             href="https://www.aptible.com/changelog"
             target="_blank"
-            className="flex-none text-gray-500 hover:text-indigo text-sm pl-4 uppercase"
+            className="flex-none text-gray-500 hover:text-indigo text-sm pl-4 uppercase hidden md:block"
             rel="noreferrer"
           >
             View Changelog{" "}
@@ -39,7 +39,7 @@ export const Footer = () => {
           <a
             href="https://dashboard.aptible.com/login"
             target="_blank"
-            className="flex-none text-gray-500 hover:text-indigo text-sm pl-4 uppercase"
+            className="flex-none text-gray-500 hover:text-indigo text-sm pl-4 uppercase hidden md:block"
             rel="noreferrer"
           >
             View Legacy App{" "}


### PR DESCRIPTION
Hide legacy view and changelog links on mobile

<img width="789" alt="Screen Shot 2023-07-18 at 9 34 06 AM" src="https://github.com/aptible/app-ui/assets/4295811/c34d84d6-376f-4b0c-9548-d4d13dfca15c">
