### PR TITLE
Make certificates status pills flex row

### DIFF
--- a/src/ui/pages/environment-detail-certificates.tsx
+++ b/src/ui/pages/environment-detail-certificates.tsx
@@ -148,7 +148,7 @@ const CertificateStatusCell = ({
   return (
     <Td className="flex-1">
       <div className="flex">
-        <div className="leading-4 flex flex-col gap-2">
+        <div className="leading-4 flex flex-row">
           <CertificateTrustedPill certificate={certificate} />
           <ManagedHTTPSPill certificate={certificate} />
         </div>


### PR DESCRIPTION
Make certificates status pills flex-row to fit more above the fold & save space.

Before
<img width="287" alt="Screen Shot 2023-08-02 at 3 04 49 PM" src="https://github.com/aptible/app-ui/assets/4295811/8b63614a-5d55-48c6-8b5d-f569eb674c76">

After
<img width="286" alt="Screen Shot 2023-08-02 at 3 04 04 PM" src="https://github.com/aptible/app-ui/assets/4295811/7bb98e1c-809e-472a-b2ba-11f809633a13">
