### PR TITLE
Tighten-Page-Margins-Optically

### DIFF
--- a/src/ui/layouts/menu-wrapped-page.tsx
+++ b/src/ui/layouts/menu-wrapped-page.tsx
@@ -22,7 +22,7 @@ export function MenuWrappedPage({ children, header }: Props) {
         <ApplicationSidebar />
       </div>
       <div
-        className="flex w-full p-8"
+        className="flex w-full py-6 px-8"
         style={{ marginLeft: collapsedOffset * 3.5 }}
       >
         <div className="flex flex-col flex-1">

--- a/src/ui/pages/search.tsx
+++ b/src/ui/pages/search.tsx
@@ -235,7 +235,7 @@ export const SearchPage = () => {
       <InputSearch
         search={search}
         onChange={onChange}
-        className="w-full"
+        className="w-full h-[36px] mt-2"
         autoFocus
       />
 


### PR DESCRIPTION
Tighten Page Margins
• Make page headers a bit tighter so they align better optically
• Make the search page tighter

<img width="1279" alt="Screen Shot 2023-08-28 at 9 30 54 PM" src="https://github.com/aptible/app-ui/assets/4295811/1b843f86-7cf8-4fa8-8598-27c9f1f90d89">
