### PR TITLE
fix: dropped excessive calls that should not get hit (before metrichorizon OR current)

### DIFF
--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -105,3 +105,8 @@ export const dateFromToday = (days: number) => {
   d.setDate(d.getDate() + days);
   return d;
 };
+
+export const secondsFromNow = (seconds: number) => {
+  const d = new Date();
+  return new Date(d.getTime() + seconds * 1000);
+};

--- a/src/ui/pages/app-detail-service.tsx
+++ b/src/ui/pages/app-detail-service.tsx
@@ -11,7 +11,7 @@ import {
 } from "@app/deploy";
 import { AppState, MetricHorizons } from "@app/types";
 
-import { Loading } from "../shared";
+import { IconInfo, Loading, Tooltip } from "../shared";
 import { ContainerMetricsChart } from "../shared/container-metrics-chart";
 import { ContainerMetricsDataTable } from "../shared/container-metrics-table";
 import {
@@ -29,6 +29,7 @@ import { fetchMetricTunnelDataForContainer } from "@app/metric-tunnel";
 import { useEffect, useState } from "react";
 import { AnyAction } from "redux";
 
+const maxDataSeries = 100;
 const metrics = ["cpu_pct", "la", "memory_all"];
 const layersToSearchForContainers = ["app", "database"];
 
@@ -81,11 +82,11 @@ export function AppDetailServicePage() {
     let requestsMade = 0;
     const actions: AnyAction[] = [];
     for (const container of containers) {
-      if (requestsMade >= 100) {
+      if (requestsMade >= maxDataSeries) {
         break;
       }
       for (const metricName of metrics) {
-        if (requestsMade >= 100) {
+        if (requestsMade >= maxDataSeries) {
           break;
         }
         // either fetch the current release OR ensure that the container was last updated within the time horizon
@@ -129,6 +130,12 @@ export function AppDetailServicePage() {
           viewHorizon={metricHorizon}
           setViewHorizon={setMetricHorizon}
         />
+        <Tooltip
+          fluid
+          text={`Showing up to ${maxDataSeries} data series (one per line on a line graph) worth of metrics.`}
+        >
+          <IconInfo className="h-5 mt-2 opacity-50 hover:opacity-100" />
+        </Tooltip>
       </div>
       <div className="my-4">
         {viewTab === "chart" ? (

--- a/src/ui/pages/db-detail-metrics.tsx
+++ b/src/ui/pages/db-detail-metrics.tsx
@@ -5,8 +5,9 @@ import {
   MetricTabTypes,
   MetricsHorizonControls,
   MetricsViewControls,
+  metricHorizonAsSeconds,
 } from "../shared/metrics-controls";
-import { dateFromToday } from "@app/date";
+import { dateFromToday, secondsFromNow } from "@app/date";
 import {
   fetchContainersByReleaseIdWithDeleted,
   fetchEnvironmentServices,
@@ -74,6 +75,7 @@ export function DatabaseMetricsPage() {
   }, [releaseIds.join("-")]);
 
   useEffect(() => {
+    const horizonInSeconds = metricHorizonAsSeconds(metricHorizon);
     let requestsMade = 0;
     const actions: AnyAction[] = [];
     for (const container of containers) {
@@ -84,15 +86,21 @@ export function DatabaseMetricsPage() {
         if (requestsMade >= 100) {
           break;
         }
-        actions.push(
-          fetchMetricTunnelDataForContainer({
-            containerId: container.id,
-            metricName,
-            metricHorizon: metricHorizon,
-            serviceId: service.id,
-          }),
-        );
-        requestsMade += 1;
+        // either fetch the current release OR ensure that the container was last updated within the time horizon
+        if (
+          container.releaseId === service.currentReleaseId ||
+          container.updatedAt >= secondsFromNow(-horizonInSeconds).toISOString()
+        ) {
+          actions.push(
+            fetchMetricTunnelDataForContainer({
+              containerId: container.id,
+              metricName,
+              metricHorizon: metricHorizon,
+              serviceId: service.id,
+            }),
+          );
+          requestsMade += 1;
+        }
       }
     }
     if (actions.length === 0) {

--- a/src/ui/pages/db-detail-metrics.tsx
+++ b/src/ui/pages/db-detail-metrics.tsx
@@ -1,4 +1,4 @@
-import { LoadResources, Loading } from "../shared";
+import { IconInfo, LoadResources, Loading, Tooltip } from "../shared";
 import { ContainerMetricsChart } from "../shared/container-metrics-chart";
 import { ContainerMetricsDataTable } from "../shared/container-metrics-table";
 import {
@@ -27,6 +27,7 @@ import { AnyAction } from "redux";
 import { batchActions } from "saga-query";
 import { useQuery } from "saga-query/react";
 
+const maxDataSeries = 100;
 const metrics = ["cpu_pct", "la", "memory_all", "iops", "fs"];
 const layersToSearchForContainers = ["app", "database"];
 
@@ -79,11 +80,11 @@ export function DatabaseMetricsPage() {
     let requestsMade = 0;
     const actions: AnyAction[] = [];
     for (const container of containers) {
-      if (requestsMade >= 100) {
+      if (requestsMade >= maxDataSeries) {
         break;
       }
       for (const metricName of metrics) {
-        if (requestsMade >= 100) {
+        if (requestsMade >= maxDataSeries) {
           break;
         }
         // either fetch the current release OR ensure that the container was last updated within the time horizon
@@ -124,6 +125,12 @@ export function DatabaseMetricsPage() {
           viewHorizon={metricHorizon}
           setViewHorizon={setMetricHorizon}
         />
+        <Tooltip
+          fluid
+          text={`Showing up to ${maxDataSeries} data series (one per line on a line graph) worth of metrics.`}
+        >
+          <IconInfo className="h-5 mt-2 opacity-50 hover:opacity-100" />
+        </Tooltip>
       </div>
       <div className="my-4">
         {viewTab === "chart" ? (

--- a/src/ui/shared/metrics-controls.tsx
+++ b/src/ui/shared/metrics-controls.tsx
@@ -4,6 +4,13 @@ import { MetricHorizons } from "@app/types";
 
 export type MetricTabTypes = "table" | "chart";
 
+export const metricHorizonAsSeconds = (metricHorizon: MetricHorizons) =>
+  ({
+    "1h": 60 * 60,
+    "1d": 60 * 60 * 24,
+    "1w": 60 * 60 * 24 * 7,
+  })[metricHorizon];
+
 export const MetricsViewControls = ({
   viewMetricTab,
   setViewMetricTab,


### PR DESCRIPTION
Correctly results in zero or near zero 404s from metrictunnel service now

<img width="1245" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/c6bcf6f0-5651-437b-83a8-d1fa189ffb92">

No failures in PR:

<img width="168" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/33ef1c1b-5b3a-4c22-96a9-35472c23dd1e">

Ex equiv in prod: 

<img width="190" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/fb250d60-1533-421a-9d12-8c305087ee59">
