### PR TITLE
Fix-Shared-Box-Padding

### DIFF
--- a/src/ui/shared/box.tsx
+++ b/src/ui/shared/box.tsx
@@ -4,7 +4,7 @@ export const Box = ({
 }: { children: React.ReactNode; className?: string }) => {
   return (
     <div
-      className={`bg-white py-10 px-10 shadow border border-black-100 rounded-lg ${className}`}
+      className={`bg-white py-8 px-8 shadow border border-black-100 rounded-lg ${className}`}
     >
       {children}
     </div>


### PR DESCRIPTION
Correct shared box padding size

BEFORE - too big

<img width="431" alt="Screen Shot 2023-08-03 at 9 21 36 AM" src="https://github.com/aptible/app-ui/assets/4295811/270b8421-48cc-47ac-b563-ca6ba9296f24">

AFTER

<img width="507" alt="Screen Shot 2023-08-03 at 9 21 26 AM" src="https://github.com/aptible/app-ui/assets/4295811/93c202dc-1f81-4701-856c-fe6b53149b5c">
