### PR TITLE
chore: added fix for using proper unit on chartjs x cartesian scale config

### DIFF
--- a/src/metric-tunnel/index.ts
+++ b/src/metric-tunnel/index.ts
@@ -216,6 +216,9 @@ export const selectMetricDataByChart = createSelector(
         data: [],
       };
       metric.values.forEach((metricValue) => {
+        if (!metricValue.date) {
+          console.log(metricValue);
+        }
         dataset.data.push({
           x: metricValue.date,
           y: metricValue.value,

--- a/src/metric-tunnel/index.ts
+++ b/src/metric-tunnel/index.ts
@@ -216,9 +216,6 @@ export const selectMetricDataByChart = createSelector(
         data: [],
       };
       metric.values.forEach((metricValue) => {
-        if (!metricValue.date) {
-          console.log(metricValue);
-        }
         dataset.data.push({
           x: metricValue.date,
           y: metricValue.value,

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -11,6 +11,7 @@ import {
   LinearScale,
   PointElement,
   TimeScale,
+  TimeUnit,
   Title,
   Tooltip,
 } from "chart.js";
@@ -29,11 +30,24 @@ ChartJS.register(
   Legend,
 );
 
+const timeHorizonToChartJSUnit = (metricHorizon: MetricHorizons): TimeUnit =>
+  ({
+    "1h": "minute" as TimeUnit,
+    "1d": "minute" as TimeUnit,
+    "1w": "day" as TimeUnit,
+  })[metricHorizon];
+
 const LineChartWrapper = ({
   showLegend = true,
   keyId,
   chart: { labels, datasets, title },
-}: { showLegend?: boolean; keyId: string; chart: ChartToCreate }) =>
+  xAxisUnit,
+}: {
+  showLegend?: boolean;
+  keyId: string;
+  chart: ChartToCreate;
+  xAxisUnit: TimeUnit;
+}) =>
   datasets && title ? (
     <Line
       datasetIdKey={keyId}
@@ -94,6 +108,7 @@ const LineChartWrapper = ({
             },
             time: {
               tooltipFormat: "yyyy-MM-dd HH:mm:ss",
+              unit: xAxisUnit,
             },
             type: "time",
           },
@@ -140,6 +155,7 @@ export const ContainerMetricsChart = ({
         keyId={`${containerIds.join("-")}-${metricNames.join(
           "-",
         )}-${metricHorizon}`}
+        xAxisUnit={timeHorizonToChartJSUnit(metricHorizon)}
         chart={chartToCreate}
       />
     </div>


### PR DESCRIPTION
1h:

<img width="1243" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/76ed4081-c59d-4638-9c9a-42e3957eacca">

1d:

<img width="1250" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/39057c72-fe01-428a-9c48-1803083c4af6">

1w:

<img width="1241" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/f0072d6c-774d-4ad7-94a7-cf114dd1fc20">
