### PR TITLE
Fix-Metrics-Table-Overflow

### DIFF
--- a/src/ui/shared/container-metrics-table.tsx
+++ b/src/ui/shared/container-metrics-table.tsx
@@ -42,7 +42,7 @@ export const ContainerMetricsDataTable = ({
   }
 
   return (
-    <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 rounded-lg w-[calc(100vw-7.5rem)]">
+    <div className="overflow-x-auto shadow ring-1 ring-black ring-opacity-5 rounded-lg md:w-full w-[calc(100vw-7.5rem)]">
       <table className="overflow-x-auto min-w-full divide-y divide-gray-300">
         <TableHead headers={columnHeaders} />
         <tbody className="divide-y divide-gray-200 bg-white">{tableRows}</tbody>


### PR DESCRIPTION
Adding a non-mobile breakpoint for w-full to the metrics table. This bug only happens when the sidebar is toggled open.

BEFORE - View of my viewport on the right side
<img width="280" alt="Screen Shot 2023-08-14 at 8 13 29 PM" src="https://github.com/aptible/app-ui/assets/4295811/2732b2cc-cd89-43f8-96a9-09c1bbec825d">


AFTER - View of my viewport on the right side
<img width="369" alt="Screen Shot 2023-08-14 at 8 13 56 PM" src="https://github.com/aptible/app-ui/assets/4295811/691b3b49-3add-417b-89e7-d1fc514f2577">

