### PR TITLE
Fix-Typo

### DIFF
--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -142,7 +142,7 @@ const DatabaseNameChange = ({ database }: DbProps) => {
         {handle !== database.handle && drains.length ? (
           <Banner variant="info" showIcon={true} className="mt-4">
             <p>
-              You must <b>reload the database</b> for the new name to appear in
+              You must <b>restart the database</b> for the new name to appear in
               the following
               <ExternalLink
                 variant="default"


### PR DESCRIPTION
Fix Typo
• Should say restart instead of reload

BEFORE
<img width="410" alt="Screen Shot 2023-09-01 at 12 45 36 PM" src="https://github.com/aptible/app-ui/assets/4295811/fd9b6719-4b45-4ad0-aa72-f06513486b4b">


AFTER
<img width="357" alt="Screen Shot 2023-09-01 at 12 46 28 PM" src="https://github.com/aptible/app-ui/assets/4295811/346d98b1-8fbb-4767-86f4-3be3110de5fc">
