### PR TITLE
download-button-tweak

### DIFF
--- a/src/ui/shared/environment/environment-activity-report-list.tsx
+++ b/src/ui/shared/environment/environment-activity-report-list.tsx
@@ -26,7 +26,7 @@ const ActivityReportListRow = ({
       </Td>
       <Td className="flex gap-2 justify-end mr-4">
         <ButtonIcon
-          icon={<IconDownload className="-mr-2" variant="sm" />}
+          icon={<IconDownload className="-mr-1" variant="sm" />}
           onClick={() => {
             dispatch(
               downloadActivityReports({
@@ -37,7 +37,9 @@ const ActivityReportListRow = ({
           }}
           variant="primary"
           size="sm"
-        />
+        >
+          CSV
+        </ButtonIcon>
       </Td>
     </tr>
   );


### PR DESCRIPTION
Make it clear that downloads are CSV files & make hit area larger

BEFORE
<img width="161" alt="Screen Shot 2023-09-07 at 11 43 04 AM" src="https://github.com/aptible/app-ui/assets/4295811/606a18ce-6177-4f80-99b5-53afc6d1e72e">

AFTER
<img width="186" alt="Screen Shot 2023-09-07 at 11 42 55 AM" src="https://github.com/aptible/app-ui/assets/4295811/b52c1816-6116-48ae-89ec-1c84a60232e9">
