### PR TITLE
Increase m5 max container size to match deploy-api limits

### DIFF
--- a/src/deploy/container/utils.ts
+++ b/src/deploy/container/utils.ts
@@ -25,7 +25,7 @@ export const CONTAINER_PROFILES: {
     costPerContainerHourInCents: 8,
     cpuShare: 0.25 / GB,
     minimumContainerSize: GB / 2,
-    maximumContainerSize: 217 * GB,
+    maximumContainerSize: 368 * GB,
     maximumContainerCount: 32,
   },
   r4: {


### PR DESCRIPTION
Ports a change from https://github.com/aptible/deploy-ui/pull/770 over to app-ui: update the max container size for m5 to 376,832 MB to match the maximum possible currently allowed by [deploy-api](https://github.com/aptible/deploy-api/blob/master/app/models/container.rb#L145) and [sweetness](https://github.com/aptible/sweetness/blob/master/lib/sweetness/constants.rb#L53).

m5 is not currently enabled in app-ui so this change should have no effect until it's enabled in a follow-up PR.