### PR TITLE
chore: updated multi-container reporting on charts

### DIFF
--- a/src/metric-tunnel/index.ts
+++ b/src/metric-tunnel/index.ts
@@ -140,16 +140,16 @@ export const selectMetricsByMetricContainerHorizon = createSelector(
 
 export const selectMetricDataAsFlatTableByContainer = createSelector(
   selectContainerMetricsAsList,
-  (_: AppState, p: { containerId: string }) => p.containerId,
+  (_: AppState, p: { containerIds: string[] }) => p.containerIds,
   (_: AppState, p: { metricHorizon: MetricHorizons }) => p.metricHorizon,
-  (containerMetrics, containerId, metricHorizon): FlatTableOfMetricsData => {
+  (containerMetrics, containerIds, metricHorizon): FlatTableOfMetricsData => {
     const result: FlatTableOfMetricsData = {
       time: [],
     };
     containerMetrics
       .filter(
         (containerMetric: ContainerMetrics) =>
-          containerMetric.containerId === containerId &&
+          containerIds.includes(containerMetric.containerId) &&
           containerMetric.metricTimeRange === metricHorizon,
       )
       .forEach((containerMetric: ContainerMetrics, idx) => {
@@ -166,12 +166,12 @@ export const selectMetricDataAsFlatTableByContainer = createSelector(
 
 export const selectMetricDataByChart = createSelector(
   selectContainerMetricsAsList,
-  (_: AppState, p: { containerId: string }) => p.containerId,
+  (_: AppState, p: { containerIds: string[] }) => p.containerIds,
   (_: AppState, p: { metricNames: string[] }) => p.metricNames,
   (_: AppState, p: { metricHorizon: MetricHorizons }) => p.metricHorizon,
   (
     containerMetrics,
-    containerId,
+    containerIds,
     metricNames,
     metricHorizon,
   ): ChartToCreate => {
@@ -198,7 +198,7 @@ export const selectMetricDataByChart = createSelector(
     };
     const metrics = containerMetrics.filter(
       (containerMetric) =>
-        containerMetric.containerId === containerId &&
+        containerIds.includes(containerMetric.containerId) &&
         metricNames.includes(containerMetric.metricName) &&
         containerMetric.metricTimeRange === metricHorizon,
     );

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -91,7 +91,7 @@ const LineChartWrapper = ({
               maxTicksLimit: 5,
             },
             time: {
-              tooltipFormat: "dd ",
+              tooltipFormat: "yyyy-MM-dd HH:mm:ss",
             },
             type: "time",
           },

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -133,6 +133,7 @@ export const ContainerMetricsChart = ({
   return (
     <div className="bg-white px-5 pt-1 pb-5 shadow rounded-lg border border-black-100 relative min-h-[400px] bg-[url('/thead-bg.png')] bg-[length:100%_46px] bg-no-repeat">
       <LineChartWrapper
+        key={containerIds.join("-")}
         keyId={`${containerIds.join("-")}-${metricNames.join(
           "-",
         )}-${metricHorizon}`}

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -119,10 +119,10 @@ export const ContainerMetricsChart = ({
   metricHorizon: MetricHorizons;
 }) => {
   // for now, we only use the FIRST container id pending cross-release
-  const containerId = containers?.[0]?.id;
+  const containerIds = containers.map((container) => container.id);
   const chartToCreate = useSelector((s: AppState) =>
     selectMetricDataByChart(s, {
-      containerId,
+      containerIds,
       metricNames,
       metricHorizon,
     }),
@@ -133,7 +133,9 @@ export const ContainerMetricsChart = ({
   return (
     <div className="bg-white px-5 pt-1 pb-5 shadow rounded-lg border border-black-100 relative min-h-[400px] bg-[url('/thead-bg.png')] bg-[length:100%_46px] bg-no-repeat">
       <LineChartWrapper
-        keyId={`${containerId}-${metricNames.join("-")}-${metricHorizon}`}
+        keyId={`${containerIds.join("-")}-${metricNames.join(
+          "-",
+        )}-${metricHorizon}`}
         chart={chartToCreate}
       />
     </div>

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -120,6 +120,7 @@ export const ContainerMetricsChart = ({
 }) => {
   // for now, we only use the FIRST container id pending cross-release
   const containerIds = containers.map((container) => container.id);
+  const containerIdsKey = containerIds.join("-");
   const chartToCreate = useSelector((s: AppState) =>
     selectMetricDataByChart(s, {
       containerIds,
@@ -133,10 +134,8 @@ export const ContainerMetricsChart = ({
   return (
     <div className="bg-white px-5 pt-1 pb-5 shadow rounded-lg border border-black-100 relative min-h-[400px] bg-[url('/thead-bg.png')] bg-[length:100%_46px] bg-no-repeat">
       <LineChartWrapper
-        key={containerIds.join("-")}
-        keyId={`${containerIds.join("-")}-${metricNames.join(
-          "-",
-        )}-${metricHorizon}`}
+        key={containerIdsKey}
+        keyId={`${containerIdsKey}-${metricNames.join("-")}-${metricHorizon}`}
         chart={chartToCreate}
       />
     </div>

--- a/src/ui/shared/container-metrics-table.tsx
+++ b/src/ui/shared/container-metrics-table.tsx
@@ -11,11 +11,11 @@ export const ContainerMetricsDataTable = ({
   metricHorizon: MetricHorizons;
 }) => {
   // will support multiple containers next, placeholder for this (and for debugging/verification)
-  const container = containers?.[0] || "";
+  const containerIds = containers.map((container) => container.id);
 
   const metricTableData = useSelector((s: AppState) =>
     selectMetricDataAsFlatTableByContainer(s, {
-      containerId: container.id,
+      containerIds,
       metricHorizon,
     }),
   );


### PR DESCRIPTION
* multicontainer support
* timestamps in tooltips

---

multiple containers should appear properly now:

<img width="1047" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/68f66443-bb1a-4bc0-88c1-11760062c689">

timestamp on tooltips:

<img width="293" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/71038ca3-a34b-4bad-9eaf-bcc67f8f59b1">

