### PR TITLE
Simplify-App-Header-Card

### DIFF
--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -19,6 +19,7 @@ import {
   appSettingsUrl,
   environmentAppsUrl,
 } from "@app/routes";
+import { capitalize } from "@app/string-utils";
 import type { AppState, DeployApp } from "@app/types";
 
 import { usePoller } from "../hooks";

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -58,9 +58,7 @@ export function AppHeader({ app }: { app: DeployApp }) {
         <div className="hidden md:block" />
         <DetailInfoItem title="Last Deployed">
           {app.lastDeployOperation
-            ? `${capitalize(
-                app.lastDeployOperation.type,
-              )} on ${prettyEnglishDate(app.lastDeployOperation?.createdAt)}`
+            ? `${prettyEnglishDate(app.lastDeployOperation?.createdAt)}`
             : "Unknown"}
         </DetailInfoItem>
         <DetailInfoItem title="Docker Image">

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -19,7 +19,6 @@ import {
   appSettingsUrl,
   environmentAppsUrl,
 } from "@app/routes";
-import { capitalize } from "@app/string-utils";
 import type { AppState, DeployApp } from "@app/types";
 
 import { usePoller } from "../hooks";


### PR DESCRIPTION
Remove the word deploy and just show the date for Last Deployed info inside the header card.

BEFORE - We don't need say the word Deploy again below the Last Deployed Header
<img width="323" alt="Screen Shot 2023-08-03 at 12 10 04 PM" src="https://github.com/aptible/app-ui/assets/4295811/2914a4c7-f3ac-4d40-a27a-36e7e173118b">

AFTER
<img width="332" alt="Screen Shot 2023-08-03 at 12 09 57 PM" src="https://github.com/aptible/app-ui/assets/4295811/49bd2278-15e0-4457-8315-269ca84a7ac8">
