### PR TITLE
chore: do not cache index.html to force reload

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -27,6 +27,9 @@ http {
 
     # Any route that doesn't have a file extension (e.g. /devices)
     location / {
+        if ( $uri = '/index.html' ) {
+            add_header Cache-Control no-store always;
+        }
         try_files $uri $uri/ /index.html;
     }
 


### PR DESCRIPTION
do not cache index.html (but leave everything else as is) so we don't flash white pages when we have newer deploys

running in locally built docker image:

<img width="744" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/4016c430-5023-4506-a80a-f53375ec302a">

