### PR TITLE
Add-EditBackupPolicyButton

### DIFF
--- a/src/ui/pages/db-detail-backups.tsx
+++ b/src/ui/pages/db-detail-backups.tsx
@@ -16,8 +16,10 @@ import { usePoller } from "../hooks";
 import {
   BannerMessages,
   ButtonCreate,
+  Button,
   DatabaseBackupsList,
   IconPlusCircle,
+  IconEdit2,
   LoadingSpinner,
 } from "../shared";
 import { useMemo } from "react";
@@ -59,7 +61,10 @@ export const DatabaseBackupsPage = () => {
           <IconPlusCircle variant="sm" className="mr-2" /> New Backup
         </ButtonCreate>
 
+        <Button variant="white"><IconEdit2 variant="sm" className="mr-2" /> Edit Backup Policy</Button>
+
         <LoadingSpinner show={pollLoader.isLoading} />
+
       </div>
 
       <BannerMessages className="my-4" {...loader} />

--- a/src/ui/pages/db-detail-backups.tsx
+++ b/src/ui/pages/db-detail-backups.tsx
@@ -7,19 +7,20 @@ import {
   pollDatabaseBackups,
   selectBackupsByDatabaseId,
   selectDatabaseById,
+  selectEnvironmentById,
 } from "@app/deploy";
 import { useLoader, useLoaderSuccess } from "@app/fx";
-import { databaseActivityUrl } from "@app/routes";
+import { databaseActivityUrl, environmentBackupsUrl } from "@app/routes";
 import { AppState } from "@app/types";
 
 import { usePoller } from "../hooks";
 import {
   BannerMessages,
   ButtonCreate,
-  Button,
+  ButtonLink,
   DatabaseBackupsList,
+  IconEdit,
   IconPlusCircle,
-  IconEdit2,
   LoadingSpinner,
 } from "../shared";
 import { useMemo } from "react";
@@ -61,10 +62,14 @@ export const DatabaseBackupsPage = () => {
           <IconPlusCircle variant="sm" className="mr-2" /> New Backup
         </ButtonCreate>
 
-        <Button variant="white"><IconEdit2 variant="sm" className="mr-2" /> Edit Backup Policy</Button>
+        <ButtonLink
+          to={environmentBackupsUrl(db.environmentId)}
+          variant="white"
+        >
+          <IconEdit variant="sm" className="mr-2" /> Edit Backup Policy
+        </ButtonLink>
 
         <LoadingSpinner show={pollLoader.isLoading} />
-
       </div>
 
       <BannerMessages className="my-4" {...loader} />

--- a/src/ui/pages/db-detail-backups.tsx
+++ b/src/ui/pages/db-detail-backups.tsx
@@ -7,7 +7,6 @@ import {
   pollDatabaseBackups,
   selectBackupsByDatabaseId,
   selectDatabaseById,
-  selectEnvironmentById,
 } from "@app/deploy";
 import { useLoader, useLoaderSuccess } from "@app/fx";
 import { databaseActivityUrl, environmentBackupsUrl } from "@app/routes";

--- a/src/ui/pages/environment-detail-backups.test.tsx
+++ b/src/ui/pages/environment-detail-backups.test.tsx
@@ -77,11 +77,11 @@ describe("EnvironmentBackupsPage", () => {
     const monthly = await screen.findByLabelText(/Monthly backups retained/);
     await act(async () => await userEvent.type(monthly, "1"));
 
-    const btn = await screen.findByRole("button", { name: /Save/ });
+    const btn = await screen.findByRole("button", { name: /Save Policy/ });
     fireEvent.click(btn);
 
     await screen.findByRole("button", { name: /Loading/ });
-    await screen.findByRole("button", { name: /Save/ });
+    await screen.findByRole("button", { name: /Save Policy/ });
 
     const newDaily = await screen.findByLabelText(/Daily backups retained/);
     expect(newDaily).toHaveValue(15);

--- a/src/ui/pages/styles.tsx
+++ b/src/ui/pages/styles.tsx
@@ -32,7 +32,7 @@ import {
   IconCreditCard,
   IconCylinder,
   IconDownload,
-  IconEdit2,
+  IconEdit,
   IconEllipsis,
   IconExternalLink,
   IconGitBranch,
@@ -537,7 +537,7 @@ const Icons = () => (
       {[
         ["IconArrowRight", <IconArrowRight />],
         ["IconArrowLeft", <IconArrowLeft />],
-        ["IconEdit2", <IconEdit2 />],
+        ["IconEdit", <IconEdit />],
         ["IconChevronUp", <IconChevronUp />],
         ["IconChevronRight", <IconChevronRight />],
         ["IconChevronDown", <IconChevronDown />],

--- a/src/ui/shared/environment/backup-retention-policy-view.tsx
+++ b/src/ui/shared/environment/backup-retention-policy-view.tsx
@@ -93,6 +93,10 @@ export const BackupRpView = ({ envId }: { envId: string }) => {
   return (
     <div className="bg-white py-8 px-8 shadow border border-black-100 rounded-lg">
       <h3 className={tokens.type.h3}>Backup Retention Policy</h3>
+      <div className="mt-4">
+        Any changes made will impact <strong>all database backups</strong>{" "}
+        inside this Environment.
+      </div>
 
       <form onSubmit={onSubmit} className="flex flex-col gap-2 mt-4">
         <FormGroup
@@ -157,7 +161,7 @@ export const BackupRpView = ({ envId }: { envId: string }) => {
             envId={envId}
             isLoading={loader.isLoading}
           >
-            Save
+            Save Policy
           </ButtonCreate>
 
           <Button variant="white" onClick={onReset}>

--- a/src/ui/shared/icons.tsx
+++ b/src/ui/shared/icons.tsx
@@ -53,7 +53,7 @@ export const IconArrowLeft = (props: Props) => {
   );
 };
 
-export const IconEdit2 = (props: Props) => {
+export const IconEdit = (props: Props) => {
   return (
     <IconStrokeBase {...props} title="Edit Icon">
       <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z" />


### PR DESCRIPTION
Add Edit Backup Policy Button to "Database / Backups Tab"

When clicked the button navigates to it's parent environment's backups tab.

Edit Backup Policy Button
<img width="928" alt="Screen Shot 2023-08-14 at 2 37 10 PM" src="https://github.com/aptible/app-ui/assets/4295811/2851ae6a-97ee-49ae-b4f4-2ca94247a25f">

Link destination
<img width="849" alt="Screen Shot 2023-08-14 at 3 20 50 PM" src="https://github.com/aptible/app-ui/assets/4295811/b273c6d5-696c-4b0b-b5cd-c24398e73602">


