### PR TITLE
fix(login): dont auto elevate token if u2f or otp present

### DIFF
--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -37,8 +37,14 @@ export const login = thunks.create<CreateTokenPayload>(
       return;
     }
 
-    const elevateCtx = yield* call(elevateToken.run, elevateToken(ctx.payload));
-    log(elevateCtx);
+    // only elevate token if it's a normal password login, otp/u2f won't work
+    if (!ctx.payload.u2f && ctx.payload.otpToken === "") {
+      const elevateCtx = yield* call(
+        elevateToken.run,
+        elevateToken(ctx.payload),
+      );
+      log(elevateCtx);
+    }
 
     yield* next();
 


### PR DESCRIPTION
Whenever we receive a 401 unauthorized we reset the user's token.  Well that's the status code we receive when trying to automatically elevate a token with otp/u2f, probably because those code have already been used.