### PR TITLE
Right align metrics button on services table

### DIFF
--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -57,7 +57,7 @@ const serviceListRow = ({
           ${metrics.estimatedCostInDollars}
         </div>
       </Td>
-      <Td className="flex-1">
+      <Td className="flex justify-end mr-4 mt-4">
         <ButtonLink
           className="w-20"
           size="sm"
@@ -108,6 +108,7 @@ export function ServicesOverview({
         }
         tableHeader={
           <TableHead
+            rightAlignedFinalCol
             headers={[
               "Service",
               "Memory Limit",


### PR DESCRIPTION
Right align metrics button on services table

BEFORE
<img width="198" alt="Screen Shot 2023-07-18 at 12 03 24 PM" src="https://github.com/aptible/app-ui/assets/4295811/e7a4a714-5040-41b8-9572-9e8bcc993cb3">


AFTER
<img width="187" alt="Screen Shot 2023-07-18 at 12 03 28 PM" src="https://github.com/aptible/app-ui/assets/4295811/e7eec943-bf40-4b23-9130-d81f41b5bdf3">
