### PR TITLE
fix-search-icon-aligment

### DIFF
--- a/src/ui/shared/input.tsx
+++ b/src/ui/shared/input.tsx
@@ -40,7 +40,7 @@ export const InputSearch = ({
   return (
     <div {...props} className={`flex relative ${className}`}>
       <IconSearch
-        className="absolute top-[9px] left-[7px]"
+        className="absolute top-[11px] left-[10px]"
         color="#595E63"
         variant="sm"
       />
@@ -50,7 +50,7 @@ export const InputSearch = ({
         value={search}
         onChange={onChange}
         autoFocus={autoFocus}
-        className="pl-8 w-full"
+        className="pl-9 w-full"
       />
     </div>
   );


### PR DESCRIPTION
**Fix search icon alignment**

BEFORE
<img width="392" alt="Screen Shot 2023-08-28 at 12 42 44 PM" src="https://github.com/aptible/app-ui/assets/4295811/09f4f007-2613-4e45-99b3-8a5e4026c29a">

AFTER

<img width="387" alt="Screen Shot 2023-08-28 at 12 42 38 PM" src="https://github.com/aptible/app-ui/assets/4295811/9eb4cf88-b4d3-4e8c-992d-07a658fa06d3">


