### PR TITLE
Keep Header Spacing Consistent

### DIFF
--- a/src/ui/shared/endpoint/endpoint-list.tsx
+++ b/src/ui/shared/endpoint/endpoint-list.tsx
@@ -117,7 +117,7 @@ const EndpointHeader = ({
       title={showTitle ? "Endpoints" : ""}
       actions={actions}
       filterBar={
-        <div>
+        <div className="pt-1">
           <InputSearch
             placeholder="Search endpoints..."
             search={search}

--- a/src/ui/shared/endpoint/endpoint-list.tsx
+++ b/src/ui/shared/endpoint/endpoint-list.tsx
@@ -203,7 +203,7 @@ export function EndpointsByOrg() {
     return (
       <EmptyResultView
         title="No endpoints yet"
-        description="Expose this application to the public internet by adding an endpoint"
+        description="Expose an application to the public internet by adding an endpoint"
         className="p-6 w-100"
       />
     );

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -160,7 +160,7 @@ const EnvsResourceHeaderTitleBar = ({
         </ButtonIcon>,
       ]}
       filterBar={
-        <div>
+        <div className="pt-1">
           <InputSearch
             placeholder="Search environments..."
             search={search}


### PR DESCRIPTION
Keep our page headers spacing consistent so the search bar (ex. Search Environments) doesn't shift between pages

https://github.com/aptible/app-ui/assets/4295811/b7c9348c-a923-4bf0-9e5f-417fe055ab4c

and

Small copy tweak for empty endpoint page

<img width="491" alt="Screen Shot 2023-08-22 at 10 59 39 PM" src="https://github.com/aptible/app-ui/assets/4295811/9318b8d8-f532-4ed9-b1a0-2567629ddb1c">

