### PR TITLE
Push-Code-Step-Tweaks

### DIFF
--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -265,7 +265,7 @@ interface StarterOption extends SelectOption {
 const starterTemplateOptions: StarterOption[] = [
   { label: "Custom Code", value: "none", query: {}, repo: "" },
   {
-    label: "Ruby on Rails v7",
+    label: "Ruby on Rails v7 Template",
     value: "git@github.com:aptible/template-rails.git",
     repo: "template-rails",
     query: {
@@ -274,19 +274,19 @@ const starterTemplateOptions: StarterOption[] = [
     },
   },
   {
-    label: "Django v4",
+    label: "Django v4 Template",
     value: "git@github.com:aptible/template-django.git",
     repo: "template-django",
     query: { dbs: ["database_url:postgresql:14"], envs: ["secret_key"] },
   },
   {
-    label: "Express v4",
+    label: "Express v4 Template",
     value: "git@github.com:aptible/template-express.git",
     repo: "template-express",
     query: { dbs: ["database_url:postgresql:14"] },
   },
   {
-    label: "Laravel v10",
+    label: "Laravel v10 Template",
     value: "git@github.com:aptible/template-laravel.git",
     repo: "template-laravel",
     query: {
@@ -295,7 +295,7 @@ const starterTemplateOptions: StarterOption[] = [
     },
   },
   {
-    label: "Deploy Demo App",
+    label: "Deploy Demo App Template",
     value: "git@github.com:aptible/deploy-demo-app.git",
     repo: "deploy-demo-app",
     query: {
@@ -353,6 +353,10 @@ export const CreateProjectGitPushPage = () => {
           <h4 className={tokens.type.h4}>
             Deploy Custom Code or Starter Template
           </h4>
+          <div class="text-black-500 mb-1 mr-2">
+            Launch your existing app with Custom Code, or learn how Aptible
+            works with a Starter Template.
+          </div>
           <div className="my-2">
             <Select
               options={starterTemplateOptions}

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -353,7 +353,7 @@ export const CreateProjectGitPushPage = () => {
           <h4 className={tokens.type.h4}>
             Deploy Custom Code or Starter Template
           </h4>
-          <div class="text-black-500 mb-1 mr-2">
+          <div className="text-black-500 mb-1 mr-2">
             Launch your existing app with Custom Code, or learn how Aptible
             works with a Starter Template.
           </div>

--- a/src/ui/shared/select.tsx
+++ b/src/ui/shared/select.tsx
@@ -29,7 +29,7 @@ export function Select<V = string>({
 }: SelectProps<V>) {
   const finClassName = cn(
     "border-black-100 text-black",
-    "hover:border-black hover:text-black-300",
+    "hover:border-black",
     "active:border-black-100 active:text-black",
     "disabled:bg-black-50 disabled:border-black-100 disabled:text-black",
     "rounded-md shadow-sm",


### PR DESCRIPTION
Changes
• Added explainer text "Launch your existing app with Custom Code, or learn how Aptible works with a Starter Template."
• Added the word Template after each starter template in the dropdown to reinforce what it is to users

<img width="979" alt="Screen Shot 2023-08-31 at 12 57 04 PM" src="https://github.com/aptible/app-ui/assets/4295811/6e4f915a-15c4-40b4-bed1-bd95f9161e45">
<img width="779" alt="Screen Shot 2023-08-31 at 12 57 08 PM" src="https://github.com/aptible/app-ui/assets/4295811/2eb6f53b-0a1c-4010-a753-5a7d754c20a9">

---

**Dropdowns**
• Don't Lighten Label Text color on hover
• Only darken the border-color

BEFORE
<img width="682" alt="Screen Shot 2023-08-31 at 1 07 34 PM" src="https://github.com/aptible/app-ui/assets/4295811/58f96f39-a75b-4b71-9d8b-c00d2e7efde8">

AFTER
<img width="680" alt="Screen Shot 2023-08-31 at 1 07 41 PM" src="https://github.com/aptible/app-ui/assets/4295811/9475cf16-5961-4300-94b8-3b8b525cad92">
