### PR TITLE
Fetch cache requests

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -218,6 +218,7 @@ const SECONDS = 1 * MS;
 const MINUTES = 60 * SECONDS;
 
 export const cacheTimer = () => timer(5 * MINUTES);
+export const cacheMinTimer = () => timer(60 * SECONDS);
 export const cacheShortTimer = () => timer(5 * SECONDS);
 
 export const api = createApi<DeployApiCtx>();

--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -297,11 +297,6 @@ export const fetchApps = api.get("/apps?per_page=5000&no_embed=true", {
   saga: cacheMinTimer(),
 });
 
-export const cancelAppsPoll = createAction("cancel-apps-poll");
-export const pollApps = api.get(["/apps?per_page=5000&no_embed=true", "poll"], {
-  saga: poll(60 * 1000, `${cancelAppsPoll}`),
-});
-
 interface AppIdProp {
   id: string;
 }

--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -1,4 +1,4 @@
-import { api, cacheShortTimer, thunks } from "@app/api";
+import { api, cacheMinTimer, thunks } from "@app/api";
 import { call, poll, select } from "@app/fx";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import {
@@ -294,18 +294,13 @@ export const selectAppsCountByStack = createSelector(
 );
 
 export const fetchApps = api.get("/apps?per_page=5000&no_embed=true", {
-  saga: cacheShortTimer(),
+  saga: cacheMinTimer(),
 });
 
 export const cancelAppsPoll = createAction("cancel-apps-poll");
-export const pollApps = thunks.create(
-  "poll-apps",
-  { saga: poll(60 * 1000, `${cancelAppsPoll}`) },
-  function* (_, next) {
-    yield* call(fetchApps.run, fetchApps());
-    yield* next();
-  },
-);
+export const pollApps = api.get(["/apps?per_page=5000&no_embed=true", "poll"], {
+  saga: poll(60 * 1000, `${cancelAppsPoll}`),
+});
 
 interface AppIdProp {
   id: string;

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -11,14 +11,7 @@ import {
   setLoaderSuccess,
 } from "@app/fx";
 
-import {
-  PaginateProps,
-  ThunkCtx,
-  api,
-  cacheTimer,
-  combinePages,
-  thunks,
-} from "@app/api";
+import { ThunkCtx, api, cacheShortTimer, cacheTimer, thunks } from "@app/api";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import {
   createReducerMap,
@@ -348,16 +341,13 @@ export const selectDatabasesCountByStack = createSelector(
   (dbs) => dbs.length,
 );
 
-export const fetchDatabases = api.get<PaginateProps>(
-  "/databases?page=:page&per_page=5000&no_embed=true",
+export const fetchDatabases = api.get(
+  "/databases?per_page=5000&no_embed=true",
   {
-    saga: cacheTimer(),
+    saga: cacheShortTimer(),
   },
 );
-export const fetchAllDatabases = thunks.create(
-  "fetch-all-databases",
-  combinePages(fetchDatabases),
-);
+
 export const fetchDatabase = api.get<{ id: string }, DeployDatabaseResponse>(
   "/databases/:id",
 );

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -11,7 +11,7 @@ import {
   setLoaderSuccess,
 } from "@app/fx";
 
-import { ThunkCtx, api, cacheShortTimer, cacheTimer, thunks } from "@app/api";
+import { ThunkCtx, api, cacheMinTimer, cacheTimer, thunks } from "@app/api";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import {
   createReducerMap,
@@ -344,7 +344,7 @@ export const selectDatabasesCountByStack = createSelector(
 export const fetchDatabases = api.get(
   "/databases?per_page=5000&no_embed=true",
   {
-    saga: cacheShortTimer(),
+    saga: cacheMinTimer(),
   },
 );
 

--- a/src/deploy/endpoint/index.ts
+++ b/src/deploy/endpoint/index.ts
@@ -1,13 +1,6 @@
 import { createAction, createSelector } from "@reduxjs/toolkit";
 
-import {
-  PaginateProps,
-  api,
-  cacheShortTimer,
-  cacheTimer,
-  combinePages,
-  thunks,
-} from "@app/api";
+import { api, cacheMinTimer, cacheShortTimer, thunks } from "@app/api";
 import {
   call,
   poll,
@@ -457,16 +450,9 @@ export const fetchEndpoint = api.get<{ id: string }>("/vhosts/:id", {
   saga: cacheShortTimer(),
 });
 
-export const fetchEndpoints = api.get<PaginateProps>(
-  "/vhosts?page=:page&per_page=5000",
-  {
-    saga: cacheTimer(),
-  },
-);
-export const fetchAllEndpoints = thunks.create(
-  "fetch-all-endpoints",
-  combinePages(fetchEndpoints),
-);
+export const fetchEndpoints = api.get("/vhosts?per_page=5000", {
+  saga: cacheMinTimer(),
+});
 
 export const cancelFetchEndpointPoll = createAction(
   "cancel-fetch-endpoint-poll",

--- a/src/deploy/environment/index.ts
+++ b/src/deploy/environment/index.ts
@@ -1,7 +1,7 @@
 import { createAction, createSelector } from "@reduxjs/toolkit";
 
-import { api, cacheShortTimer, thunks } from "@app/api";
-import { call, latest, poll, put, select } from "@app/fx";
+import { api, cacheMinTimer } from "@app/api";
+import { latest, poll, put, select } from "@app/fx";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import { selectOrganizationSelectedId } from "@app/organizations";
 import {
@@ -198,18 +198,13 @@ export const selectEnvironmentByName = createSelector(
 export const fetchEnvironmentById = api.get<{ id: string }>("/accounts/:id");
 
 export const fetchEnvironments = api.get("/accounts?per_page=5000", {
-  saga: cacheShortTimer(),
+  saga: cacheMinTimer(),
 });
 
 export const cancelEnvPoll = createAction("cancel-env-poll");
-export const pollEnvs = thunks.create(
-  "poll-envs",
-  { saga: poll(60 * 1000, `${cancelEnvPoll}`) },
-  function* (_, next) {
-    yield* call(fetchEnvironments.run, fetchEnvironments());
-    yield* next();
-  },
-);
+export const pollEnvs = api.get(["/accounts?per_page=5000", "poll-envs"], {
+  saga: poll(60 * 1000, `${cancelEnvPoll}`),
+});
 
 export const fetchEnvironmentOperations = api.get<{ id: string }>(
   "/accounts/:id/operations",

--- a/src/deploy/environment/index.ts
+++ b/src/deploy/environment/index.ts
@@ -1,7 +1,7 @@
-import { createAction, createSelector } from "@reduxjs/toolkit";
+import { createSelector } from "@reduxjs/toolkit";
 
 import { api, cacheMinTimer } from "@app/api";
-import { latest, poll, put, select } from "@app/fx";
+import { latest, put, select } from "@app/fx";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import { selectOrganizationSelectedId } from "@app/organizations";
 import {
@@ -199,11 +199,6 @@ export const fetchEnvironmentById = api.get<{ id: string }>("/accounts/:id");
 
 export const fetchEnvironments = api.get("/accounts?per_page=5000", {
   saga: cacheMinTimer(),
-});
-
-export const cancelEnvPoll = createAction("cancel-env-poll");
-export const pollEnvs = api.get(["/accounts?per_page=5000", "poll-envs"], {
-  saga: poll(60 * 1000, `${cancelEnvPoll}`),
 });
 
 export const fetchEnvironmentOperations = api.get<{ id: string }>(

--- a/src/deploy/log-drain/index.ts
+++ b/src/deploy/log-drain/index.ts
@@ -1,4 +1,4 @@
-import { PaginateProps, api, cacheTimer, combinePages, thunks } from "@app/api";
+import { api, cacheMinTimer, cacheTimer, thunks } from "@app/api";
 import { defaultEntity, defaultHalHref, extractIdFromLink } from "@app/hal";
 import {
   createReducerMap,
@@ -233,16 +233,10 @@ export const selectLogDrainsByEnvId = createSelector(
 export const hasDeployLogDrain = (a: DeployLogDrain) => a.id !== "";
 export const logDrainReducers = createReducerMap(slice);
 
-export const fetchLogDrains = api.get<PaginateProps>(
-  "/log_drains?page=:page&per_page=5000",
-  {
-    saga: cacheTimer(),
-  },
-);
-export const fetchAllLogDrains = thunks.create(
-  "fetch-all-log-drains",
-  combinePages(fetchLogDrains),
-);
+export const fetchLogDrains = api.get("/log_drains?per_page=5000", {
+  saga: cacheMinTimer(),
+});
+
 export const fetchEnvLogDrains = api.get<{ id: string }>(
   "/accounts/:id/log_drains",
   {

--- a/src/deploy/metric-drain/index.ts
+++ b/src/deploy/metric-drain/index.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { PaginateProps, api, cacheTimer, combinePages, thunks } from "@app/api";
+import { api, cacheTimer, thunks } from "@app/api";
 import {
   call,
   put,
@@ -163,16 +163,10 @@ export const fetchEnvMetricDrains = api.get<{ id: string }>(
   "/accounts/:id/metric_drains",
 );
 
-export const fetchMetricDrains = api.get<PaginateProps>(
-  "/metric_drains?page=:page&per_page=5000",
-  {
-    saga: cacheTimer(),
-  },
-);
-export const fetchAllMetricDrains = thunks.create(
-  "fetch-all-metric-drains",
-  combinePages(fetchMetricDrains),
-);
+export const fetchMetricDrains = api.get("/metric_drains?per_page=5000", {
+  saga: cacheTimer(),
+});
+
 interface CreateMetricDrainBase {
   envId: string;
   handle: string;

--- a/src/deploy/service/index.ts
+++ b/src/deploy/service/index.ts
@@ -1,11 +1,4 @@
-import {
-  PaginateProps,
-  api,
-  cacheShortTimer,
-  cacheTimer,
-  combinePages,
-  thunks,
-} from "@app/api";
+import { api, cacheMinTimer, cacheShortTimer } from "@app/api";
 import { defaultEntity, defaultHalHref, extractIdFromLink } from "@app/hal";
 import {
   createAction,
@@ -241,16 +234,10 @@ export const selectAppToServicesMap = createSelector(
 
 export const fetchService = api.get<{ id: string }>("/services/:id");
 
-export const fetchServices = api.get<PaginateProps>(
-  "/services?page=:page&per_page=5000",
-  {
-    saga: cacheTimer(),
-  },
-);
-export const fetchAllServices = thunks.create(
-  "fetch-all-services",
-  combinePages(fetchServices),
-);
+export const fetchServices = api.get("/services?per_page=5000", {
+  saga: cacheMinTimer(),
+});
+
 export const fetchEnvironmentServices = api.get<{ id: string }>(
   "/accounts/:id/services",
 );

--- a/src/deploy/stack/index.ts
+++ b/src/deploy/stack/index.ts
@@ -1,4 +1,4 @@
-import { PaginateProps, api, cacheTimer, combinePages, thunks } from "@app/api";
+import { api, cacheMinTimer } from "@app/api";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import { selectOrganizationSelectedId } from "@app/organizations";
 import {
@@ -266,12 +266,9 @@ export const selectContainerProfilesForStack = createSelector(
 
 export const stackReducers = createReducerMap(slice);
 
-export const fetchStacks = api.get<PaginateProps>("/stacks?page=:page");
-export const fetchAllStacks = thunks.create(
-  "fetch-all-stacks",
-  { saga: cacheTimer() },
-  combinePages(fetchStacks),
-);
+export const fetchStacks = api.get("/stacks?per_page=5000", {
+  saga: cacheMinTimer(),
+});
 
 export const fetchStack = api.get<{ id: string }>("/stacks/:id");
 

--- a/src/initial-data/index.ts
+++ b/src/initial-data/index.ts
@@ -7,14 +7,14 @@ import {
   fetchRoles,
 } from "@app/auth";
 import {
-  fetchAllEndpoints,
-  fetchAllLogDrains,
-  fetchAllMetricDrains,
-  fetchAllServices,
-  fetchAllStacks,
   fetchApps,
   fetchDatabases,
+  fetchEndpoints,
   fetchEnvironments,
+  fetchLogDrains,
+  fetchMetricDrains,
+  fetchServices,
+  fetchStacks,
 } from "@app/deploy";
 import { selectOrganizationSelected } from "@app/organizations";
 import { AnyAction } from "@app/types";
@@ -28,14 +28,14 @@ export function* onFetchInitData() {
     call(fetchUsers.run, fetchUsers({ orgId: org.id })),
     call(fetchRoles.run, fetchRoles({ orgId: org.id })),
     call(fetchCurrentUserRoles.run, fetchCurrentUserRoles({ userId: userId })),
-    call(fetchAllStacks.run, fetchAllStacks()),
+    call(fetchStacks.run, fetchStacks()),
     call(fetchEnvironments.run, fetchEnvironments()),
     call(fetchApps.run, fetchApps()),
     call(fetchDatabases.run, fetchDatabases()),
-    call(fetchAllLogDrains.run, fetchAllLogDrains()),
-    call(fetchAllMetricDrains.run, fetchAllMetricDrains()),
-    call(fetchAllServices.run, fetchAllServices()),
-    call(fetchAllEndpoints.run, fetchAllEndpoints()),
+    call(fetchLogDrains.run, fetchLogDrains()),
+    call(fetchMetricDrains.run, fetchMetricDrains()),
+    call(fetchServices.run, fetchServices()),
+    call(fetchEndpoints.run, fetchEndpoints()),
   ]);
 }
 

--- a/src/initial-data/index.ts
+++ b/src/initial-data/index.ts
@@ -13,6 +13,7 @@ import {
   fetchEnvironments,
   fetchLogDrains,
   fetchMetricDrains,
+  fetchOrgOperations,
   fetchServices,
   fetchStacks,
 } from "@app/deploy";
@@ -36,6 +37,7 @@ export function* onFetchInitData() {
     call(fetchMetricDrains.run, fetchMetricDrains()),
     call(fetchServices.run, fetchServices()),
     call(fetchEndpoints.run, fetchEndpoints()),
+    call(fetchOrgOperations.run, fetchOrgOperations({ orgId: org.id })),
   ]);
 }
 

--- a/src/initial-data/index.ts
+++ b/src/initial-data/index.ts
@@ -7,14 +7,14 @@ import {
   fetchRoles,
 } from "@app/auth";
 import {
-  fetchAllApps,
-  fetchAllDatabases,
   fetchAllEndpoints,
-  fetchAllEnvironments,
   fetchAllLogDrains,
   fetchAllMetricDrains,
   fetchAllServices,
   fetchAllStacks,
+  fetchApps,
+  fetchDatabases,
+  fetchEnvironments,
 } from "@app/deploy";
 import { selectOrganizationSelected } from "@app/organizations";
 import { AnyAction } from "@app/types";
@@ -29,9 +29,9 @@ export function* onFetchInitData() {
     call(fetchRoles.run, fetchRoles({ orgId: org.id })),
     call(fetchCurrentUserRoles.run, fetchCurrentUserRoles({ userId: userId })),
     call(fetchAllStacks.run, fetchAllStacks()),
-    call(fetchAllEnvironments.run, fetchAllEnvironments()),
-    call(fetchAllApps.run, fetchAllApps()),
-    call(fetchAllDatabases.run, fetchAllDatabases()),
+    call(fetchEnvironments.run, fetchEnvironments()),
+    call(fetchApps.run, fetchApps()),
+    call(fetchDatabases.run, fetchDatabases()),
     call(fetchAllLogDrains.run, fetchAllLogDrains()),
     call(fetchAllMetricDrains.run, fetchAllMetricDrains()),
     call(fetchAllServices.run, fetchAllServices()),

--- a/src/ui/layouts/environment-detail-layout.tsx
+++ b/src/ui/layouts/environment-detail-layout.tsx
@@ -1,6 +1,6 @@
 import { timeAgo } from "@app/date";
 import {
-  fetchAllApps,
+  fetchApps,
   fetchEndpointsByEnvironmentId,
   fetchEnvironmentById,
   fetchEnvironmentOperations,
@@ -135,7 +135,7 @@ function EnvironmentPageHeader({ id }: { id: string }): React.ReactElement {
     dispatch(setResourceStats({ id, type: "environment" }));
   }, []);
 
-  useQuery(fetchAllApps());
+  useQuery(fetchApps());
   useQuery(fetchEndpointsByEnvironmentId({ id }));
   useQuery(fetchEnvironmentOperations({ id }));
   const loader = useQuery(fetchEnvironmentById({ id }));

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -8,9 +8,9 @@ import { timeBetween } from "@app/date";
 import {
   cancelAppOpsPoll,
   createEndpointOperation,
-  fetchAllApps,
   fetchAllEnvOps,
   fetchApp,
+  fetchApps,
   fetchConfiguration,
   fetchDatabasesByEnvId,
   fetchEndpointsByAppId,
@@ -113,7 +113,7 @@ export const CreateProjectFromAccountSetupPage = () => {
   );
 
   useEffect(() => {
-    dispatch(fetchAllApps());
+    dispatch(fetchApps());
   }, []);
 
   useEffect(() => {

--- a/src/ui/pages/create-project-name.tsx
+++ b/src/ui/pages/create-project-name.tsx
@@ -6,8 +6,8 @@ import { useApi, useLoaderSuccess, useQuery } from "saga-query/react";
 
 import {
   createDeployApp,
-  fetchAllStacks,
   fetchEnvironmentById,
+  fetchStacks,
   selectEnvironmentById,
   selectStackById,
   selectStackPublicDefault,
@@ -270,7 +270,7 @@ export const CreateProjectNamePage = () => {
   const defaultStack = useSelector(selectStackPublicDefault);
   const stackId = queryStackId || defaultStack.id;
 
-  useQuery(fetchAllStacks());
+  useQuery(fetchStacks());
 
   if (queryEnvId === "") {
     return (

--- a/src/ui/pages/deployments.tsx
+++ b/src/ui/pages/deployments.tsx
@@ -1,6 +1,6 @@
 import {
-  fetchAllApps,
-  fetchAllEnvironments,
+  fetchApps,
+  fetchEnvironments,
   selectAppsByEnvOnboarding,
   selectLatestDeployOp,
 } from "@app/deploy";
@@ -56,8 +56,8 @@ export const DeploymentsPage = ({
   const accountIds =
     searchParams.get("accounts")?.split(",").filter(Boolean) || [];
   const apps = useSelector(selectAppsByEnvOnboarding);
-  const envsLoader = useLoader(fetchAllEnvironments());
-  const appsLoader = useLoader(fetchAllApps());
+  const envsLoader = useLoader(fetchEnvironments());
+  const appsLoader = useLoader(fetchApps());
   const filteredApps = apps.filter((app) => {
     if (accountIds.length === 0) return true;
     return accountIds.includes(app.environmentId);

--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@app/fx";
 import { useSelector } from "react-redux";
 
 import {
-  fetchAllStacks,
+  fetchStacks,
   getStackType,
   selectAppsCountByStack,
   selectDatabasesCountByStack,
@@ -66,7 +66,7 @@ function StackListRow({ stack }: { stack: DeployStack }) {
 }
 
 function StackList() {
-  const query = useQuery(fetchAllStacks());
+  const query = useQuery(fetchStacks());
 
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -1,9 +1,9 @@
 import { prettyDateRelative } from "@app/date";
 import {
   calcServiceMetrics,
-  fetchAllApps,
-  fetchAllEnvironments,
+  fetchApps,
   fetchEnvironmentById,
+  fetchEnvironments,
   selectAppsForTableSearch,
   selectAppsForTableSearchByEnvironmentId,
   selectLatestOpByAppId,
@@ -230,8 +230,8 @@ export const AppsResourceHeaderTitleBar = ({
 };
 
 export const AppListByOrg = () => {
-  const query = useQuery(fetchAllApps());
-  useQuery(fetchAllEnvironments());
+  const query = useQuery(fetchApps());
+  useQuery(fetchEnvironments());
 
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
@@ -267,7 +267,7 @@ export const AppListByEnvironment = ({
   environmentId: string;
 }) => {
   const navigate = useNavigate();
-  const loader = useLoader(fetchAllApps());
+  const loader = useLoader(fetchApps());
   useQuery(fetchEnvironmentById({ id: environmentId }));
 
   const apps = useSelector((s: AppState) =>

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -7,9 +7,9 @@ import { Tooltip } from "../tooltip";
 import { prettyDateRelative } from "@app/date";
 import {
   DeployDatabaseRow,
-  fetchAllDatabases,
-  fetchAllEnvironments,
+  fetchDatabases,
   fetchEnvironmentById,
+  fetchEnvironments,
   getContainerProfileFromType,
   hourlyAndMonthlyCostsForContainers,
   selectDatabasesForTableSearch,
@@ -199,8 +199,8 @@ const DbsResourceHeaderTitleBar = ({
 };
 
 export const DatabaseListByOrg = () => {
-  const query = useQuery(fetchAllDatabases());
-  useQuery(fetchAllEnvironments());
+  const query = useQuery(fetchDatabases());
+  useQuery(fetchEnvironments());
 
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
@@ -266,7 +266,7 @@ export const DatabaseListByEnvironment = ({
   environmentId: string;
 }) => {
   const navigate = useNavigate();
-  const query = useQuery(fetchAllDatabases());
+  const query = useQuery(fetchDatabases());
   useQuery(fetchEnvironmentById({ id: environmentId }));
 
   const onCreate = () => {

--- a/src/ui/shared/endpoint/endpoint-list.tsx
+++ b/src/ui/shared/endpoint/endpoint-list.tsx
@@ -5,6 +5,7 @@ import { Link, useSearchParams } from "react-router-dom";
 import {
   DeployEndpointRow,
   fetchCertificateById,
+  fetchEndpoints,
   getEndpointText,
   getEndpointUrl,
   requiresAcmeSetup,
@@ -196,6 +197,7 @@ export const EndpointList = ({
 export function EndpointsByOrg() {
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
+  useQuery(fetchEndpoints());
   const onChange = (nextSearch: string) => {
     setParams({ search: nextSearch });
   };

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -1,6 +1,6 @@
 import { prettyEnglishDate, timeAgo } from "@app/date";
 import {
-  fetchAllEnvironments,
+  fetchEnvironments,
   selectAppsByEnvId,
   selectDatabasesByEnvId,
   selectEnvironmentsForTableSearch,
@@ -203,7 +203,7 @@ const environmentHeaders = [
 ];
 
 export function EnvironmentListByStack({ stackId }: { stackId: string }) {
-  const query = useQuery(fetchAllEnvironments());
+  const query = useQuery(fetchEnvironments());
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
   const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
@@ -252,7 +252,7 @@ export function EnvironmentListByStack({ stackId }: { stackId: string }) {
   );
 }
 export function EnvironmentList() {
-  const query = useQuery(fetchAllEnvironments());
+  const query = useQuery(fetchEnvironments());
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
   const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/ui/shared/select-environments.tsx
+++ b/src/ui/shared/select-environments.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@app/fx";
 import { useSelector } from "react-redux";
 
-import { fetchAllEnvironments, selectEnvironmentsAsOptions } from "@app/deploy";
+import { fetchEnvironments, selectEnvironmentsAsOptions } from "@app/deploy";
 
 import { EmptyResources, ErrorResources } from "./load-resources";
 import { Loading } from "./loading";
@@ -13,9 +13,7 @@ export const EnvironmentSelect = ({
 }: {
   onSelect: (s: SelectOption) => void;
 } & Omit<SelectProps, "options" | "onSelect">) => {
-  const { isInitialLoading, isError, message } = useQuery(
-    fetchAllEnvironments(),
-  );
+  const { isInitialLoading, isError, message } = useQuery(fetchEnvironments());
   const options = useSelector(selectEnvironmentsAsOptions);
 
   if (isInitialLoading) {

--- a/src/ui/shared/select-stacks.tsx
+++ b/src/ui/shared/select-stacks.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@app/fx";
 import { useSelector } from "react-redux";
 
-import { fetchAllStacks, selectStacksByOrgAsOptions } from "@app/deploy";
+import { fetchStacks, selectStacksByOrgAsOptions } from "@app/deploy";
 
 import { selectOrganizationSelected } from "@app/organizations";
 import { AppState } from "@app/types";
@@ -10,7 +10,7 @@ import { Loading } from "./loading";
 import { Select, SelectProps } from "./select";
 
 export const StackSelect = (props: Omit<SelectProps, "options">) => {
-  const { isInitialLoading, isError, message } = useQuery(fetchAllStacks());
+  const { isInitialLoading, isError, message } = useQuery(fetchStacks());
   const org = useSelector(selectOrganizationSelected);
   const options = useSelector((s: AppState) =>
     selectStacksByOrgAsOptions(s, { orgId: org.id }),


### PR DESCRIPTION
This PR cleans up some of our old logic for fetching index pages now that we can fetch all resources in a single request.  It further adds a modest cache timer (60 seconds) so we don't keep fetching index pages when we just fetched them successfully.