### PR TITLE
Right-Align-Actions-for-LogDrains-and-MetricDrains

### DIFF
--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -220,7 +220,9 @@ const LogDrainsSection = ({ id }: { id: string }) => {
             {logDrains.length} Log Drain{logDrains.length !== 1 && "s"}
           </p>
         }
-        tableHeader={<TableHead rightAlignedFinalCol headers={logDrainsHeaders} />}
+        tableHeader={
+          <TableHead rightAlignedFinalCol headers={logDrainsHeaders} />
+        }
         tableBody={
           <>
             {logDrains.map((logDrain) => (
@@ -373,7 +375,9 @@ const MetricDrainsSection = ({ id }: { id: string }) => {
               {metricDrains.length !== 1 && "s"}
             </p>
           }
-          tableHeader={<TableHead rightAlignedFinalCol headers={metricDrainsHeaders} />}
+          tableHeader={
+            <TableHead rightAlignedFinalCol headers={metricDrainsHeaders} />
+          }
           tableBody={
             <>
               {metricDrains.map((metricDrain) => (

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -221,7 +221,12 @@ const LogDrainsSection = ({ id }: { id: string }) => {
           </p>
         }
         tableHeader={
-          <TableHead rightAlignedFinalCol headers={logDrainsHeaders} />}
+          <TableHead
+            rightAlignedFinalCol
+            headers={
+              logDrainsHeaders}
+          />
+        }
         tableBody={
           <>
             {logDrains.map((logDrain) => (
@@ -374,7 +379,13 @@ const MetricDrainsSection = ({ id }: { id: string }) => {
               {metricDrains.length !== 1 && "s"}
             </p>
           }
-          tableHeader={<TableHead rightAlignedFinalCol headers={metricDrainsHeaders} />}
+          tableHeader={
+            <TableHead
+              rightAlignedFinalCol
+              headers={
+                metricDrainsHeaders}
+            />
+          }
           tableBody={
             <>
               {metricDrains.map((metricDrain) => (

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -220,12 +220,7 @@ const LogDrainsSection = ({ id }: { id: string }) => {
             {logDrains.length} Log Drain{logDrains.length !== 1 && "s"}
           </p>
         }
-        tableHeader={
-          <TableHead
-            rightAlignedFinalCol
-            headers={logDrainsHeaders}
-          />
-        }
+        tableHeader={<TableHead rightAlignedFinalCol headers={logDrainsHeaders} />}
         tableBody={
           <>
             {logDrains.map((logDrain) => (
@@ -378,12 +373,7 @@ const MetricDrainsSection = ({ id }: { id: string }) => {
               {metricDrains.length !== 1 && "s"}
             </p>
           }
-          tableHeader={
-            <TableHead
-              rightAlignedFinalCol
-              headers={metricDrainsHeaders}
-            />
-          }
+          tableHeader={<TableHead rightAlignedFinalCol headers={metricDrainsHeaders} />}
           tableBody={
             <>
               {metricDrains.map((metricDrain) => (

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -221,7 +221,7 @@ const LogDrainsSection = ({ id }: { id: string }) => {
           </p>
         }
         tableHeader={
-          <TableHead headers={logDrainsHeaders} rightAlignedFinalCol />}
+          <TableHead rightAlignedFinalCol headers={logDrainsHeaders} />}
         tableBody={
           <>
             {logDrains.map((logDrain) => (
@@ -374,7 +374,7 @@ const MetricDrainsSection = ({ id }: { id: string }) => {
               {metricDrains.length !== 1 && "s"}
             </p>
           }
-          tableHeader={<TableHead headers={metricDrainsHeaders} rightAlignedFinalCol />}
+          tableHeader={<TableHead rightAlignedFinalCol headers={metricDrainsHeaders} />}
           tableBody={
             <>
               {metricDrains.map((metricDrain) => (

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -155,7 +155,7 @@ const LogDrainActions = ({ logDrain }: { logDrain: DeployLogDrain }) => {
   });
 
   return (
-    <Td className="flex-1">
+    <Td className="flex justify-end gap-2 mr-4">
       <Group variant="horizontal" size="sm">
         <ButtonOps
           size="sm"
@@ -220,7 +220,8 @@ const LogDrainsSection = ({ id }: { id: string }) => {
             {logDrains.length} Log Drain{logDrains.length !== 1 && "s"}
           </p>
         }
-        tableHeader={<TableHead headers={logDrainsHeaders} />}
+        tableHeader={
+          <TableHead headers={logDrainsHeaders} rightAlignedFinalCol />}
         tableBody={
           <>
             {logDrains.map((logDrain) => (
@@ -312,7 +313,7 @@ const MetricDrainActions = ({
   });
 
   return (
-    <Td className="flex-1">
+    <Td className="flex justify-end gap-2 mr-4">
       <Group variant="horizontal" size="sm">
         <ButtonOps
           size="sm"
@@ -373,7 +374,7 @@ const MetricDrainsSection = ({ id }: { id: string }) => {
               {metricDrains.length !== 1 && "s"}
             </p>
           }
-          tableHeader={<TableHead headers={metricDrainsHeaders} />}
+          tableHeader={<TableHead headers={metricDrainsHeaders} rightAlignedFinalCol />}
           tableBody={
             <>
               {metricDrains.map((metricDrain) => (

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -223,8 +223,7 @@ const LogDrainsSection = ({ id }: { id: string }) => {
         tableHeader={
           <TableHead
             rightAlignedFinalCol
-            headers={
-              logDrainsHeaders}
+            headers={logDrainsHeaders}
           />
         }
         tableBody={
@@ -382,8 +381,7 @@ const MetricDrainsSection = ({ id }: { id: string }) => {
           tableHeader={
             <TableHead
               rightAlignedFinalCol
-              headers={
-                metricDrainsHeaders}
+              headers={metricDrainsHeaders}
             />
           }
           tableBody={


### PR DESCRIPTION
Right align actions for Log Drains and Metric Drains

BEFORE
<img width="405" alt="Screen Shot 2023-08-29 at 8 26 49 PM" src="https://github.com/aptible/app-ui/assets/4295811/3bcb96fc-b067-4f46-80cd-c79ab13ee753">

AFTER

<img width="293" alt="Screen Shot 2023-08-29 at 8 26 38 PM" src="https://github.com/aptible/app-ui/assets/4295811/1781e4f4-1779-4c10-9450-7f39ac4cd838">

