### PR TITLE
chore: corrected some numbers on tables/layout views

### DIFF
--- a/src/deploy/app/utils.ts
+++ b/src/deploy/app/utils.ts
@@ -144,7 +144,7 @@ export const calcMetrics = (services: DeployService[]) => {
   const totalCPU = () => {
     let total = 0;
     services.forEach((s) => {
-      total += (s.containerMemoryLimitMb / 1024) * 0.25;
+      total += s.containerMemoryLimitMb * getContainerProfileFromType(s.instanceClass).cpuShare;
     });
     return total;
   };

--- a/src/deploy/app/utils.ts
+++ b/src/deploy/app/utils.ts
@@ -144,7 +144,9 @@ export const calcMetrics = (services: DeployService[]) => {
   const totalCPU = () => {
     let total = 0;
     services.forEach((s) => {
-      total += s.containerMemoryLimitMb * getContainerProfileFromType(s.instanceClass).cpuShare;
+      total +=
+        s.containerMemoryLimitMb *
+        getContainerProfileFromType(s.instanceClass).cpuShare;
     });
     return total;
   };


### PR DESCRIPTION
This was coercing a 0.25 multiplier every time, which was wrong. It needed to use the cpushare for the instance class to work

---

With fix

<img width="725" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/e8c77aec-8f12-4dd7-a6b3-d215abc25b67">

matches prod

<img width="948" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/501e6e19-41ba-4fab-aa54-22f4b5194da2">


---

Without fix (note it's 1, not 0.5):

<img width="936" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/0aa1361f-ced7-4ad3-a81b-342fdef0e924">
