### PR TITLE
Table Tweaks

### DIFF
--- a/src/ui/shared/table.tsx
+++ b/src/ui/shared/table.tsx
@@ -14,7 +14,7 @@ export const Td = ({ children, className }: CellProps) => {
   const classes = cn(
     tokens.type["small lighter"],
     "pl-4 py-3",
-    "whitespace-nowrap",
+    "break-words",
     className,
   );
   return <td className={classes}>{children}</td>;


### PR DESCRIPTION
Allow long TDs to wrap in our tables

BEFORE - TD content overflows
<img width="747" alt="Screen Shot 2023-08-07 at 4 39 36 PM" src="https://github.com/aptible/app-ui/assets/4295811/cdd6e49f-dc97-45a1-9dd5-2e5adc31c568">

AFTER
<img width="734" alt="Screen Shot 2023-08-07 at 4 39 45 PM" src="https://github.com/aptible/app-ui/assets/4295811/136b7bf3-74a6-4438-9bce-d355a6bc33c3">
