### PR TITLE
Fix mobile login box styling

### DIFF
--- a/src/ui/layouts/error-boundary.tsx
+++ b/src/ui/layouts/error-boundary.tsx
@@ -20,7 +20,7 @@ function GenericErrorFallback({ error }: { error: Error | string }) {
   return (
     <HeroBgLayout>
       <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md h-screen">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10">
+        <div className="bg-white py-8 px-10 shadow rounded-lg">
           <h1 className="text-lg font-semibold text-red mb-">
             <IconAlertTriangle
               className="inline -mt-1 mr-2"

--- a/src/ui/pages/elevate.tsx
+++ b/src/ui/pages/elevate.tsx
@@ -72,7 +72,7 @@ export const ElevatePage = () => {
       </div>
 
       <div className="mt-8">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-black-100">
+        <div className="bg-white py-8 px-10 shadow rounded-lg border border-black-100">
           <form className="space-y-4" onSubmit={onSubmit}>
             <BannerMessages className="my-2" {...loader} />
             <FormGroup label="Email" htmlFor="input-email">

--- a/src/ui/pages/login.tsx
+++ b/src/ui/pages/login.tsx
@@ -111,7 +111,7 @@ export const LoginPage = () => {
       </div>
 
       <div className="mt-8">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-black-100">
+        <div className="bg-white py-8 px-10 shadow rounded-lg border border-black-100">
           <form className="space-y-4" onSubmit={onSubmit}>
             {isOtpRequired ? (
               <BannerMessages

--- a/src/ui/pages/signup.tsx
+++ b/src/ui/pages/signup.tsx
@@ -162,7 +162,7 @@ export const SignupPage = () => {
       </div>
 
       <div className="mt-8">
-        <div className="bg-white py-8 px-4 shadow sm:rounded-lg sm:px-10 border border-black-100">
+        <div className="bg-white py-8 px-10 shadow rounded-lg border border-black-100">
           <form className="space-y-4" onSubmit={onSubmitForm}>
             <FormGroup label="Name" htmlFor="name">
               <Input

--- a/src/ui/shared/box.tsx
+++ b/src/ui/shared/box.tsx
@@ -4,7 +4,7 @@ export const Box = ({
 }: { children: React.ReactNode; className?: string }) => {
   return (
     <div
-      className={`bg-white py-8 px-8 shadow border border-black-100 rounded-lg ${className}`}
+      className={`bg-white py-10 px-10 shadow border border-black-100 rounded-lg ${className}`}
     >
       {children}
     </div>


### PR DESCRIPTION
On mobile screens, login, sign up, 404 page buttons and input fields lose all their padding around them (the container div padding drops). This fixes that.

BEFORE
<img width="562" alt="Screen Shot 2023-08-02 at 4 26 01 PM" src="https://github.com/aptible/app-ui/assets/4295811/3ac12f26-43b4-46b3-b1f2-32a4701ec776">

AFTER
<img width="562" alt="Screen Shot 2023-08-02 at 4 20 18 PM" src="https://github.com/aptible/app-ui/assets/4295811/1380d8a1-cfa1-4c23-a0f5-42ef0fa9df4d">

