### PR TITLE
Fix Code Wrapping Bug

### DIFF
--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -45,7 +45,7 @@ export const PreCode = ({
   return (
     <div className="relative">
       <code
-        className={`p-4 rounded-lg text-sm pr-14 overflow-x-auto block [overflow-wrap:anywhere] ${className}`}
+        className={`p-4 rounded-lg text-sm pr-14 overflow-x-auto block ${className}`}
       >
         {segments.map(({ text, className }, idx) => {
           return (

--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -45,7 +45,7 @@ export const PreCode = ({
   return (
     <div className="relative">
       <code
-        className={`p-4 rounded-lg text-sm pr-14 overflow-x-auto block ${className}`}
+        className={`p-4 rounded-lg text-sm pr-14 overflow-x-auto block [overflow-wrap:anywhere] ${className}`}
       >
         {segments.map(({ text, className }, idx) => {
           return (

--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -44,8 +44,8 @@ export const PreCode = ({
 
   return (
     <div className="relative">
-      <pre
-        className={`p-4 rounded-lg text-sm pr-14 overflow-x-auto ${className}`}
+      <code
+        className={`p-4 rounded-lg text-sm pr-14 overflow-x-auto block ${className}`}
       >
         {segments.map(({ text, className }, idx) => {
           return (
@@ -55,7 +55,7 @@ export const PreCode = ({
             </span>
           );
         })}
-      </pre>
+      </code>
       {allowCopy ? (
         <div
           title="Copy to clipboard"


### PR DESCRIPTION
In deploy-ui, the current behavior is to wrap code. This PR matches that behavior.

BEFORE
 
<img width="1201" alt="Screen Shot 2023-08-04 at 4 35 16 PM" src="https://github.com/aptible/app-ui/assets/4295811/b15b0559-75e0-42be-b255-97f22fd3ef71">


AFTER
<img width="1190" alt="Screen Shot 2023-08-04 at 4 34 53 PM" src="https://github.com/aptible/app-ui/assets/4295811/e60cc308-a097-40f5-8673-bfd475cf3e72">
