### PR TITLE
improve-div-centering-on-mobile-breakpoints

### DIFF
--- a/src/ui/layouts/hero-bg-layout.tsx
+++ b/src/ui/layouts/hero-bg-layout.tsx
@@ -21,7 +21,7 @@ export const HeroBgLayout = ({
         <div className={showLogo ? "py-16" : "py-10"}>
           <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
             <div className={showLogo ? "py-4" : "py-0"}>
-              <div className="flex justify-center container">
+              <div className="flex justify-center container mx-auto">
                 <div style={{ width }}>
                   {showLogo ? (
                     <div className="flex items-center justify-center mb-5">


### PR DESCRIPTION
Center Divs
• Stop jumping on breakpoints

BEFORE
https://github.com/aptible/app-ui/assets/4295811/045fce06-517b-4ab1-96f6-bb3c65f0e41c


AFTER
https://github.com/aptible/app-ui/assets/4295811/3363c90c-ff85-47b2-b105-2b7ef86b8c09


