### PR TITLE
Collapsed Navigation Styling

### DIFF
--- a/src/ui/layouts/menu-wrapped-page.tsx
+++ b/src/ui/layouts/menu-wrapped-page.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export function MenuWrappedPage({ children, header }: Props) {
   const { collapsed } = useSelector(selectNav);
-  const collapsedOffset = collapsed ? 14 : 64;
+  const collapsedOffset = collapsed ? 15.2 : 64;
 
   return (
     <div className="flex h-full">

--- a/src/ui/shared/application-sidebar.tsx
+++ b/src/ui/shared/application-sidebar.tsx
@@ -120,8 +120,8 @@ export const ApplicationSidebar = () => {
                         width: 12,
                         height: 12,
                         marginRight: -8,
-                        marginLeft: -2,
-                        transform: "scale(2.5, 2.5)",
+                        marginLeft: -1,
+                        transform: "scale(1.8, 1.8)",
                       }
                     : {}
                 }


### PR DESCRIPTION
Fix padding issues so icons are aligned properly to the bar's width.

BEFORE & AFTER
<img width="364" alt="Screen Shot 2023-07-20 at 1 27 05 PM" src="https://github.com/aptible/app-ui/assets/4295811/64887565-4b45-4323-9f2a-59c4d20e97cd">
