### PR TITLE
Org Picker Button Styling

### DIFF
--- a/src/ui/pages/org-picker.tsx
+++ b/src/ui/pages/org-picker.tsx
@@ -54,7 +54,7 @@ export const OrgPickerPage = () => {
   return (
     <MenuWrappedPage>
       <div className="flex flex-col gap-2">
-        <h1 className={tokens.type.h1}>Choose Organization</h1>
+        <h2 className={tokens.type.h2}>Choose Organization</h2>
 
         <div>
           {orgList.map((o) => {

--- a/src/ui/shared/org-picker.tsx
+++ b/src/ui/shared/org-picker.tsx
@@ -30,7 +30,9 @@ export const OrgPicker = () => {
       />
       <div>
         <div className="text-black">{org.name.slice(0, 20)}</div>
-        <div className="text-gray-500 text-sm -mt-1">{user.name.slice(0, 20)}</div>
+        <div className="text-gray-500 text-sm -mt-1">
+          {user.name.slice(0, 20)}
+        </div>
       </div>
     </div>
   );

--- a/src/ui/shared/org-picker.tsx
+++ b/src/ui/shared/org-picker.tsx
@@ -30,9 +30,7 @@ export const OrgPicker = () => {
       />
       <div>
         <div className="text-black">{org.name.slice(0, 20)}</div>
-        <div className="text-gray-500 text-sm">
-          {user.name.slice(0, 20)}
-        </div>
+        <div className="text-gray-500 text-sm">{user.name.slice(0, 20)}</div>
       </div>
     </div>
   );

--- a/src/ui/shared/org-picker.tsx
+++ b/src/ui/shared/org-picker.tsx
@@ -21,6 +21,7 @@ export const OrgPicker = () => {
         "border border-gray-200 bg-white rounded-lg cursor-pointer",
         "px-2 py-1",
         "flex items-center",
+        "hover:bg-black-50",
       ])}
     >
       <IconWorkplace

--- a/src/ui/shared/org-picker.tsx
+++ b/src/ui/shared/org-picker.tsx
@@ -30,7 +30,7 @@ export const OrgPicker = () => {
       />
       <div>
         <div className="text-black">{org.name.slice(0, 20)}</div>
-        <div className="text-gray-500 text-sm">{user.name.slice(0, 20)}</div>
+        <div className="text-gray-500 text-sm -mt-1">{user.name.slice(0, 20)}</div>
       </div>
     </div>
   );

--- a/src/ui/shared/org-picker.tsx
+++ b/src/ui/shared/org-picker.tsx
@@ -30,7 +30,7 @@ export const OrgPicker = () => {
       />
       <div>
         <div className="text-black">{org.name.slice(0, 20)}</div>
-        <div className="text-gray-500 text-sm -mt-1">
+        <div className="text-gray-500 text-sm">
           {user.name.slice(0, 20)}
         </div>
       </div>


### PR DESCRIPTION
• Add hover state to org picker button
• Made "Choose Organization" type match the same font-size as our page labels (h2)

BEFORE
<img width="563" alt="Screen Shot 2023-08-23 at 10 44 32 AM" src="https://github.com/aptible/app-ui/assets/4295811/89b294d9-909a-4e8b-9d62-246a369cd3a4">


AFTER
<img width="550" alt="Screen Shot 2023-08-23 at 10 57 10 AM" src="https://github.com/aptible/app-ui/assets/4295811/8e3234c7-5f8e-4181-8be1-02547fcb0724">


