### PR TITLE
move-reveal-creds-to-db-header

### DIFF
--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -29,6 +29,7 @@ import {
   DetailInfoItem,
   DetailPageHeaderView,
   DetailTitleBar,
+  Secret,
   TabItem,
 } from "../shared";
 import { ActiveOperationNotice } from "../shared/active-operation-notice";
@@ -87,6 +88,10 @@ export function DatabaseHeader({
           {CONTAINER_PROFILES[service.instanceClass].name}
         </DetailInfoItem>
       </DetailInfoGrid>
+      <div className="text-base font-semibold text-gray-900 -mb-2">
+        Reveal Credentials
+      </div>
+      <Secret secret={database.connectionUrl} />
     </DetailHeader>
   );
 }

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -10,7 +10,6 @@ import {
   IconTrash,
   Input,
   Label,
-  Secret,
 } from "../shared";
 import {
   deprovisionDatabase,

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -132,12 +132,6 @@ export const DatabaseSettingsPage = () => {
               </ul>
             </Banner>
           ) : null}
-          <div className="my-4">
-            <Label className="text-base font-semibold text-gray-900 block">
-              Credentials
-            </Label>
-            <Secret secret={database.connectionUrl} />
-          </div>
 
           <hr className="mt-6" />
 


### PR DESCRIPTION
Move Reveal Credentials to Database Header

BEFORE
<img width="668" alt="Screen Shot 2023-08-22 at 3 45 11 PM" src="https://github.com/aptible/app-ui/assets/4295811/eff7badd-67b9-4a89-aba7-71107cc046cc">


AFTER
<img width="738" alt="Screen Shot 2023-08-22 at 3 43 43 PM" src="https://github.com/aptible/app-ui/assets/4295811/2cc7b24e-22e9-44fa-bb50-734da85b8d06">
