### PR TITLE
fix-logdrain-typo

### DIFF
--- a/src/ui/pages/create-log-drain.tsx
+++ b/src/ui/pages/create-log-drain.tsx
@@ -355,7 +355,7 @@ export const CreateLogDrainPage = () => {
                     <p>
                       Must be in the format of{" "}
                       <Code>
-                        https://logs.logdna.com/aptible/ingest/INGESTION KEY
+                        https://logs.mezmo.com/aptible/ingest/INGESTION KEY
                       </Code>
                       . Refer to{" "}
                       <ExternalLink

--- a/src/ui/pages/create-log-drain.tsx
+++ b/src/ui/pages/create-log-drain.tsx
@@ -224,8 +224,12 @@ export const CreateLogDrainPage = () => {
             />
           </FormGroup>
 
-          <Label>Sources</Label>
-          <p>Select which logs should be captured:</p>
+          <div className="flex flex-col">
+            <Label>Sources</Label>
+            <p className="text-gray-500">
+              Select which logs should be captured:
+            </p>
+          </div>
           <CheckBox
             label="App Logs"
             name="app-logs"

--- a/src/ui/pages/create-log-drain.tsx
+++ b/src/ui/pages/create-log-drain.tsx
@@ -73,7 +73,7 @@ const validators = {
 
 const options: SelectOption<LogDrainType>[] = [
   { value: "datadog", label: "Datadog" },
-  { value: "logdna", label: "Log DNA (formerly Mezmo)" },
+  { value: "logdna", label: "Mezmo (formerly LogDNA)" },
   { value: "papertrail", label: "Papertrail" },
   { value: "sumologic", label: "Sumo Logic" },
   { value: "insightops", label: "InsightOps" },


### PR DESCRIPTION
Fix Log Drain Typo, LogDNA is now called Mezmo

BEFORE
<img width="1139" alt="Screen Shot 2023-08-30 at 12 44 21 PM" src="https://github.com/aptible/app-ui/assets/4295811/ad7e8aa2-6364-44dd-9928-0540e7544704">


AFTER - Mezmo is the correct label
<img width="1011" alt="Screen Shot 2023-08-30 at 12 50 15 PM" src="https://github.com/aptible/app-ui/assets/4295811/061f8804-2631-42d8-bc4e-804e75c7c9f0">


