### PR TITLE
chore: added restart actions for dbs/apps/drains

### DIFF
--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -415,6 +415,30 @@ export const appEntities = {
   }),
 };
 
+export const restartApp = api.post<{ id: string }, DeployOperationResponse>(
+  ["/apps/:id/operations", "restart"],
+  function* (ctx, next) {
+    const { id } = ctx.payload;
+    const body = {
+      type: "restart",
+      id,
+    };
+
+    ctx.request = ctx.req({ body: JSON.stringify(body) });
+    yield* next();
+
+    if (!ctx.json.ok) {
+      return;
+    }
+
+    const opId = ctx.json.data.id;
+    ctx.loader = {
+      message: `Restart app operation queued (operation ID: ${opId})`,
+      meta: { opId: `${opId}` },
+    };
+  },
+);
+
 export const deprovisionApp = thunks.create<{
   appId: string;
 }>("deprovision-app", function* (ctx, next) {

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -697,7 +697,7 @@ export const restartDatabase = api.post<
 export const scaleDatabase = api.post<
   DatabaseScaleProps,
   DeployOperationResponse
->(["/databases/:id/operations", "restart"], function* (ctx, next) {
+>(["/databases/:id/operations", "scale"], function* (ctx, next) {
   const { id, diskSize, containerProfile, containerSize } = ctx.payload;
   const body = {
     type: "restart",

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -670,6 +670,30 @@ export interface DatabaseScaleProps {
   containerProfile?: InstanceClass;
 }
 
+export const restartDatabase = api.post<
+  { id: string },
+  DeployOperationResponse
+>(["/databases/:id/operations", "restart"], function* (ctx, next) {
+  const { id } = ctx.payload;
+  const body = {
+    type: "restart",
+    id,
+  };
+
+  ctx.request = ctx.req({ body: JSON.stringify(body) });
+  yield* next();
+
+  if (!ctx.json.ok) {
+    return;
+  }
+
+  const opId = ctx.json.data.id;
+  ctx.loader = {
+    message: `Restart database operation queued (operation ID: ${opId})`,
+    meta: { opId: `${opId}` },
+  };
+});
+
 export const scaleDatabase = api.post<
   DatabaseScaleProps,
   DeployOperationResponse

--- a/src/deploy/log-drain/index.ts
+++ b/src/deploy/log-drain/index.ts
@@ -344,6 +344,31 @@ export const provisionLogDrain = thunks.create<CreateLogDrainProps>(
   },
 );
 
+export const restartLogDrain = api.post<
+  { id: string },
+  DeployOperationResponse
+>(["/log_drains/:id/operations", "restart"], function* (ctx, next) {
+  const { id } = ctx.payload;
+  // an empty configure triggers a restart for log drains
+  const body = {
+    type: "configure",
+    id,
+  };
+
+  ctx.request = ctx.req({ body: JSON.stringify(body) });
+  yield* next();
+
+  if (!ctx.json.ok) {
+    return;
+  }
+
+  const opId = ctx.json.data.id;
+  ctx.loader = {
+    message: `Restart log drain operation queued (operation ID: ${opId})`,
+    meta: { opId: `${opId}` },
+  };
+});
+
 export const logDrainEntities = {
   log_drain: defaultEntity({
     id: "log_drain",

--- a/src/deploy/log-drain/index.ts
+++ b/src/deploy/log-drain/index.ts
@@ -108,6 +108,11 @@ export interface DeployLogDrainResponse {
   created_at: string;
   updated_at: string;
   status: ProvisionableStatus;
+  _embedded: {
+    backend: {
+      channel: string;
+    };
+  };
   _links: {
     account: LinkResponse;
   };
@@ -131,6 +136,7 @@ export const deserializeLogDrain = (payload: any): DeployLogDrain => {
     drainEphemeralSessions: payload.drain_ephemeral_sessions,
     drainProxies: payload.drain_proxies,
     environmentId: extractIdFromLink(links.account),
+    backendChannel: payload._embedded.backend.channel,
     createdAt: payload.created_at,
     updatedAt: payload.updated_at,
     status: payload.status,
@@ -158,6 +164,11 @@ export const defaultLogDrainResponse = (
     status: "pending",
     created_at: now,
     updated_at: now,
+    _embedded: {
+      backend: {
+        channel: "",
+      },
+    },
     _links: {
       account: defaultHalHref(),
     },
@@ -184,6 +195,7 @@ export const defaultDeployLogDrain = (
     drainEphemeralSessions: false,
     drainDatabases: false,
     environmentId: "",
+    backendChannel: "",
     createdAt: now,
     updatedAt: now,
     status: "pending",

--- a/src/deploy/log-drain/index.ts
+++ b/src/deploy/log-drain/index.ts
@@ -344,6 +344,30 @@ export const provisionLogDrain = thunks.create<CreateLogDrainProps>(
   },
 );
 
+export const deprovisionLogDrain = api.post<
+  { id: string },
+  DeployOperationResponse
+>(["/log_drains/:id/operations", "deprovision"], function* (ctx, next) {
+  const { id } = ctx.payload;
+  const body = {
+    type: "deprovision",
+    id,
+  };
+
+  ctx.request = ctx.req({ body: JSON.stringify(body) });
+  yield* next();
+
+  if (!ctx.json.ok) {
+    return;
+  }
+
+  const opId = ctx.json.data.id;
+  ctx.loader = {
+    message: `Deprovision log drain operation queued (operation ID: ${opId})`,
+    meta: { opId: `${opId}` },
+  };
+});
+
 export const restartLogDrain = api.post<
   { id: string },
   DeployOperationResponse

--- a/src/deploy/metric-drain/index.ts
+++ b/src/deploy/metric-drain/index.ts
@@ -317,6 +317,31 @@ export const provisionMetricDrain = thunks.create<CreateMetricDrainProps>(
   },
 );
 
+export const deprovisionMetricDrain = api.post<
+  { id: string },
+  DeployOperationResponse
+>(["/metric_drains/:id/operations", "deprovision"], function* (ctx, next) {
+  const { id } = ctx.payload;
+  // an empty provision triggers a restart for metric drains
+  const body = {
+    type: "deprovision",
+    id,
+  };
+
+  ctx.request = ctx.req({ body: JSON.stringify(body) });
+  yield* next();
+
+  if (!ctx.json.ok) {
+    return;
+  }
+
+  const opId = ctx.json.data.id;
+  ctx.loader = {
+    message: `Deprovision log drain operation queued (operation ID: ${opId})`,
+    meta: { opId: `${opId}` },
+  };
+});
+
 export const restartMetricDrain = api.post<
   { id: string },
   DeployOperationResponse

--- a/src/deploy/metric-drain/index.ts
+++ b/src/deploy/metric-drain/index.ts
@@ -317,6 +317,31 @@ export const provisionMetricDrain = thunks.create<CreateMetricDrainProps>(
   },
 );
 
+export const restartMetricDrain = api.post<
+  { id: string },
+  DeployOperationResponse
+>(["/metric_drains/:id/operations", "restart"], function* (ctx, next) {
+  const { id } = ctx.payload;
+  // an empty provision triggers a restart for metric drains
+  const body = {
+    type: "provision",
+    id,
+  };
+
+  ctx.request = ctx.req({ body: JSON.stringify(body) });
+  yield* next();
+
+  if (!ctx.json.ok) {
+    return;
+  }
+
+  const opId = ctx.json.data.id;
+  ctx.loader = {
+    message: `Restart log drain operation queued (operation ID: ${opId})`,
+    meta: { opId: `${opId}` },
+  };
+});
+
 export const metricDrainEntities = {
   metric_drain: defaultEntity({
     id: "metric_drain",

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -329,6 +329,7 @@ export interface DeployLogDrain extends Provisionable, Timestamps {
   drainEphemeralSessions: boolean;
   drainProxies: boolean;
   environmentId: string;
+  backendChannel: string;
 }
 
 export interface DeployMetricDrain extends Provisionable, Timestamps {

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   BoxGroup,
   Button,
-  ButtonIcon,
   ButtonLinkExternal,
   ExternalLink,
   FormGroup,

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -3,13 +3,16 @@ import {
   Box,
   BoxGroup,
   Button,
+  ButtonIcon,
   ButtonLinkExternal,
   ExternalLink,
   FormGroup,
   IconAlertTriangle,
   IconExternalLink,
+  IconRefresh,
   IconTrash,
   Input,
+  Label,
   PreCode,
   listToInvertedTextColor,
 } from "../shared";
@@ -18,13 +21,14 @@ import {
   fetchApp,
   fetchEnvLogDrains,
   fetchEnvMetricDrains,
+  restartApp,
   selectAppById,
   selectLogDrainsByEnvId,
   selectMetricDrainsByEnvId,
   updateApp,
 } from "@app/deploy";
-import { useLoader, useQuery } from "@app/fx";
-import { appActivityUrl } from "@app/routes";
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
+import { appActivityUrl, operationDetailUrl } from "@app/routes";
 import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
 import { SyntheticEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -75,6 +79,16 @@ export const AppSettingsPage = () => {
     dispatch(deprovisionApp({ appId: app.id }));
     navigate(appActivityUrl(id));
   };
+
+  const restartAction = restartApp({ id });
+  const restartLoader = useLoader(restartAction);
+  const submitRestart = (e: SyntheticEvent) => {
+    e.preventDefault();
+    dispatch(restartAction);
+  };
+  useLoaderSuccess(restartLoader, () => {
+    navigate(operationDetailUrl(restartLoader.meta.opId));
+  });
 
   const disabledDeprovisioning =
     isDeprovisioning || app.handle !== deleteConfirm;
@@ -157,15 +171,32 @@ export const AppSettingsPage = () => {
             ) : null}
           </FormGroup>
 
+          <Label className="mt-4">Restart App</Label>
+          <Button
+            variant="white"
+            disabled={restartLoader.isLoading}
+            className="h-15 w-30 mb-0 ml-0 mt-4 flex"
+            onClick={submitRestart}
+          >
+            <IconRefresh className="mr-2" />
+            {isDeprovisioning ? "Restarting App..." : "Restart App"}
+          </Button>
+
           <hr className="mt-6" />
 
           <div className="flex mt-4">
             <Button
               className="w-40 flex semibold"
               type="submit"
-              disabled={isUpdating || updatingAppLoader.isLoading}
+              disabled={
+                isUpdating ||
+                updatingAppLoader.isLoading ||
+                restartLoader.isLoading
+              }
             >
-              {isUpdating || updatingAppLoader.isLoading
+              {isUpdating ||
+              updatingAppLoader.isLoading ||
+              restartLoader.isLoading
                 ? "Loading..."
                 : "Save Changes"}
             </Button>

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -1,20 +1,7 @@
-import {
-  Banner,
-  Box,
-  BoxGroup,
-  Button,
-  ButtonLinkExternal,
-  ExternalLink,
-  FormGroup,
-  IconAlertTriangle,
-  IconExternalLink,
-  IconRefresh,
-  IconTrash,
-  Input,
-  Label,
-  PreCode,
-  listToInvertedTextColor,
-} from "../shared";
+import { useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate, useParams } from "react-router";
+
 import {
   deprovisionApp,
   fetchApp,
@@ -28,22 +15,125 @@ import {
 } from "@app/deploy";
 import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { appActivityUrl, operationDetailUrl } from "@app/routes";
-import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
-import { MouseEventHandler, SyntheticEvent, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { useNavigate, useParams } from "react-router";
+import {
+  AppState,
+  DeployApp,
+  DeployLogDrain,
+  DeployMetricDrain,
+} from "@app/types";
 
-export const AppSettingsPage = () => {
-  const [handle, setHandle] = useState<string>("");
-  const [deleteConfirm, setDeleteConfirm] = useState<string>("");
+import {
+  Banner,
+  Box,
+  BoxGroup,
+  Button,
+  ButtonCreate,
+  ButtonDestroy,
+  ButtonLinkExternal,
+  ButtonOps,
+  ExternalLink,
+  FormGroup,
+  Group,
+  IconAlertTriangle,
+  IconExternalLink,
+  IconRefresh,
+  IconTrash,
+  Input,
+  Label,
+  PreCode,
+  listToInvertedTextColor,
+} from "../shared";
+
+interface AppProps {
+  app: DeployApp;
+}
+
+const AppDeprovision = ({ app }: AppProps) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const updatingAppLoader = useLoader(updateApp);
-  const deprovisioningAppLoader = useLoader(deprovisionApp);
+  const [deleteConfirm, setDeleteConfirm] = useState<string>("");
+  const action = deprovisionApp({ appId: app.id });
+  const loader = useLoader(action);
+  const onClick = (ev: React.FormEvent<HTMLFormElement>) => {
+    ev.preventDefault();
+    dispatch(action);
+    navigate(appActivityUrl(app.id));
+  };
+  const isDisabled = app.handle !== deleteConfirm;
 
-  const { id = "" } = useParams();
-  useQuery(fetchApp({ id }));
-  const app = useSelector((s: AppState) => selectAppById(s, { id }));
+  return (
+    <form onSubmit={onClick}>
+      <h1 className="text-lg text-red-500 font-semibold flex items-center gap-2">
+        <IconAlertTriangle variant="sm" color="#AD1A1A" />
+        Deprovision App
+      </h1>
+
+      <Group>
+        <p>
+          This will permanently deprovision <strong>{app.handle}</strong> app.
+          This action cannot be undone. If you want to proceed, type the{" "}
+          <strong>{app.handle}</strong> below to continue.
+        </p>
+
+        <Group variant="horizontal" size="sm" className="items-center">
+          <Input
+            className="flex-1"
+            disabled={loader.isLoading}
+            name="delete-confirm"
+            type="text"
+            value={deleteConfirm}
+            onChange={(e) => setDeleteConfirm(e.currentTarget.value)}
+            id="delete-confirm"
+          />
+          <ButtonDestroy
+            envId={app.environmentId}
+            type="submit"
+            variant="delete"
+            className="w-70 flex"
+            disabled={isDisabled}
+            isLoading={loader.isLoading}
+          >
+            <IconTrash color="#FFF" className="mr-2" />
+            Deprovision App
+          </ButtonDestroy>
+        </Group>
+      </Group>
+    </form>
+  );
+};
+
+const AppRestart = ({ app }: AppProps) => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const action = restartApp({ id: app.id });
+  const loader = useLoader(action);
+  const onClick = () => {
+    dispatch(action);
+  };
+  useLoaderSuccess(loader, () => {
+    navigate(operationDetailUrl(loader.meta.opId));
+  });
+
+  return (
+    <div>
+      <Label className="mt-4">Restart App</Label>
+      <ButtonOps
+        envId={app.environmentId}
+        variant="white"
+        className="flex"
+        onClick={onClick}
+        isLoading={loader.isLoading}
+      >
+        <IconRefresh className="mr-2" variant="sm" />
+        Restart
+      </ButtonOps>
+    </div>
+  );
+};
+
+const AppNameChange = ({ app }: AppProps) => {
+  const dispatch = useDispatch();
+  const [handle, setHandle] = useState<string>("");
   const logDrains = useSelector((s: AppState) =>
     selectLogDrainsByEnvId(s, { envId: app.environmentId }),
   );
@@ -57,32 +147,81 @@ export const AppSettingsPage = () => {
   const drains: (DeployLogDrain | DeployMetricDrain)[] =
     [...logDrains, ...metricDrains] || [];
 
+  const action = updateApp({ id: app.id, handle });
+  const loader = useLoader(action);
+  const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    dispatch(action);
+  };
+
   useEffect(() => {
     setHandle(app.handle);
   }, [app.id]);
 
-  const onSubmitForm = (e: SyntheticEvent) => {
-    e.preventDefault();
+  return (
+    <form onSubmit={onSubmitForm}>
+      <FormGroup label="App Name" htmlFor="input-name">
+        <Input
+          name="app-handle"
+          type="text"
+          value={handle}
+          onChange={(e) => setHandle(e.currentTarget.value)}
+          autoComplete="name"
+          id="input-name"
+        />
 
-    dispatch(updateApp({ id, handle }));
-  };
+        {handle !== app.handle && drains.length ? (
+          <Banner variant="info" showIcon={false} className="mt-4">
+            <p>
+              You must <b>restart the app</b> for the new name to appear in the
+              following log and metric drains, view the docs (
+              <ExternalLink
+                variant="default"
+                href="https://www.aptible.com/docs/log-drains"
+              >
+                log drains
+              </ExternalLink>
+              ,{" "}
+              <ExternalLink
+                variant="default"
+                href="https://www.aptible.com/docs/metric-drains"
+              >
+                metric drains
+              </ExternalLink>
+              ) to learn more:
+            </p>
+            <ul className="list-disc ml-4 mt-2">
+              {drains.map((drain) => (
+                <li key={drain.id}>{drain.handle}</li>
+              ))}
+            </ul>
+          </Banner>
+        ) : null}
+      </FormGroup>
 
-  const requestDeprovisionApp: MouseEventHandler<HTMLButtonElement> = () => {
-    dispatch(deprovisionApp({ appId: app.id }));
-    navigate(appActivityUrl(id));
-  };
+      <Group variant="horizontal" size="sm" className="mt-4">
+        <ButtonCreate
+          envId={app.environmentId}
+          className="w-40 semibold"
+          type="submit"
+          disabled={handle === app.handle}
+          isLoading={loader.isLoading}
+        >
+          Save Changes
+        </ButtonCreate>
 
-  const restartAction = restartApp({ id });
-  const restartLoader = useLoader(restartAction);
-  const submitRestart: MouseEventHandler<HTMLButtonElement> = () => {
-    dispatch(restartAction);
-  };
-  useLoaderSuccess(restartLoader, () => {
-    navigate(operationDetailUrl(restartLoader.meta.opId));
-  });
+        <Button variant="white" onClick={() => setHandle(app.handle)}>
+          Cancel
+        </Button>
+      </Group>
+    </form>
+  );
+};
 
-  const disabledDeprovisioning =
-    app.handle !== deleteConfirm || deprovisioningAppLoader.isLoading;
+export const AppSettingsPage = () => {
+  const { id = "" } = useParams();
+  useQuery(fetchApp({ id }));
+  const app = useSelector((s: AppState) => selectAppById(s, { id }));
 
   return (
     <BoxGroup>
@@ -119,120 +258,16 @@ export const AppSettingsPage = () => {
           />
         </div>
       </Box>
+
       <Box>
         <h1 className="text-lg text-gray-500">App Settings</h1>
-        <br />
-        <form onSubmit={onSubmitForm}>
-          <FormGroup label="App Name" htmlFor="input-name">
-            <Input
-              name="app-handle"
-              type="text"
-              value={handle}
-              onChange={(e) => setHandle(e.currentTarget.value)}
-              autoComplete="name"
-              data-testid="input-name"
-              id="input-name"
-            />
-            {handle !== app.handle && drains.length ? (
-              <Banner variant="info" showIcon={false} className="mt-4">
-                <p>
-                  You must <b>restart the app</b> for the new name to appear in
-                  the following log and metric drains, view the docs (
-                  <ExternalLink
-                    variant="default"
-                    href="https://www.aptible.com/docs/log-drains"
-                  >
-                    log drains
-                  </ExternalLink>
-                  ,{" "}
-                  <ExternalLink
-                    variant="default"
-                    href="https://www.aptible.com/docs/metric-drains"
-                  >
-                    metric drains
-                  </ExternalLink>
-                  ) to learn more:
-                </p>
-                <ul className="list-disc ml-4 mt-2">
-                  {drains.map((drain) => (
-                    <li>{drain.handle}</li>
-                  ))}
-                </ul>
-              </Banner>
-            ) : null}
-          </FormGroup>
-
-          <Label className="mt-4">Restart App</Label>
-          <Button
-            variant="white"
-            disabled={restartLoader.isLoading}
-            className="h-15 w-30 mb-0 ml-0 mt-1 flex"
-            onClick={submitRestart}
-          >
-            <IconRefresh className="mr-2" variant="sm" />
-            {deprovisioningAppLoader.isLoading || restartLoader.isLoading
-              ? "Restarting..."
-              : "Restart"}
-          </Button>
-
-          <hr className="mt-6" />
-
-          <div className="flex mt-4">
-            <Button
-              className="w-40 flex semibold"
-              type="submit"
-              disabled={updatingAppLoader.isLoading || restartLoader.isLoading}
-            >
-              {updatingAppLoader.isLoading || restartLoader.isLoading
-                ? "Loading..."
-                : "Save Changes"}
-            </Button>
-          </div>
-        </form>
+        <AppNameChange app={app} />
+        <hr className="mt-6" />
+        <AppRestart app={app} />
       </Box>
-      <Box className="mb-8">
-        <h1 className="text-lg text-red-500 font-semibold">
-          <IconAlertTriangle
-            className="inline pr-3 mb-1"
-            style={{ width: 32 }}
-            color="#AD1A1A"
-          />
-          Deprovision App
-        </h1>
-        <div className="mt-2">
-          <p>
-            This will permanently deprovision <strong>{app.handle}</strong> app.
-            This action cannot be undone. If you want to proceed, type the{" "}
-            <strong>{app.handle}</strong> below to continue.
-          </p>
-          <div className="flex mt-4 wd-60">
-            <Input
-              className="flex"
-              disabled={deprovisioningAppLoader.isLoading}
-              name="delete-confirm"
-              type="text"
-              value={deleteConfirm}
-              onChange={(e) => setDeleteConfirm(e.currentTarget.value)}
-              data-testid="delete-confirm"
-              id="delete-confirm"
-            />
-            <Button
-              variant="secondary"
-              style={{
-                backgroundColor: "#AD1A1A",
-                color: "#FFF",
-              }}
-              disabled={disabledDeprovisioning}
-              className="h-15 w-60 mb-0 ml-4 flex"
-              onClick={requestDeprovisionApp}
-            >
-              <IconTrash color="#FFF" className="mr-2" />
-              {deprovisioningAppLoader.isLoading
-                ? "Deprovisioning..."
-                : "Deprovision App"}
-            </Button>
-          </div>
-        </div>
+
+      <Box>
+        <AppDeprovision app={app} />
       </Box>
     </BoxGroup>
   );

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -174,10 +174,10 @@ export const AppSettingsPage = () => {
           <Button
             variant="white"
             disabled={restartLoader.isLoading}
-            className="h-15 w-30 mb-0 ml-0 mt-4 flex"
+            className="h-15 w-30 mb-0 ml-0 mt-1 flex"
             onClick={submitRestart}
           >
-            <IconRefresh className="mr-2" />
+            <IconRefresh className="mr-2" variant="sm" />
             {isDeprovisioning ? "Restarting App..." : "Restart App"}
           </Button>
 

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -170,7 +170,7 @@ export const AppSettingsPage = () => {
             ) : null}
           </FormGroup>
 
-          <Label className="mt-4">Restart App</Label>
+          <Label className="mt-4">Restart</Label>
           <Button
             variant="white"
             disabled={restartLoader.isLoading}

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -178,7 +178,7 @@ export const AppSettingsPage = () => {
             onClick={submitRestart}
           >
             <IconRefresh className="mr-2" variant="sm" />
-            {isDeprovisioning ? "Restarting App..." : "Restart App"}
+            {isDeprovisioning ? "Restarting..." : "Restart"}
           </Button>
 
           <hr className="mt-6" />

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -36,11 +36,10 @@ import { useNavigate, useParams } from "react-router";
 export const AppSettingsPage = () => {
   const [handle, setHandle] = useState<string>("");
   const [deleteConfirm, setDeleteConfirm] = useState<string>("");
-  const [isDeprovisioning, setIsDeprovisioning] = useState<boolean>(false);
-  const [isUpdating, setIsUpdating] = useState<boolean>(false);
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const updatingAppLoader = useLoader(updateApp);
+  const deprovisioningAppLoader = useLoader(deprovisionApp);
 
   const { id = "" } = useParams();
   useQuery(fetchApp({ id }));
@@ -65,14 +64,10 @@ export const AppSettingsPage = () => {
   const onSubmitForm = (e: SyntheticEvent) => {
     e.preventDefault();
 
-    setIsUpdating(true);
     dispatch(updateApp({ id, handle }));
-    setIsUpdating(false);
   };
 
   const requestDeprovisionApp: MouseEventHandler<HTMLButtonElement> = () => {
-    setIsUpdating(true);
-    setIsDeprovisioning(true);
     dispatch(deprovisionApp({ appId: app.id }));
     navigate(appActivityUrl(id));
   };
@@ -87,7 +82,7 @@ export const AppSettingsPage = () => {
   });
 
   const disabledDeprovisioning =
-    isDeprovisioning || app.handle !== deleteConfirm;
+    app.handle !== deleteConfirm || deprovisioningAppLoader.isLoading;
 
   return (
     <BoxGroup>
@@ -175,7 +170,9 @@ export const AppSettingsPage = () => {
             onClick={submitRestart}
           >
             <IconRefresh className="mr-2" variant="sm" />
-            {isDeprovisioning ? "Restarting..." : "Restart"}
+            {deprovisioningAppLoader.isLoading || restartLoader.isLoading
+              ? "Restarting..."
+              : "Restart"}
           </Button>
 
           <hr className="mt-6" />
@@ -184,15 +181,9 @@ export const AppSettingsPage = () => {
             <Button
               className="w-40 flex semibold"
               type="submit"
-              disabled={
-                isUpdating ||
-                updatingAppLoader.isLoading ||
-                restartLoader.isLoading
-              }
+              disabled={updatingAppLoader.isLoading || restartLoader.isLoading}
             >
-              {isUpdating ||
-              updatingAppLoader.isLoading ||
-              restartLoader.isLoading
+              {updatingAppLoader.isLoading || restartLoader.isLoading
                 ? "Loading..."
                 : "Save Changes"}
             </Button>
@@ -217,7 +208,7 @@ export const AppSettingsPage = () => {
           <div className="flex mt-4 wd-60">
             <Input
               className="flex"
-              disabled={isDeprovisioning}
+              disabled={deprovisioningAppLoader.isLoading}
               name="delete-confirm"
               type="text"
               value={deleteConfirm}
@@ -236,7 +227,9 @@ export const AppSettingsPage = () => {
               onClick={requestDeprovisionApp}
             >
               <IconTrash color="#FFF" className="mr-2" />
-              {isDeprovisioning ? "Deprovisioning..." : "Deprovision App"}
+              {deprovisioningAppLoader.isLoading
+                ? "Deprovisioning..."
+                : "Deprovision App"}
             </Button>
           </div>
         </div>

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -170,7 +170,7 @@ export const AppSettingsPage = () => {
             ) : null}
           </FormGroup>
 
-          <Label className="mt-4">Restart</Label>
+          <Label className="mt-4">Restart App</Label>
           <Button
             variant="white"
             disabled={restartLoader.isLoading}

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -29,7 +29,7 @@ import {
 import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { appActivityUrl, operationDetailUrl } from "@app/routes";
 import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
-import { SyntheticEvent, useEffect, useState } from "react";
+import { MouseEventHandler, SyntheticEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
 
@@ -70,9 +70,7 @@ export const AppSettingsPage = () => {
     setIsUpdating(false);
   };
 
-  const requestDeprovisionApp = (e: SyntheticEvent) => {
-    e.preventDefault();
-
+  const requestDeprovisionApp: MouseEventHandler<HTMLButtonElement> = () => {
     setIsUpdating(true);
     setIsDeprovisioning(true);
     dispatch(deprovisionApp({ appId: app.id }));
@@ -81,8 +79,7 @@ export const AppSettingsPage = () => {
 
   const restartAction = restartApp({ id });
   const restartLoader = useLoader(restartAction);
-  const submitRestart = (e: SyntheticEvent) => {
-    e.preventDefault();
+  const submitRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartAction);
   };
   useLoaderSuccess(restartLoader, () => {

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -144,7 +144,7 @@ export const DatabaseSettingsPage = () => {
             </Banner>
           ) : null}
 
-          <Label className="mt-4">Restart</Label>
+          <Label className="mt-4">Restart Database</Label>
           <Button
             variant="white"
             disabled={restartLoader.isLoading}

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -148,10 +148,10 @@ export const DatabaseSettingsPage = () => {
           <Button
             variant="white"
             disabled={restartLoader.isLoading}
-            className="h-15 w-30 mb-0 ml-0 mt-4 flex"
+            className="h-15 w-30 mb-0 ml-0 mt-1 flex"
             onClick={submitRestart}
           >
-            <IconRefresh className="mr-2" />
+            <IconRefresh className="mr-2" variant="sm" />
             {isDeprovisioning ? "Restarting Database..." : "Restart Database"}
           </Button>
 

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -7,6 +7,7 @@ import {
   FormGroup,
   IconAlertTriangle,
   IconExternalLink,
+  IconRefresh,
   IconTrash,
   Input,
   Label,
@@ -15,13 +16,14 @@ import {
   deprovisionDatabase,
   fetchEnvLogDrains,
   fetchEnvMetricDrains,
+  restartDatabase,
   selectDatabaseById,
   selectLogDrainsByEnvId,
   selectMetricDrainsByEnvId,
   updateDatabase,
 } from "@app/deploy";
-import { useLoader, useQuery } from "@app/fx";
-import { databaseActivityUrl } from "@app/routes";
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
+import { databaseActivityUrl, operationDetailUrl } from "@app/routes";
 import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
 import { SyntheticEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -71,6 +73,16 @@ export const DatabaseSettingsPage = () => {
     dispatch(deprovisionDatabase({ dbId: database.id }));
     navigate(databaseActivityUrl(id));
   };
+
+  const restartAction = restartDatabase({ id });
+  const restartLoader = useLoader(restartAction);
+  const submitRestart = (e: SyntheticEvent) => {
+    e.preventDefault();
+    dispatch(restartAction);
+  };
+  useLoaderSuccess(restartLoader, () => {
+    navigate(operationDetailUrl(restartLoader.meta.opId));
+  });
 
   const disabledDeprovisioning =
     isDeprovisioning || database.handle !== deleteConfirm;
@@ -131,6 +143,17 @@ export const DatabaseSettingsPage = () => {
               </ul>
             </Banner>
           ) : null}
+
+          <Label className="mt-4">Restart Database</Label>
+          <Button
+            variant="white"
+            disabled={restartLoader.isLoading}
+            className="h-15 w-30 mb-0 ml-0 mt-4 flex"
+            onClick={submitRestart}
+          >
+            <IconRefresh className="mr-2" />
+            {isDeprovisioning ? "Restarting Database..." : "Restart Database"}
+          </Button>
 
           <hr className="mt-6" />
 

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -144,7 +144,7 @@ export const DatabaseSettingsPage = () => {
             </Banner>
           ) : null}
 
-          <Label className="mt-4">Restart Database</Label>
+          <Label className="mt-4">Restart</Label>
           <Button
             variant="white"
             disabled={restartLoader.isLoading}

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from "react-router";
 
 import {
   deprovisionDatabase,
+  fetchDatabase,
   fetchEnvLogDrains,
   fetchEnvMetricDrains,
   restartDatabase,
@@ -24,10 +25,15 @@ import {
 import {
   Banner,
   Box,
+  BoxGroup,
   Button,
+  ButtonCreate,
+  ButtonDestroy,
   ButtonLinkExternal,
+  ButtonOps,
   ExternalLink,
   FormGroup,
+  Group,
   IconAlertTriangle,
   IconExternalLink,
   IconRefresh,
@@ -36,60 +42,54 @@ import {
   Label,
 } from "../shared";
 
-const DeprovisionDatabase = ({ database }: DbProps) => {
+const DatabaseDeprovision = ({ database }: DbProps) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const [deleteConfirm, setDeleteConfirm] = useState<string>("");
   const action = deprovisionDatabase({ dbId: database.id });
   const loader = useLoader(action);
-  const onClick = () => {
+  const onSubmit = () => {
     dispatch(action);
     navigate(databaseActivityUrl(database.id));
   };
-  const disabledDeprovisioning = database.handle !== deleteConfirm;
+  const isDisabled = database.handle !== deleteConfirm;
 
   return (
-    <>
-      <h1 className="text-lg text-red-500 font-semibold">
-        <IconAlertTriangle
-          className="inline pr-3 mb-1"
-          style={{ width: 32 }}
-          color="#AD1A1A"
-        />
+    <form onSubmit={onSubmit}>
+      <h1 className="text-lg text-red-500 font-semibold flex items-center gap-2">
+        <IconAlertTriangle variant="sm" color="#AD1A1A" />
         Deprovision Database
       </h1>
-      <div className="mt-2">
+
+      <Group>
         <p>
           This will permanently deprovision <strong>{database.handle}</strong>{" "}
           database. This action cannot be undone. If you want to proceed, type
           the <strong>{database.handle}</strong> below to continue.
         </p>
-        <div className="flex mt-4 wd-60">
+
+        <Group variant="horizontal" size="sm" className="items-center">
           <Input
-            className="flex"
+            className="flex-1"
             name="delete-confirm"
             type="text"
             value={deleteConfirm}
             onChange={(e) => setDeleteConfirm(e.currentTarget.value)}
             id="delete-confirm"
           />
-          <Button
-            variant="secondary"
-            style={{
-              backgroundColor: "#AD1A1A",
-              color: "#FFF",
-            }}
-            disabled={disabledDeprovisioning}
+          <ButtonDestroy
+            envId={database.environmentId}
+            variant="delete"
+            disabled={isDisabled}
             isLoading={loader.isLoading}
-            className="h-15 w-70 mb-0 ml-4 flex"
-            onClick={onClick}
+            className="w-70"
           >
             <IconTrash color="#FFF" className="mr-2" />
             Deprovision Database
-          </Button>
-        </div>
-      </div>
-    </>
+          </ButtonDestroy>
+        </Group>
+      </Group>
+    </form>
   );
 };
 
@@ -97,7 +97,7 @@ interface DbProps {
   database: DeployDatabase;
 }
 
-const ChangeName = ({ database }: DbProps) => {
+const DatabaseNameChange = ({ database }: DbProps) => {
   const dispatch = useDispatch();
   const [handle, setHandle] = useState<string>("");
   useEffect(() => {
@@ -124,62 +124,65 @@ const ChangeName = ({ database }: DbProps) => {
 
   return (
     <form onSubmit={onSubmit}>
-      <FormGroup label={""} htmlFor="input-name">
-        <Label className="text-base font-semibold text-gray-900 block">
-          Database Name
-        </Label>
+      <FormGroup label="Database Name" htmlFor="input-name">
         <Input
           name="app-handle"
           type="text"
           value={handle}
           onChange={(e) => setHandle(e.currentTarget.value)}
           autoComplete="name"
-          data-testid="input-name"
           id="input-name"
         />
-      </FormGroup>
-      {handle !== database.handle && drains.length ? (
-        <Banner variant="info" showIcon={false} className="mt-4">
-          <p>
-            You must <b>reload the database</b> for the new name to appear in
-            the following log and metric drains, view the docs (
-            <ExternalLink
-              variant="default"
-              href="https://www.aptible.com/docs/log-drains"
-            >
-              log drains
-            </ExternalLink>
-            ,{" "}
-            <ExternalLink
-              variant="default"
-              href="https://www.aptible.com/docs/metric-drains"
-            >
-              metric drains
-            </ExternalLink>
-            ) to learn more:
-          </p>
-          <ul className="list-disc ml-4 mt-2">
-            {drains.map((drain) => (
-              <li>{drain.handle}</li>
-            ))}
-          </ul>
-        </Banner>
-      ) : null}
 
-      <div className="flex mt-4">
-        <Button
-          className="w-40 flex semibold"
+        {handle !== database.handle && drains.length ? (
+          <Banner variant="info" showIcon={false} className="mt-4">
+            <p>
+              You must <b>reload the database</b> for the new name to appear in
+              the following log and metric drains, view the docs (
+              <ExternalLink
+                variant="default"
+                href="https://www.aptible.com/docs/log-drains"
+              >
+                log drains
+              </ExternalLink>
+              ,{" "}
+              <ExternalLink
+                variant="default"
+                href="https://www.aptible.com/docs/metric-drains"
+              >
+                metric drains
+              </ExternalLink>
+              ) to learn more:
+            </p>
+            <ul className="list-disc ml-4 mt-2">
+              {drains.map((drain) => (
+                <li>{drain.handle}</li>
+              ))}
+            </ul>
+          </Banner>
+        ) : null}
+      </FormGroup>
+
+      <Group variant="horizontal" size="sm" className="mt-4">
+        <ButtonCreate
+          envId={database.environmentId}
+          className="w-40 semibold"
           type="submit"
           isLoading={loader.isLoading}
+          disabled={handle === database.handle}
         >
           Save Changes
+        </ButtonCreate>
+
+        <Button variant="white" onClick={() => setHandle(database.handle)}>
+          Cancel
         </Button>
-      </div>
+      </Group>
     </form>
   );
 };
 
-const RestartDatabase = ({ database }: DbProps) => {
+const DatabaseRestart = ({ database }: DbProps) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const action = restartDatabase({ id: database.id });
@@ -193,25 +196,27 @@ const RestartDatabase = ({ database }: DbProps) => {
   return (
     <>
       <Label className="mt-4">Restart Database</Label>
-      <Button
+      <ButtonOps
+        envId={database.environmentId}
         variant="white"
         isLoading={loader.isLoading}
-        className="h-15 w-30 mb-0 ml-0 mt-1 flex"
+        className="flex"
         onClick={onClick}
       >
         <IconRefresh className="mr-2" variant="sm" />
         Restart
-      </Button>
+      </ButtonOps>
     </>
   );
 };
 
 export const DatabaseSettingsPage = () => {
   const { id = "" } = useParams();
+  useQuery(fetchDatabase({ id }));
   const database = useSelector((s: AppState) => selectDatabaseById(s, { id }));
 
   return (
-    <div className="mb-4">
+    <BoxGroup>
       <Box>
         <ButtonLinkExternal
           href="https://www.aptible.com/docs/managing-databases"
@@ -222,17 +227,16 @@ export const DatabaseSettingsPage = () => {
           View Docs
           <IconExternalLink className="inline ml-1 h-5 mt-0" />
         </ButtonLinkExternal>
+
         <h1 className="text-lg text-gray-500">Database Settings</h1>
-        <br />
-
-        <ChangeName database={database} />
+        <DatabaseNameChange database={database} />
         <hr className="mt-6" />
-        <RestartDatabase database={database} />
+        <DatabaseRestart database={database} />
       </Box>
 
-      <Box className="mt-4 mb-8">
-        <DeprovisionDatabase database={database} />
+      <Box>
+        <DatabaseDeprovision database={database} />
       </Box>
-    </div>
+    </BoxGroup>
   );
 };

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -152,7 +152,7 @@ export const DatabaseSettingsPage = () => {
             onClick={submitRestart}
           >
             <IconRefresh className="mr-2" variant="sm" />
-            {isDeprovisioning ? "Restarting Database..." : "Restart Database"}
+            {isDeprovisioning ? "Restarting..." : "Restart"}
           </Button>
 
           <hr className="mt-6" />

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -25,7 +25,7 @@ import {
 import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { databaseActivityUrl, operationDetailUrl } from "@app/routes";
 import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
-import { SyntheticEvent, useEffect, useState } from "react";
+import { MouseEventHandler, SyntheticEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
 
@@ -65,19 +65,17 @@ export const DatabaseSettingsPage = () => {
     setIsUpdating(false);
   };
 
-  const requestDeprovisionDatabase = (e: SyntheticEvent) => {
-    e.preventDefault();
-
-    setIsUpdating(true);
-    setIsDeprovisioning(true);
-    dispatch(deprovisionDatabase({ dbId: database.id }));
-    navigate(databaseActivityUrl(id));
-  };
+  const requestDeprovisionDatabase: MouseEventHandler<HTMLButtonElement> =
+    () => {
+      setIsUpdating(true);
+      setIsDeprovisioning(true);
+      dispatch(deprovisionDatabase({ dbId: database.id }));
+      navigate(databaseActivityUrl(id));
+    };
 
   const restartAction = restartDatabase({ id });
   const restartLoader = useLoader(restartAction);
-  const submitRestart = (e: SyntheticEvent) => {
-    e.preventDefault();
+  const submitRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartAction);
   };
   useLoaderSuccess(restartLoader, () => {

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -1,3 +1,26 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate, useParams } from "react-router";
+
+import {
+  deprovisionDatabase,
+  fetchEnvLogDrains,
+  fetchEnvMetricDrains,
+  restartDatabase,
+  selectDatabaseById,
+  selectLogDrainsByEnvId,
+  selectMetricDrainsByEnvId,
+  updateDatabase,
+} from "@app/deploy";
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
+import { databaseActivityUrl, operationDetailUrl } from "@app/routes";
+import {
+  AppState,
+  DeployDatabase,
+  DeployLogDrain,
+  DeployMetricDrain,
+} from "@app/types";
+
 import {
   Banner,
   Box,
@@ -12,40 +35,86 @@ import {
   Input,
   Label,
 } from "../shared";
-import {
-  deprovisionDatabase,
-  fetchEnvLogDrains,
-  fetchEnvMetricDrains,
-  restartDatabase,
-  selectDatabaseById,
-  selectLogDrainsByEnvId,
-  selectMetricDrainsByEnvId,
-  updateDatabase,
-} from "@app/deploy";
-import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
-import { databaseActivityUrl, operationDetailUrl } from "@app/routes";
-import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
-import { MouseEventHandler, SyntheticEvent, useEffect, useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import { useNavigate, useParams } from "react-router";
 
-export const DatabaseSettingsPage = () => {
-  const { id = "" } = useParams();
-  const [deleteConfirm, setDeleteConfirm] = useState<string>("");
-  const [handle, setHandle] = useState<string>("");
-  const [isDeprovisioning, setIsDeprovisioning] = useState<boolean>(false);
-  const [isUpdating, setIsUpdating] = useState<boolean>(false);
+const DeprovisionDatabase = ({ database }: DbProps) => {
   const navigate = useNavigate();
-
   const dispatch = useDispatch();
-  const database = useSelector((s: AppState) => selectDatabaseById(s, { id }));
+  const [deleteConfirm, setDeleteConfirm] = useState<string>("");
+  const action = deprovisionDatabase({ dbId: database.id });
+  const loader = useLoader(action);
+  const onClick = () => {
+    dispatch(action);
+    navigate(databaseActivityUrl(database.id));
+  };
+  const disabledDeprovisioning = database.handle !== deleteConfirm;
+
+  return (
+    <>
+      <h1 className="text-lg text-red-500 font-semibold">
+        <IconAlertTriangle
+          className="inline pr-3 mb-1"
+          style={{ width: 32 }}
+          color="#AD1A1A"
+        />
+        Deprovision Database
+      </h1>
+      <div className="mt-2">
+        <p>
+          This will permanently deprovision <strong>{database.handle}</strong>{" "}
+          database. This action cannot be undone. If you want to proceed, type
+          the <strong>{database.handle}</strong> below to continue.
+        </p>
+        <div className="flex mt-4 wd-60">
+          <Input
+            className="flex"
+            name="delete-confirm"
+            type="text"
+            value={deleteConfirm}
+            onChange={(e) => setDeleteConfirm(e.currentTarget.value)}
+            id="delete-confirm"
+          />
+          <Button
+            variant="secondary"
+            style={{
+              backgroundColor: "#AD1A1A",
+              color: "#FFF",
+            }}
+            disabled={disabledDeprovisioning}
+            isLoading={loader.isLoading}
+            className="h-15 w-70 mb-0 ml-4 flex"
+            onClick={onClick}
+          >
+            <IconTrash color="#FFF" className="mr-2" />
+            Deprovision Database
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+interface DbProps {
+  database: DeployDatabase;
+}
+
+const ChangeName = ({ database }: DbProps) => {
+  const dispatch = useDispatch();
+  const [handle, setHandle] = useState<string>("");
+  useEffect(() => {
+    setHandle(database.handle);
+  }, [database.id]);
+  const action = updateDatabase({ id: database.id, handle });
+  const loader = useLoader(action);
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    dispatch(action);
+  };
   const logDrains = useSelector((s: AppState) =>
     selectLogDrainsByEnvId(s, { envId: database.environmentId }),
   );
   const metricDrains = useSelector((s: AppState) =>
     selectMetricDrainsByEnvId(s, { envId: database.environmentId }),
   );
-  const updatingDatabaseLoader = useLoader(updateDatabase);
 
   useQuery(fetchEnvLogDrains({ id: database.environmentId }));
   useQuery(fetchEnvMetricDrains({ id: database.environmentId }));
@@ -53,37 +122,93 @@ export const DatabaseSettingsPage = () => {
   const drains: (DeployLogDrain | DeployMetricDrain)[] =
     [...logDrains, ...metricDrains] || [];
 
-  useEffect(() => {
-    setHandle(database.handle);
-  }, [database.id]);
+  return (
+    <form onSubmit={onSubmit}>
+      <FormGroup label={""} htmlFor="input-name">
+        <Label className="text-base font-semibold text-gray-900 block">
+          Database Name
+        </Label>
+        <Input
+          name="app-handle"
+          type="text"
+          value={handle}
+          onChange={(e) => setHandle(e.currentTarget.value)}
+          autoComplete="name"
+          data-testid="input-name"
+          id="input-name"
+        />
+      </FormGroup>
+      {handle !== database.handle && drains.length ? (
+        <Banner variant="info" showIcon={false} className="mt-4">
+          <p>
+            You must <b>reload the database</b> for the new name to appear in
+            the following log and metric drains, view the docs (
+            <ExternalLink
+              variant="default"
+              href="https://www.aptible.com/docs/log-drains"
+            >
+              log drains
+            </ExternalLink>
+            ,{" "}
+            <ExternalLink
+              variant="default"
+              href="https://www.aptible.com/docs/metric-drains"
+            >
+              metric drains
+            </ExternalLink>
+            ) to learn more:
+          </p>
+          <ul className="list-disc ml-4 mt-2">
+            {drains.map((drain) => (
+              <li>{drain.handle}</li>
+            ))}
+          </ul>
+        </Banner>
+      ) : null}
 
-  const onSubmitForm = (e: SyntheticEvent) => {
-    e.preventDefault();
+      <div className="flex mt-4">
+        <Button
+          className="w-40 flex semibold"
+          type="submit"
+          isLoading={loader.isLoading}
+        >
+          Save Changes
+        </Button>
+      </div>
+    </form>
+  );
+};
 
-    setIsUpdating(true);
-    dispatch(updateDatabase({ id, handle }));
-    setIsUpdating(false);
+const RestartDatabase = ({ database }: DbProps) => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const action = restartDatabase({ id: database.id });
+  const loader = useLoader(action);
+  const onClick = () => {
+    dispatch(action);
   };
-
-  const requestDeprovisionDatabase: MouseEventHandler<HTMLButtonElement> =
-    () => {
-      setIsUpdating(true);
-      setIsDeprovisioning(true);
-      dispatch(deprovisionDatabase({ dbId: database.id }));
-      navigate(databaseActivityUrl(id));
-    };
-
-  const restartAction = restartDatabase({ id });
-  const restartLoader = useLoader(restartAction);
-  const submitRestart: MouseEventHandler<HTMLButtonElement> = () => {
-    dispatch(restartAction);
-  };
-  useLoaderSuccess(restartLoader, () => {
-    navigate(operationDetailUrl(restartLoader.meta.opId));
+  useLoaderSuccess(loader, () => {
+    navigate(operationDetailUrl(loader.meta.opId));
   });
+  return (
+    <>
+      <Label className="mt-4">Restart Database</Label>
+      <Button
+        variant="white"
+        isLoading={loader.isLoading}
+        className="h-15 w-30 mb-0 ml-0 mt-1 flex"
+        onClick={onClick}
+      >
+        <IconRefresh className="mr-2" variant="sm" />
+        Restart
+      </Button>
+    </>
+  );
+};
 
-  const disabledDeprovisioning =
-    isDeprovisioning || database.handle !== deleteConfirm;
+export const DatabaseSettingsPage = () => {
+  const { id = "" } = useParams();
+  const database = useSelector((s: AppState) => selectDatabaseById(s, { id }));
 
   return (
     <div className="mb-4">
@@ -99,117 +224,14 @@ export const DatabaseSettingsPage = () => {
         </ButtonLinkExternal>
         <h1 className="text-lg text-gray-500">Database Settings</h1>
         <br />
-        <form onSubmit={onSubmitForm}>
-          <FormGroup label={""} htmlFor="input-name">
-            <Label className="text-base font-semibold text-gray-900 block">
-              Database Name
-            </Label>
-            <Input
-              name="app-handle"
-              type="text"
-              value={handle}
-              onChange={(e) => setHandle(e.currentTarget.value)}
-              autoComplete="name"
-              data-testid="input-name"
-              id="input-name"
-            />
-          </FormGroup>
-          {handle !== database.handle && drains.length ? (
-            <Banner variant="info" showIcon={false} className="mt-4">
-              <p>
-                You must <b>reload the database</b> for the new name to appear
-                in the following log and metric drains, view the docs (
-                <ExternalLink
-                  variant="default"
-                  href="https://www.aptible.com/docs/log-drains"
-                >
-                  log drains
-                </ExternalLink>
-                ,{" "}
-                <ExternalLink
-                  variant="default"
-                  href="https://www.aptible.com/docs/metric-drains"
-                >
-                  metric drains
-                </ExternalLink>
-                ) to learn more:
-              </p>
-              <ul className="list-disc ml-4 mt-2">
-                {drains.map((drain) => (
-                  <li>{drain.handle}</li>
-                ))}
-              </ul>
-            </Banner>
-          ) : null}
 
-          <Label className="mt-4">Restart Database</Label>
-          <Button
-            variant="white"
-            disabled={restartLoader.isLoading}
-            className="h-15 w-30 mb-0 ml-0 mt-1 flex"
-            onClick={submitRestart}
-          >
-            <IconRefresh className="mr-2" variant="sm" />
-            {isDeprovisioning ? "Restarting..." : "Restart"}
-          </Button>
-
-          <hr className="mt-6" />
-
-          <div className="flex mt-4">
-            <Button
-              className="w-40 flex semibold"
-              type="submit"
-              disabled={isUpdating || updatingDatabaseLoader.isLoading}
-            >
-              {isUpdating || updatingDatabaseLoader.isLoading
-                ? "Loading..."
-                : "Save Changes"}
-            </Button>
-          </div>
-        </form>
+        <ChangeName database={database} />
+        <hr className="mt-6" />
+        <RestartDatabase database={database} />
       </Box>
 
       <Box className="mt-4 mb-8">
-        <h1 className="text-lg text-red-500 font-semibold">
-          <IconAlertTriangle
-            className="inline pr-3 mb-1"
-            style={{ width: 32 }}
-            color="#AD1A1A"
-          />
-          Deprovision Database
-        </h1>
-        <div className="mt-2">
-          <p>
-            This will permanently deprovision <strong>{database.handle}</strong>{" "}
-            database. This action cannot be undone. If you want to proceed, type
-            the <strong>{database.handle}</strong> below to continue.
-          </p>
-          <div className="flex mt-4 wd-60">
-            <Input
-              className="flex"
-              disabled={isDeprovisioning}
-              name="delete-confirm"
-              type="text"
-              value={deleteConfirm}
-              onChange={(e) => setDeleteConfirm(e.currentTarget.value)}
-              data-testid="delete-confirm"
-              id="delete-confirm"
-            />
-            <Button
-              variant="secondary"
-              style={{
-                backgroundColor: "#AD1A1A",
-                color: "#FFF",
-              }}
-              disabled={disabledDeprovisioning}
-              className="h-15 w-70 mb-0 ml-4 flex"
-              onClick={requestDeprovisionDatabase}
-            >
-              <IconTrash color="#FFF" className="mr-2" />
-              {isDeprovisioning ? "Deprovisioning..." : "Deprovision Database"}
-            </Button>
-          </div>
-        </div>
+        <DeprovisionDatabase database={database} />
       </Box>
     </div>
   );

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -1,19 +1,7 @@
 import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
+import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
 
-import {
-  Button,
-  ButtonCreate,
-  IconPlusCircle,
-  LoadResources,
-  Pill,
-  ResourceListView,
-  TableHead,
-  Td,
-  pillStyles,
-  tokens,
-} from "../shared";
-import { EmptyResourcesTable } from "../shared/empty-resources-table";
 import { prettyDateRelative } from "@app/date";
 import {
   deprovisionLogDrain,
@@ -32,8 +20,22 @@ import {
 } from "@app/routes";
 import { capitalize } from "@app/string-utils";
 import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
-import { MouseEventHandler } from "react";
-import { useDispatch, useSelector } from "react-redux";
+
+import {
+  ButtonCreate,
+  ButtonDestroy,
+  ButtonOps,
+  EmptyResourcesTable,
+  Group,
+  IconPlusCircle,
+  LoadResources,
+  Pill,
+  ResourceListView,
+  TableHead,
+  Td,
+  pillStyles,
+  tokens,
+} from "../shared";
 
 const DrainStatusPill = ({
   drain,
@@ -86,6 +88,7 @@ const LogDrainHandleCell = ({ logDrain }: { logDrain: DeployLogDrain }) => {
     </Td>
   );
 };
+
 const LogDrainSourcesCell = ({ logDrain }: { logDrain: DeployLogDrain }) => {
   const drainSources = [];
   if (logDrain.drainApps) {
@@ -133,17 +136,19 @@ const LogDrainLastUpdatedCell = ({
 const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+
   const restartAction = restartLogDrain({ id: logDrain.id });
   const restartLoader = useLoader(restartAction);
-  const submitRestart: MouseEventHandler<HTMLButtonElement> = () => {
+  const submitRestart = () => {
     dispatch(restartAction);
   };
   useLoaderSuccess(restartLoader, () => {
     navigate(operationDetailUrl(restartLoader.meta.opId));
   });
+
   const deprovisionAction = deprovisionLogDrain({ id: logDrain.id });
   const deprovisionLoader = useLoader(deprovisionAction);
-  const submitDeprovision: MouseEventHandler<HTMLButtonElement> = () => {
+  const submitDeprovision = () => {
     dispatch(deprovisionAction);
   };
   useLoaderSuccess(deprovisionLoader, () => {
@@ -152,31 +157,30 @@ const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
 
   return (
     <Td className="flex-1">
-      <div className="flex">
-        <Button
-          className="flex semibold"
+      <Group variant="horizontal" size="sm">
+        <ButtonOps
+          size="sm"
+          envId={logDrain.environmentId}
+          className="semibold"
           onClick={submitRestart}
-          disabled={
-            restartLoader.isLoading ||
-            logDrain.backendChannel === "log_forwarder"
-          }
+          isLoading={restartLoader.isLoading}
+          disabled={logDrain.backendChannel === "log_forwarder"}
         >
-          {restartLoader.isLoading ? "Restarting..." : "Restart"}
-        </Button>
-        <Button
-          className="flex semibold ml-4"
+          Restart
+        </ButtonOps>
+
+        <ButtonDestroy
+          size="sm"
+          envId={logDrain.environmentId}
+          className="semibold"
           onClick={submitDeprovision}
-          disabled={deprovisionLoader.isLoading}
-          variant="secondary"
-          style={{
-            backgroundColor: "#AD1A1A",
-            color: "#FFF",
-          }}
+          isLoading={deprovisionLoader.isLoading}
+          variant="delete"
           requireConfirm
         >
-          {deprovisionLoader.isLoading ? "Deleting..." : "Delete"}
-        </Button>
-      </div>
+          Delete
+        </ButtonDestroy>
+      </Group>
     </Td>
   );
 };
@@ -289,17 +293,19 @@ const MetricDrainActions = ({
 }: { metricDrain: DeployMetricDrain }) => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+
   const restartAction = restartMetricDrain({ id: metricDrain.id });
   const restartLoader = useLoader(restartAction);
-  const submitRestart: MouseEventHandler<HTMLButtonElement> = () => {
+  const submitRestart = () => {
     dispatch(restartAction);
   };
   useLoaderSuccess(restartLoader, () => {
     navigate(operationDetailUrl(restartLoader.meta.opId));
   });
+
   const deprovisionAction = deprovisionMetricDrain({ id: metricDrain.id });
   const deprovisionLoader = useLoader(deprovisionAction);
-  const submitDeprovision: MouseEventHandler<HTMLButtonElement> = () => {
+  const submitDeprovision = () => {
     dispatch(deprovisionAction);
   };
   useLoaderSuccess(deprovisionLoader, () => {
@@ -308,28 +314,29 @@ const MetricDrainActions = ({
 
   return (
     <Td className="flex-1">
-      <div className="flex">
-        <Button
-          className="flex semibold"
+      <Group variant="horizontal" size="sm">
+        <ButtonOps
+          size="sm"
+          envId={metricDrain.environmentId}
+          className="semibold"
           onClick={submitRestart}
-          disabled={restartLoader.isLoading}
+          isLoading={restartLoader.isLoading}
         >
-          {restartLoader.isLoading ? "Restarting..." : "Restart"}
-        </Button>
-        <Button
-          className="flex semibold ml-4"
+          Restart
+        </ButtonOps>
+
+        <ButtonDestroy
+          size="sm"
+          envId={metricDrain.environmentId}
+          className="semibold"
           onClick={submitDeprovision}
-          disabled={deprovisionLoader.isLoading}
-          variant="secondary"
-          style={{
-            backgroundColor: "#AD1A1A",
-            color: "#FFF",
-          }}
+          isLoading={deprovisionLoader.isLoading}
+          variant="delete"
           requireConfirm
         >
-          {deprovisionLoader.isLoading ? "Deleting..." : "Delete"}
-        </Button>
-      </div>
+          Delete
+        </ButtonDestroy>
+      </Group>
     </Td>
   );
 };
@@ -398,14 +405,15 @@ export const EnvironmentIntegrationsPage = () => {
 
   return (
     <div>
-      <div className="flex gap-2 mb-4">
+      <Group variant="horizontal" size="sm" className="mb-4">
         <ButtonCreate envId={id} onClick={onCreateLogs}>
           <IconPlusCircle variant="sm" className="mr-1" /> New Log Drain
         </ButtonCreate>
         <ButtonCreate envId={id} onClick={onCreateMetrics}>
           <IconPlusCircle variant="sm" className="mr-1" /> New Metric Drain
         </ButtonCreate>
-      </div>
+      </Group>
+
       <LogDrainsSection id={id} />
       <MetricDrainsSection id={id} />
     </div>

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -1,7 +1,8 @@
-import { useQuery } from "@app/fx";
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { useNavigate, useParams } from "react-router";
 
 import {
+  Button,
   ButtonCreate,
   IconPlusCircle,
   LoadResources,
@@ -17,13 +18,20 @@ import { prettyDateRelative } from "@app/date";
 import {
   fetchEnvLogDrains,
   fetchEnvMetricDrains,
+  restartLogDrain,
+  restartMetricDrain,
   selectLogDrainsByEnvId,
   selectMetricDrainsByEnvId,
 } from "@app/deploy";
-import { createLogDrainUrl, createMetricDrainUrl } from "@app/routes";
+import {
+  createLogDrainUrl,
+  createMetricDrainUrl,
+  operationDetailUrl,
+} from "@app/routes";
 import { capitalize } from "@app/string-utils";
 import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
-import { useSelector } from "react-redux";
+import { SyntheticEvent } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
 const DrainStatusPill = ({
   drain,
@@ -120,7 +128,41 @@ const LogDrainLastUpdatedCell = ({
   );
 };
 
-const logDrainsHeaders = ["Status", "Handle", "Sources", "Last Updated"];
+const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const restartAction = restartLogDrain({ id: logDrain.id });
+  const restartLoader = useLoader(restartAction);
+  const submitRestart = (e: SyntheticEvent) => {
+    e.preventDefault();
+    dispatch(restartAction);
+  };
+  useLoaderSuccess(restartLoader, () => {
+    navigate(operationDetailUrl(restartLoader.meta.opId));
+  });
+
+  return (
+    <Td className="flex-1">
+      <div className="flex">
+        <Button
+          className="flex semibold"
+          onClick={submitRestart}
+          disabled={restartLoader.isLoading}
+        >
+          {restartLoader.isLoading ? "Restarting..." : "Restart"}
+        </Button>
+      </div>
+    </Td>
+  );
+};
+
+const logDrainsHeaders = [
+  "Status",
+  "Handle",
+  "Sources",
+  "Last Updated",
+  "Actions",
+];
 
 const LogDrainsSection = ({ id }: { id: string }) => {
   const query = useQuery(fetchEnvLogDrains({ id }));
@@ -159,6 +201,7 @@ const LogDrainsSection = ({ id }: { id: string }) => {
                 <LogDrainHandleCell logDrain={logDrain} />
                 <LogDrainSourcesCell logDrain={logDrain} />
                 <LogDrainLastUpdatedCell logDrain={logDrain} />
+                <LogDrainActions logDrain={logDrain} />
               </tr>
             ))}
           </>
@@ -216,7 +259,37 @@ const MetricDrainLastUpdatedCell = ({
   );
 };
 
-const metricDrainsHeaders = ["Status", "Handle", "Last Updated"];
+const MetricDrainActions = ({
+  metricDrain,
+}: { metricDrain: DeployMetricDrain }) => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const restartAction = restartMetricDrain({ id: metricDrain.id });
+  const restartLoader = useLoader(restartAction);
+  const submitRestart = (e: SyntheticEvent) => {
+    e.preventDefault();
+    dispatch(restartAction);
+  };
+  useLoaderSuccess(restartLoader, () => {
+    navigate(operationDetailUrl(restartLoader.meta.opId));
+  });
+
+  return (
+    <Td className="flex-1">
+      <div className="flex">
+        <Button
+          className="flex semibold"
+          onClick={submitRestart}
+          disabled={restartLoader.isLoading}
+        >
+          {restartLoader.isLoading ? "Restarting..." : "Restart"}
+        </Button>
+      </div>
+    </Td>
+  );
+};
+
+const metricDrainsHeaders = ["Status", "Handle", "Last Updated", "Actions"];
 
 const MetricDrainsSection = ({ id }: { id: string }) => {
   const query = useQuery(fetchEnvMetricDrains({ id }));
@@ -257,6 +330,7 @@ const MetricDrainsSection = ({ id }: { id: string }) => {
                   <MetricDrainPrimaryCell metricDrain={metricDrain} />
                   <MetricDrainHandleCell metricDrain={metricDrain} />
                   <MetricDrainLastUpdatedCell metricDrain={metricDrain} />
+                  <MetricDrainActions metricDrain={metricDrain} />
                 </tr>
               ))}
             </>

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -169,6 +169,7 @@ const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
             backgroundColor: "#AD1A1A",
             color: "#FFF",
           }}
+          requireConfirm
         >
           {deprovisionLoader.isLoading ? "Deleting..." : "Delete"}
         </Button>
@@ -321,6 +322,7 @@ const MetricDrainActions = ({
             backgroundColor: "#AD1A1A",
             color: "#FFF",
           }}
+          requireConfirm
         >
           {deprovisionLoader.isLoading ? "Deleting..." : "Delete"}
         </Button>

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -16,6 +16,8 @@ import {
 import { EmptyResourcesTable } from "../shared/empty-resources-table";
 import { prettyDateRelative } from "@app/date";
 import {
+  deprovisionLogDrain,
+  deprovisionMetricDrain,
   fetchEnvLogDrains,
   fetchEnvMetricDrains,
   restartLogDrain,
@@ -139,6 +141,14 @@ const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
   useLoaderSuccess(restartLoader, () => {
     navigate(operationDetailUrl(restartLoader.meta.opId));
   });
+  const deprovisionAction = deprovisionLogDrain({ id: logDrain.id });
+  const deprovisionLoader = useLoader(deprovisionAction);
+  const submitDeprovision: MouseEventHandler<HTMLButtonElement> = () => {
+    dispatch(deprovisionAction);
+  };
+  useLoaderSuccess(deprovisionLoader, () => {
+    navigate(operationDetailUrl(deprovisionLoader.meta.opId));
+  });
 
   return (
     <Td className="flex-1">
@@ -149,6 +159,18 @@ const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
           disabled={restartLoader.isLoading}
         >
           {restartLoader.isLoading ? "Restarting..." : "Restart"}
+        </Button>
+        <Button
+          className="flex semibold ml-4"
+          onClick={submitDeprovision}
+          disabled={deprovisionLoader.isLoading}
+          variant="secondary"
+          style={{
+            backgroundColor: "#AD1A1A",
+            color: "#FFF",
+          }}
+        >
+          {deprovisionLoader.isLoading ? "Deleting..." : "Delete"}
         </Button>
       </div>
     </Td>
@@ -271,6 +293,14 @@ const MetricDrainActions = ({
   useLoaderSuccess(restartLoader, () => {
     navigate(operationDetailUrl(restartLoader.meta.opId));
   });
+  const deprovisionAction = deprovisionMetricDrain({ id: metricDrain.id });
+  const deprovisionLoader = useLoader(deprovisionAction);
+  const submitDeprovision: MouseEventHandler<HTMLButtonElement> = () => {
+    dispatch(deprovisionAction);
+  };
+  useLoaderSuccess(deprovisionLoader, () => {
+    navigate(operationDetailUrl(deprovisionLoader.meta.opId));
+  });
 
   return (
     <Td className="flex-1">
@@ -281,6 +311,18 @@ const MetricDrainActions = ({
           disabled={restartLoader.isLoading}
         >
           {restartLoader.isLoading ? "Restarting..." : "Restart"}
+        </Button>
+        <Button
+          className="flex semibold ml-4"
+          onClick={submitDeprovision}
+          disabled={deprovisionLoader.isLoading}
+          variant="secondary"
+          style={{
+            backgroundColor: "#AD1A1A",
+            color: "#FFF",
+          }}
+        >
+          {deprovisionLoader.isLoading ? "Deleting..." : "Delete"}
         </Button>
       </div>
     </Td>

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -156,7 +156,10 @@ const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
         <Button
           className="flex semibold"
           onClick={submitRestart}
-          disabled={restartLoader.isLoading}
+          disabled={
+            restartLoader.isLoading ||
+            logDrain.backendChannel === "log_forwarder"
+          }
         >
           {restartLoader.isLoading ? "Restarting..." : "Restart"}
         </Button>

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -30,7 +30,7 @@ import {
 } from "@app/routes";
 import { capitalize } from "@app/string-utils";
 import { AppState, DeployLogDrain, DeployMetricDrain } from "@app/types";
-import { SyntheticEvent } from "react";
+import { MouseEventHandler } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 const DrainStatusPill = ({
@@ -133,8 +133,7 @@ const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
   const dispatch = useDispatch();
   const restartAction = restartLogDrain({ id: logDrain.id });
   const restartLoader = useLoader(restartAction);
-  const submitRestart = (e: SyntheticEvent) => {
-    e.preventDefault();
+  const submitRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartAction);
   };
   useLoaderSuccess(restartLoader, () => {
@@ -266,8 +265,7 @@ const MetricDrainActions = ({
   const dispatch = useDispatch();
   const restartAction = restartMetricDrain({ id: metricDrain.id });
   const restartLoader = useLoader(restartAction);
-  const submitRestart = (e: SyntheticEvent) => {
-    e.preventDefault();
+  const submitRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartAction);
   };
   useLoaderSuccess(restartLoader, () => {

--- a/src/ui/pages/styles.tsx
+++ b/src/ui/pages/styles.tsx
@@ -12,12 +12,14 @@ import {
 import {
   AptibleLogo,
   Banner,
+  Box,
   Breadcrumbs,
   Button,
   ButtonIcon,
   ButtonLink,
   CheckBox,
   FormGroup,
+  Group,
   IconAlertTriangle,
   IconArrowLeft,
   IconArrowRight,
@@ -701,6 +703,42 @@ const Dates = () => {
   );
 };
 
+const NegativeSpace = () => {
+  return (
+    <Group>
+      <div>
+        <h1 className={tokens.type.h1}>Grouping</h1>
+
+        <Box>A simple box</Box>
+      </div>
+
+      <div>
+        <h1 className={tokens.type.h1}>Grouping</h1>
+
+        <div>
+          <h2 className={tokens.type.h2}>Default</h2>
+
+          <Group>
+            <Box>One</Box>
+            <Box>Two</Box>
+            <Box>Three</Box>
+          </Group>
+        </div>
+
+        <div>
+          <h2 className={tokens.type.h2}>Horizontal</h2>
+
+          <Group variant="horizontal">
+            <Box>One</Box>
+            <Box>Two</Box>
+            <Box>Three</Box>
+          </Group>
+        </div>
+      </div>
+    </Group>
+  );
+};
+
 export const StylesPage = () => (
   <div className="px-4 py-4">
     <StylesWrapper navigation={<StylesNavigation />}>
@@ -718,6 +756,7 @@ export const StylesPage = () => (
       <DetailBoxes />
       <Secrets />
       <Dates />
+      <NegativeSpace />
     </StylesWrapper>
   </div>
 );

--- a/src/ui/shared/button.tsx
+++ b/src/ui/shared/button.tsx
@@ -197,3 +197,4 @@ const createButtonPermission = (
 
 export const ButtonCreate = createButtonPermission("deploy");
 export const ButtonDestroy = createButtonPermission("destroy");
+export const ButtonOps = createButtonPermission("observability");

--- a/src/ui/shared/button.tsx
+++ b/src/ui/shared/button.tsx
@@ -4,7 +4,7 @@ import { selectUserHasPerms } from "@app/deploy";
 import { capitalize } from "@app/string-utils";
 import { AppState, PermissionScope } from "@app/types";
 import cn from "classnames";
-import { ButtonHTMLAttributes, FC } from "react";
+import { ButtonHTMLAttributes, FC, useState } from "react";
 import { useSelector } from "react-redux";
 import { Link, LinkProps } from "react-router-dom";
 
@@ -16,6 +16,7 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size?: Size;
   shape?: Shape;
   isLoading?: boolean;
+  requireConfirm?: boolean;
   children?: React.ReactNode;
 }
 
@@ -105,8 +106,10 @@ export const Button: FC<ButtonProps> = ({
   isLoading = false,
   type = "button",
   className = "",
+  requireConfirm = false,
   ...props
 }) => {
+  const [confirmPrompted, setConfirmPrompted] = useState(false);
   const classes = cn(
     "flex items-center justify-center",
     buttonLayout[layout],
@@ -115,6 +118,26 @@ export const Button: FC<ButtonProps> = ({
     buttonShapeStyle(size, shape),
     { "opacity-50": props.disabled },
   );
+  if (confirmPrompted) {
+    return (
+      <button
+        {...props}
+        type={type}
+        className={`${className} ${classes}`}
+        disabled={isLoading || props.disabled}
+      >
+        Confirm
+      </button>
+    );
+  }
+
+  if (requireConfirm) {
+    props = {
+      ...props,
+      onClick: () => setConfirmPrompted(true),
+    };
+  }
+
   return (
     <button
       {...props}

--- a/src/ui/shared/group.tsx
+++ b/src/ui/shared/group.tsx
@@ -1,0 +1,15 @@
+export const Group = ({
+  children,
+  className = "",
+  variant = "vertical",
+  size = "lg",
+}: {
+  children: React.ReactNode;
+  className?: string;
+  variant?: "horizontal" | "vertical";
+  size?: "sm" | "lg";
+}) => {
+  const orient = variant === "vertical" ? "flex-col" : "flex-row";
+  const gap = size === "lg" ? "gap-4" : "gap-2";
+  return <div className={`flex ${gap} ${orient} ${className}`}>{children}</div>;
+};

--- a/src/ui/shared/index.ts
+++ b/src/ui/shared/index.ts
@@ -54,3 +54,4 @@ export * from "./add-ssh-key";
 export * from "./endpoint";
 export * from "./cert";
 export * from "./code";
+export * from "./group";

--- a/src/ui/shared/input.tsx
+++ b/src/ui/shared/input.tsx
@@ -10,7 +10,12 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 
 export const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const classes = cn(
-    "appearance-none block px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-gray-500 focus:border-gray-500 text-base disabled:cursor-not-allowed disabled:opacity-50",
+    "appearance-none outline-none",
+    "leading-none",
+    "p-3",
+    "border border-gray-300 placeholder-gray-400 rounded-md shadow-sm",
+    "focus:ring-inset focus:ring-gray-500 focus:border-gray-500",
+    "disabled:cursor-not-allowed disabled:opacity-50",
     props.className,
   );
   return (


### PR DESCRIPTION
~TODO - disable on v4 log drains as well (restart not allowed)~

---

* ~proof~
* ~tests~ (adding to part 2 with deletes)

<img width="506" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/cf57ad4a-c3df-4bbb-b4d9-a515ee0da5b8">

<img width="425" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/43aa449e-3cbd-4c5e-87b1-830e4f083331">

<img width="1279" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/9ba09b39-5ac8-4192-bd72-0eb1d665e90d">


delete works w/ confirm

<img width="994" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/ea9c230f-ab70-46ee-8e27-af7dd9df3e53">

<img width="1041" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/2c25dc86-c364-4bb1-ab07-b7ce845f802c">

<img width="1015" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/2f7d2e5f-8984-4514-8f76-effaaa9210b8">

if v4, would look like this:

<img width="1037" alt="image" src="https://github.com/aptible/app-ui/assets/2961973/dc5223f7-6d82-46ac-b80a-7d95b37ac1a5">
