### PR TITLE
chore: use client caching + limit number of requests in loops

### DIFF
--- a/src/metric-tunnel/index.ts
+++ b/src/metric-tunnel/index.ts
@@ -1,4 +1,4 @@
-import { metricTunnelApi } from "@app/api";
+import { cacheTimer, metricTunnelApi } from "@app/api";
 import { createReducerMap, createTable } from "@app/slice-helpers";
 import { AppState, ContainerMetrics, MetricHorizons } from "@app/types";
 import { createSelector } from "@reduxjs/toolkit";
@@ -239,6 +239,7 @@ export const fetchMetricTunnelDataForContainer = metricTunnelApi.get<
   MetricTunnelContainerResponse
 >(
   `/proxy/:containerId?horizon=:metricHorizon&ts=${getUtc()}&metric=:metricName&requestedTicks=600`,
+  { saga: cacheTimer() },
   function* (ctx, next) {
     yield* next();
 

--- a/src/ui/pages/app-detail-service.tsx
+++ b/src/ui/pages/app-detail-service.tsx
@@ -76,9 +76,14 @@ export function AppDetailServicePage() {
   }, [releaseIds.join("-")]);
 
   useEffect(() => {
+    let requestsMade = 0;
     const actions: AnyAction[] = [];
-    containers.forEach((container) =>
-      metrics.forEach((metricName) => {
+    for (const container of containers) {
+      for (const metricName of metrics) {
+        if (requestsMade >= 100) {
+          return;
+        }
+        requestsMade += 1;
         actions.push(
           fetchMetricTunnelDataForContainer({
             containerId: container.id,
@@ -87,8 +92,8 @@ export function AppDetailServicePage() {
             serviceId: service.id,
           }),
         );
-      }),
-    );
+      }
+    }
     if (actions.length === 0) {
       return;
     }

--- a/src/ui/pages/app-detail-service.tsx
+++ b/src/ui/pages/app-detail-service.tsx
@@ -79,11 +79,13 @@ export function AppDetailServicePage() {
     let requestsMade = 0;
     const actions: AnyAction[] = [];
     for (const container of containers) {
+      if (requestsMade >= 100) {
+        break;
+      }
       for (const metricName of metrics) {
         if (requestsMade >= 100) {
-          return;
+          break;
         }
-        requestsMade += 1;
         actions.push(
           fetchMetricTunnelDataForContainer({
             containerId: container.id,
@@ -92,6 +94,7 @@ export function AppDetailServicePage() {
             serviceId: service.id,
           }),
         );
+        requestsMade += 1;
       }
     }
     if (actions.length === 0) {

--- a/src/ui/pages/db-detail-metrics.tsx
+++ b/src/ui/pages/db-detail-metrics.tsx
@@ -77,11 +77,13 @@ export function DatabaseMetricsPage() {
     let requestsMade = 0;
     const actions: AnyAction[] = [];
     for (const container of containers) {
+      if (requestsMade >= 100) {
+        break;
+      }
       for (const metricName of metrics) {
         if (requestsMade >= 100) {
-          return;
+          break;
         }
-        requestsMade += 1;
         actions.push(
           fetchMetricTunnelDataForContainer({
             containerId: container.id,
@@ -90,6 +92,7 @@ export function DatabaseMetricsPage() {
             serviceId: service.id,
           }),
         );
+        requestsMade += 1;
       }
     }
     if (actions.length === 0) {

--- a/src/ui/pages/db-detail-metrics.tsx
+++ b/src/ui/pages/db-detail-metrics.tsx
@@ -74,9 +74,14 @@ export function DatabaseMetricsPage() {
   }, [releaseIds.join("-")]);
 
   useEffect(() => {
+    let requestsMade = 0;
     const actions: AnyAction[] = [];
-    containers.forEach((container) =>
-      metrics.forEach((metricName) => {
+    for (const container of containers) {
+      for (const metricName of metrics) {
+        if (requestsMade >= 100) {
+          return;
+        }
+        requestsMade += 1;
         actions.push(
           fetchMetricTunnelDataForContainer({
             containerId: container.id,
@@ -85,8 +90,8 @@ export function DatabaseMetricsPage() {
             serviceId: service.id,
           }),
         );
-      }),
-    );
+      }
+    }
     if (actions.length === 0) {
       return;
     }


### PR DESCRIPTION
This works: 

<img width="1420" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/bf63d718-773e-454b-ba6e-421b26fda8ac">

<img width="1405" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/f1aef0d5-b4a1-4db1-8e20-2771c99ed272">
