### PR TITLE
starfx

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "redux": "^4.2.1",
     "redux-batched-actions": "^0.5.0",
     "redux-persist": "^6.0.0",
-    "saga-query": "^9.0.2",
+    "starfx": "^0.0.33",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.2.2",
     "vite": "^4.4.10",

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -1,11 +1,8 @@
+import type { AppState } from "@app/types";
+import { CookieNotice, ModalPortal, StandaloneErrorBoundary } from "@app/ui";
 import type { Store } from "@reduxjs/toolkit";
 import { StrictMode } from "react";
 import { Provider } from "react-redux";
-
-import type { AppState } from "@app/types";
-import { ModalPortal, StandaloneErrorBoundary } from "@app/ui";
-
-import { CookieNotice } from "@app/ui/shared/cookie-notice";
 import { RouterProvider } from "react-router";
 import { router } from "./router";
 

--- a/src/app/packages.ts
+++ b/src/app/packages.ts
@@ -20,6 +20,7 @@ import * as signal from "@app/signal";
 import * as theme from "@app/theme";
 import * as token from "@app/token";
 import * as users from "@app/users";
+import { OpFn } from "starfx";
 
 const corePackages: any[] = [
   env,
@@ -60,17 +61,22 @@ export const reducers = corePackages.reduce((acc, pkg) => {
   return { ...acc, ...pkg.reducers };
 }, {});
 
-const initialSagas = {
-  api: api.saga(),
-  authApi: authApi.saga(),
-  metricTunnelApi: metricTunnelApi.saga(),
-  thunks: thunks.saga(),
-  billingApi: billingApi.saga(),
+const initialSagas: { [key: string]: OpFn } = {
+  api: api.bootup,
+  authApi: authApi.bootup,
+  metricTunnelApi: metricTunnelApi.bootup,
+  thunks: thunks.bootup,
+  billingApi: billingApi.bootup,
 };
 
-export const sagas = corePackages.reduce((acc, pkg) => {
-  if (!pkg.sagas) {
-    return acc;
-  }
-  return { ...acc, ...pkg.sagas };
-}, initialSagas);
+export const sagas = corePackages.reduce<{ [key: string]: OpFn }>(
+  (acc, pkg) => {
+    if (!pkg.sagas) {
+      return acc;
+    }
+    return { ...acc, ...pkg.sagas };
+  },
+  initialSagas,
+);
+
+export const tasks = Object.values(sagas);

--- a/src/app/test/trial-notice.test.tsx
+++ b/src/app/test/trial-notice.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from "@testing-library/react";
 
 import { fetchStripeSources, fetchTrials } from "@app/billing";
+import { selectLoaderById } from "@app/fx";
 import { server, testEnv, verifiedUserHandlers } from "@app/mocks";
 import { setupAppIntegrationTest, waitForBootup, waitForData } from "@app/test";
 import { rest } from "msw";
-import { selectLoaderById } from "saga-query";
 
 describe("Trial notice", () => {
   describe("with no trials", () => {

--- a/src/auth/accept-invitation.ts
+++ b/src/auth/accept-invitation.ts
@@ -35,14 +35,15 @@ export const acceptInvitation = authApi.post<AcceptInvitation>(
     // After accepting an invitation, we need to refresh our token to get elevated permissions
     // Once the elevated permissions are granted, we need to reload all assets using bootup.
     const token = yield* select(selectToken);
-    yield* call(
-      exchangeToken.run,
-      exchangeToken({
-        actorToken: token.accessToken,
-        subjectToken: token.userUrl,
-        subjectTokenType: "aptible:user:href",
-        scope: "manage",
-      }),
+    yield* call(() =>
+      exchangeToken.run(
+        exchangeToken({
+          actorToken: token.accessToken,
+          subjectToken: token.userUrl,
+          subjectTokenType: "aptible:user:href",
+          scope: "manage",
+        }),
+      ),
     );
   },
 );

--- a/src/auth/elevate.ts
+++ b/src/auth/elevate.ts
@@ -19,10 +19,13 @@ export const elevate = thunks.create<ElevateToken>(
     // use ctx.name not ctx.key (this is important for webauthn!)
     const id = ctx.name;
     yield* put(setLoaderStart({ id }));
-    const tokenCtx = yield* call(elevateToken.run, elevateToken(ctx.payload));
+    const tokenCtx = yield* call(() =>
+      elevateToken.run(elevateToken(ctx.payload)),
+    );
 
     if (!tokenCtx.json.ok) {
-      const { message, error, code, exception_context } = tokenCtx.json.data;
+      const { message, error, code, exception_context } = tokenCtx.json
+        .data as any;
       yield* put(
         setLoaderError({
           id,
@@ -53,12 +56,12 @@ export const elevateWebauthn = thunks.create<
   yield* put(setLoaderStart({ id }));
 
   try {
-    const u2f = yield* call(webauthnGet, webauthn.payload);
-    yield* call(elevate.run, elevate({ ...props, u2f }));
+    const u2f = yield* call(() => webauthnGet(webauthn.payload));
+    yield* call(() => elevate.run(elevate({ ...props, u2f })));
     yield* next();
     yield* put(setLoaderSuccess({ id }));
   } catch (err) {
-    yield put(
+    yield* put(
       setLoaderError({
         id,
         message: (err as Error).message,

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -23,10 +23,13 @@ export const login = thunks.create<CreateTokenPayload>(
     // use ctx.name not ctx.key (this is important for webauthn!)
     const id = ctx.name;
     yield* put(setLoaderStart({ id }));
-    const tokenCtx = yield* call(createToken.run, createToken(ctx.payload));
+    const tokenCtx = yield* call(() =>
+      createToken.run(createToken(ctx.payload)),
+    );
 
     if (!tokenCtx.json.ok) {
-      const { error, code, exception_context, message } = tokenCtx.json.data;
+      const { error, code, exception_context, message } = tokenCtx.json
+        .data as any;
       yield* put(
         setLoaderError({
           id,
@@ -39,9 +42,8 @@ export const login = thunks.create<CreateTokenPayload>(
 
     // only elevate token if it's a normal password login, otp/u2f won't work
     if (!ctx.payload.u2f && ctx.payload.otpToken === "") {
-      const elevateCtx = yield* call(
-        elevateToken.run,
-        elevateToken(ctx.payload),
+      const elevateCtx = yield* call(() =>
+        elevateToken.run(elevateToken(ctx.payload)),
       );
       log(elevateCtx);
     }
@@ -71,12 +73,12 @@ export const loginWebauthn = thunks.create<
   }
 
   try {
-    const u2f = yield* call(webauthnGet, webauthn.payload);
-    yield* call(login.run, login({ ...props, u2f }));
+    const u2f = yield* call(() => webauthnGet(webauthn.payload));
+    yield* call(() => login.run(login({ ...props, u2f })));
     yield* next();
   } catch (err) {
     console.error(err);
-    yield put(
+    yield* put(
       setLoaderError({
         id,
         message: (err as Error).message,

--- a/src/auth/logout.ts
+++ b/src/auth/logout.ts
@@ -1,7 +1,6 @@
 import {
-  all,
   batchActions,
-  call,
+  parallel,
   put,
   select,
   setLoaderStart,
@@ -22,10 +21,11 @@ export const logout = thunks.create("logout", function* (ctx, next) {
   yield* put(setLoaderStart({ id: ctx.name }));
   const token = yield* select(selectToken);
   const elevatedToken = yield* select(selectElevatedToken);
-  yield* all([
-    call(deleteToken.run, deleteToken({ id: token.tokenId })),
-    call(deleteToken.run, deleteToken({ id: elevatedToken.tokenId })),
+  const group = yield* parallel([
+    () => deleteToken.run(deleteToken({ id: token.tokenId })),
+    () => deleteToken.run(deleteToken({ id: elevatedToken.tokenId })),
   ]);
+  yield* group;
   yield* next();
   yield* put(
     batchActions([

--- a/src/auth/membership.ts
+++ b/src/auth/membership.ts
@@ -1,8 +1,8 @@
 import { authApi, thunks } from "@app/api";
 import { selectEnv } from "@app/env";
 import {
-  all,
   call,
+  parallel,
   put,
   select,
   setLoaderError,
@@ -10,7 +10,7 @@ import {
   setLoaderSuccess,
 } from "@app/fx";
 import { extractIdFromLink } from "@app/hal";
-import { HalEmbedded } from "@app/types";
+import { AuthApiError, HalEmbedded } from "@app/types";
 
 export const createMembership = authApi.post<{ id: string; userUrl: string }>(
   "/roles/:id/memberships",
@@ -26,7 +26,8 @@ export const deleteMembership = authApi.delete<{ id: string }>(
 );
 const fetchMembershipsByRole = authApi.get<
   { roleId: string },
-  HalEmbedded<{ memberships: any[] }>
+  HalEmbedded<{ memberships: any[] }>,
+  AuthApiError
 >("/roles/:roleId/memberships", authApi.cache());
 
 export const updateUserMemberships = thunks.create<{
@@ -42,7 +43,7 @@ export const updateUserMemberships = thunks.create<{
   const userUrl = `${env.authUrl}/users/${userId}`;
 
   const addReqs = add.map((roleId) =>
-    call(createMembership.run, createMembership({ userUrl, id: roleId })),
+    call(() => createMembership.run(createMembership({ userUrl, id: roleId }))),
   );
 
   // We have the role but in order to remove a role associated with a user
@@ -53,9 +54,8 @@ export const updateUserMemberships = thunks.create<{
   // memberships for a role and then filter by the user.
   const rmReqs: any[] = [];
   for (let i = 0; i < remove.length; i += 1) {
-    const memberships = yield* call(
-      fetchMembershipsByRole.run,
-      fetchMembershipsByRole({ roleId: remove[i] }),
+    const memberships = yield* call(() =>
+      fetchMembershipsByRole.run(fetchMembershipsByRole({ roleId: remove[i] })),
     );
     if (!memberships.json.ok) {
       continue;
@@ -64,14 +64,14 @@ export const updateUserMemberships = thunks.create<{
     const membership = memberships.json.data._embedded.memberships.find(
       (m) => userId === extractIdFromLink(m._links.user),
     );
-    const cl = call(
-      deleteMembership.run,
-      deleteMembership({ id: membership.id }),
+    const cl = call(() =>
+      deleteMembership.run(deleteMembership({ id: membership.id })),
     );
     rmReqs.push(cl);
   }
 
-  const results: any[] = yield* all([...addReqs, ...rmReqs]);
+  const group = yield* parallel([...addReqs, ...rmReqs]);
+  const results: any[] = yield* group;
 
   yield* next();
 

--- a/src/auth/organization.ts
+++ b/src/auth/organization.ts
@@ -1,14 +1,12 @@
-import { call, select } from "@app/fx";
-
 import { authApi, cacheTimer } from "@app/api";
+import { call, select } from "@app/fx";
 import {
   OrganizationResponse,
   selectOrganizationSelectedId,
   setOrganizationSelected,
 } from "@app/organizations";
 import { selectToken } from "@app/token";
-import { ApiGen, HalEmbedded } from "@app/types";
-
+import { AuthApiError, HalEmbedded } from "@app/types";
 import { exchangeToken } from "./token";
 
 export const fetchOrganizations = authApi.get<
@@ -17,7 +15,7 @@ export const fetchOrganizations = authApi.get<
 >(
   "/organizations",
   {
-    saga: cacheTimer(),
+    supervisor: cacheTimer(),
   },
   function* (ctx, next) {
     yield* next();
@@ -41,7 +39,7 @@ export const fetchReauthOrganizations = authApi.get<
   HalEmbedded<{ organizations: OrganizationResponse[] }>
 >(
   "/reauthenticate_organizations",
-  { saga: cacheTimer() },
+  { supervisor: cacheTimer() },
   function* (ctx, next) {
     yield* next();
     if (!ctx.json.ok) return;
@@ -58,31 +56,33 @@ interface CreateOrg {
   name: string;
 }
 
-export const createOrganization = authApi.post<CreateOrg, OrganizationResponse>(
-  "/organizations",
-  function* onCreateOrg(ctx, next): ApiGen {
-    const { name } = ctx.payload;
-    ctx.request = ctx.req({
-      body: JSON.stringify({ name }),
-    });
-    yield* next();
-    const token = yield* select(selectToken);
-    if (!ctx.json.ok) {
-      return;
-    }
+export const createOrganization = authApi.post<
+  CreateOrg,
+  OrganizationResponse,
+  AuthApiError
+>("/organizations", function* onCreateOrg(ctx, next) {
+  const { name } = ctx.payload;
+  ctx.request = ctx.req({
+    body: JSON.stringify({ name }),
+  });
+  yield* next();
+  const token = yield* select(selectToken);
+  if (!ctx.json.ok) {
+    return;
+  }
 
-    yield* call(
-      exchangeToken.run,
+  yield* call(() =>
+    exchangeToken.run(
       exchangeToken({
         actorToken: token.accessToken,
         subjectToken: token.userUrl,
         subjectTokenType: "aptible:user:href",
         scope: "manage",
       }),
-    );
-    ctx.actions.push(setOrganizationSelected(ctx.json.data.id));
-  },
-);
+    ),
+  );
+  ctx.actions.push(setOrganizationSelected(ctx.json.data.id));
+});
 
 export const removeUserFromOrg = authApi.delete<{
   orgId: string;

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -11,7 +11,7 @@ import {
   setToken,
 } from "@app/token";
 import { tunaEvent, tunaIdentify } from "@app/tuna";
-import { AuthApiCtx } from "@app/types";
+import { AuthApiCtx, AuthApiError } from "@app/types";
 import { PublicKeyCredentialWithAssertionJSON } from "@github/webauthn-json";
 import { AUTH_LOADER_ID } from "./loader";
 
@@ -29,18 +29,20 @@ function saveToken(ctx: AuthApiCtx<any, TokenSuccessResponse>) {
   ctx.actions.push(setToken(curToken));
 }
 
-export const fetchCurrentToken = authApi.get<never, TokenSuccessResponse>(
-  "/current_token",
-  function* onFetchToken(ctx, next) {
-    ctx.noToken = true;
-    yield* next();
-    yield* call(saveToken, ctx);
-  },
-);
+export const fetchCurrentToken = authApi.get<
+  never,
+  TokenSuccessResponse,
+  AuthApiError
+>("/current_token", function* onFetchToken(ctx, next) {
+  ctx.noToken = true;
+  yield* next();
+  yield* call(() => saveToken(ctx));
+});
 
 export const createToken = authApi.post<
   CreateTokenPayload,
-  TokenSuccessResponse
+  TokenSuccessResponse,
+  AuthApiError
 >("/tokens", function* onCreateToken(ctx, next) {
   ctx.request = ctx.req({
     body: JSON.stringify({
@@ -59,7 +61,7 @@ export const createToken = authApi.post<
   if (ctx.json.ok) {
     tunaIdentify(ctx.payload.username);
   }
-  yield* call(saveToken, ctx);
+  yield* call(() => saveToken(ctx));
 });
 
 export type ElevateToken = CreateTokenPayload;
@@ -103,45 +105,46 @@ export interface ExchangeToken {
   ssoOrganization?: string;
 }
 
-export const exchangeToken = authApi.post<ExchangeToken, TokenSuccessResponse>(
-  "exchange-token",
-  function* onExchangeToken(ctx, next) {
-    const {
-      actorToken,
-      subjectToken,
-      subjectTokenType,
-      scope,
-      ssoOrganization = "",
-    } = ctx.payload;
-    ctx.request = ctx.req({
-      url: "/tokens",
-      method: "POST",
-      body: JSON.stringify({
-        expires_in: 86090,
-        _source: "app-ui",
-        grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-        actor_token_type: "urn:ietf:params:oauth:token-type:jwt",
-        actor_token: actorToken,
-        subject_token_type: subjectTokenType,
-        subject_token: subjectToken,
-        scope: scope,
-        sso_organization: ssoOrganization,
-      }),
-    });
+export const exchangeToken = authApi.post<
+  ExchangeToken,
+  TokenSuccessResponse,
+  AuthApiError
+>("exchange-token", function* onExchangeToken(ctx, next) {
+  const {
+    actorToken,
+    subjectToken,
+    subjectTokenType,
+    scope,
+    ssoOrganization = "",
+  } = ctx.payload;
+  ctx.request = ctx.req({
+    url: "/tokens",
+    method: "POST",
+    body: JSON.stringify({
+      expires_in: 86090,
+      _source: "app-ui",
+      grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+      actor_token_type: "urn:ietf:params:oauth:token-type:jwt",
+      actor_token: actorToken,
+      subject_token_type: subjectTokenType,
+      subject_token: subjectToken,
+      scope: scope,
+      sso_organization: ssoOrganization,
+    }),
+  });
 
-    yield* next();
-    // `exchangeToken` is used when a new user creates an org as well as when
-    // a user impersonates another user.
-    // Regardless, we want to reset the store first then save the token because
-    // resetStore will delete the token stored inside redux.
-    ctx.actions.push(resetStore(), setLoaderSuccess({ id: AUTH_LOADER_ID }));
-    if (ctx.json.ok) {
-      tunaEvent("exchanged-token", ctx.payload);
-    }
-    yield* call(saveToken, ctx);
-    ctx.loader = { message: "Success" };
-  },
-);
+  yield* next();
+  // `exchangeToken` is used when a new user creates an org as well as when
+  // a user impersonates another user.
+  // Regardless, we want to reset the store first then save the token because
+  // resetStore will delete the token stored inside redux.
+  ctx.actions.push(resetStore(), setLoaderSuccess({ id: AUTH_LOADER_ID }));
+  if (ctx.json.ok) {
+    tunaEvent("exchanged-token", ctx.payload);
+  }
+  yield* call(() => saveToken(ctx));
+  ctx.loader = { message: "Success" };
+});
 
 export const revokeAllTokens = authApi.post(
   "/tokens/revoke_all_accessible",

--- a/src/auth/verify-email.ts
+++ b/src/auth/verify-email.ts
@@ -11,7 +11,7 @@ interface VerifyEmail {
 
 export const verifyEmail = authApi.post<VerifyEmail>(
   "/verifications",
-  { saga: leading },
+  { supervisor: leading },
   function* onVerifyEmail(ctx: AuthApiCtx<any, VerifyEmail>, next) {
     const { challengeId, verificationCode, userId } = ctx.payload;
     ctx.request = ctx.req({

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -1,5 +1,5 @@
 import { billingApi, cacheTimer, thunks } from "@app/api";
-import { all, call } from "@app/fx";
+import { call, parallel } from "@app/fx";
 import { defaultHalHref } from "@app/hal";
 import { createAssign, createReducerMap } from "@app/slice-helpers";
 import { AppState, BillingDetail, LinkResponse } from "@app/types";
@@ -99,12 +99,12 @@ export const createStripeSource = billingApi.post<StripeSourceProps>(
 
 export const fetchStripeSources = billingApi.get<{ id: string }>(
   "/billing_details/:id/stripe_sources",
-  { saga: cacheTimer() },
+  { supervisor: cacheTimer() },
   billingApi.cache(),
 );
 export const fetchTrials = billingApi.get<{ id: string }>(
   "/billing_details/:id/trials",
-  { saga: cacheTimer() },
+  { supervisor: cacheTimer() },
   billingApi.cache(),
 );
 // const fetchExternalPaymentSources = billingApi.get<{ id: string }>('/billing_details/:id/external_payment_sources');
@@ -171,9 +171,8 @@ export const createSignupBillingRecords =
   thunks.create<CreateBillingRecordProps>(
     "create-signup-billing-records",
     function* (ctx, next) {
-      const dtail = yield* call(
-        createBillingDetail.run,
-        createBillingDetail(ctx.payload),
+      const dtail = yield* call(() =>
+        createBillingDetail.run(createBillingDetail(ctx.payload)),
       );
       if (!dtail.json.ok) {
         ctx.json = {
@@ -183,15 +182,22 @@ export const createSignupBillingRecords =
         return;
       }
 
-      const results = yield* all([
-        call(createBillingCycle.run, createBillingCycle(ctx.payload)),
-        call(createBillingContact.run, createBillingContact(ctx.payload)),
+      const group = yield* parallel([
+        () => createBillingCycle.run(createBillingCycle(ctx.payload)),
+        () => createBillingContact.run(createBillingContact(ctx.payload)),
       ]);
+      const results = yield* group;
       // check each resp for an error
       const msg: string[] = [];
       for (let i = 0; i < results.length; i += 1) {
-        if (!results[i].json.ok) {
-          msg.push(results[i].json.data.message);
+        const result = results[i];
+        if (!result.ok) {
+          msg.push(result.error.message);
+          continue;
+        }
+
+        if (!result.value.json.ok) {
+          msg.push(result.value.json.data.message);
         }
       }
 

--- a/src/bootup/index.ts
+++ b/src/bootup/index.ts
@@ -20,92 +20,91 @@ import {
   fetchStacks,
 } from "@app/deploy";
 import {
-  all,
   call,
-  fork,
+  parallel,
   put,
   select,
   setLoaderStart,
   setLoaderSuccess,
+  spawn,
   take,
   takeEvery,
 } from "@app/fx";
 import { selectOrganizationSelected } from "@app/organizations";
 import { fetchSystemStatus } from "@app/system-status";
 import { selectAccessToken } from "@app/token";
-import { AnyAction, ApiGen } from "@app/types";
+import { AnyAction } from "@app/types";
 import { fetchUser, fetchUsers, selectCurrentUserId } from "@app/users";
 import { REHYDRATE } from "redux-persist";
 
 export const FETCH_REQUIRED_DATA = "fetch-required-data";
 
-export const bootup = thunks.create(
-  "bootup",
-  function* onBootup(ctx, next): ApiGen {
-    const id = ctx.name;
-    yield* put(setLoaderStart({ id }));
-    // wait for redux-persist to rehydrate redux store
-    yield* take(REHYDRATE);
+export const bootup = thunks.create("bootup", function* onBootup(ctx, next) {
+  const id = ctx.name;
+  yield* put(setLoaderStart({ id }));
+  // wait for redux-persist to rehydrate redux store
+  yield* take(REHYDRATE);
 
-    yield* call(fetchCurrentToken.run, fetchCurrentToken());
-    const token: string = yield* select(selectAccessToken);
-    if (!token) {
-      yield* put(
-        setLoaderSuccess({
-          id: FETCH_REQUIRED_DATA,
-          message: "no token found",
-        }),
-      );
-      yield* put(setLoaderSuccess({ id, message: "no token found" }));
-      return;
-    }
+  yield* call(() => fetchCurrentToken.run(fetchCurrentToken()));
+  const token: string = yield* select(selectAccessToken);
+  if (!token) {
+    yield* put(
+      setLoaderSuccess({
+        id: FETCH_REQUIRED_DATA,
+        message: "no token found",
+      }),
+    );
+    yield* put(setLoaderSuccess({ id, message: "no token found" }));
+    return;
+  }
 
-    yield* call(fetchOrganizations.run, fetchOrganizations());
-    yield* fork(onFetchRequiredData);
-    yield* call(onFetchResourceData);
-    yield* put(setLoaderSuccess({ id }));
-    yield* next();
-  },
-);
+  yield* call(() => fetchOrganizations.run(fetchOrganizations()));
+  const task = yield* spawn(onFetchRequiredData);
+  yield* call(onFetchResourceData);
+  yield* task;
+  yield* put(setLoaderSuccess({ id }));
+  yield* next();
+});
 
 function* onFetchRequiredData() {
   yield* put(setLoaderStart({ id: FETCH_REQUIRED_DATA }));
   const org = yield* select(selectOrganizationSelected);
   const userId = yield* select(selectCurrentUserId);
-  yield* all([
-    call(fetchUser.run, fetchUser({ userId })),
-    call(
-      fetchBillingDetail.run,
-      fetchBillingDetail({ id: org.billingDetailId }),
-    ),
+  const group = yield* parallel<unknown>([
+    () => fetchUser.run(fetchUser({ userId })),
+    () =>
+      fetchBillingDetail.run(fetchBillingDetail({ id: org.billingDetailId })),
   ]);
+  yield* group;
   yield* put(setLoaderSuccess({ id: FETCH_REQUIRED_DATA }));
 }
 
 function* onFetchResourceData() {
   const org = yield* select(selectOrganizationSelected);
   const userId = yield* select(selectCurrentUserId);
-  yield* all([
-    call(fetchUsers.run, fetchUsers({ orgId: org.id })),
-    call(fetchRoles.run, fetchRoles({ orgId: org.id })),
-    call(fetchCurrentUserRoles.run, fetchCurrentUserRoles({ userId: userId })),
-    call(fetchStacks.run, fetchStacks()),
-    call(fetchEnvironments.run, fetchEnvironments()),
-    call(fetchApps.run, fetchApps()),
-    call(fetchDatabases.run, fetchDatabases()),
-    call(fetchDatabaseImages.run, fetchDatabaseImages()),
-    call(fetchLogDrains.run, fetchLogDrains()),
-    call(fetchMetricDrains.run, fetchMetricDrains()),
-    call(fetchServices.run, fetchServices()),
-    call(fetchEndpoints.run, fetchEndpoints()),
-    call(fetchOrgOperations.run, fetchOrgOperations({ orgId: org.id })),
-    call(fetchSystemStatus.run, fetchSystemStatus()),
+  const group = yield* parallel<unknown>([
+    () => fetchUsers.run(fetchUsers({ orgId: org.id })),
+    () => fetchRoles.run(fetchRoles({ orgId: org.id })),
+    () => fetchCurrentUserRoles.run(fetchCurrentUserRoles({ userId: userId })),
+    () => fetchStacks.run(fetchStacks()),
+    () => fetchEnvironments.run(fetchEnvironments()),
+    () => fetchApps.run(fetchApps()),
+    () => fetchDatabases.run(fetchDatabases()),
+    () => fetchDatabaseImages.run(fetchDatabaseImages()),
+    () => fetchLogDrains.run(fetchLogDrains()),
+    () => fetchMetricDrains.run(fetchMetricDrains()),
+    () => fetchServices.run(fetchServices()),
+    () => fetchEndpoints.run(fetchEndpoints()),
+    () => fetchOrgOperations.run(fetchOrgOperations({ orgId: org.id })),
+    () => fetchSystemStatus.run(fetchSystemStatus()),
   ]);
+  yield* group;
 }
 
 function* onRefreshData() {
-  yield* call(fetchOrganizations.run, fetchOrganizations());
-  yield* all([call(onFetchRequiredData), call(onFetchResourceData)]);
+  yield* call(() => fetchOrganizations.run(fetchOrganizations()));
+  const group = yield* parallel([onFetchRequiredData, onFetchResourceData]);
+  yield* group;
 }
 
 function* watchRefreshData() {
@@ -115,7 +114,8 @@ function* watchRefreshData() {
       action.payload?.id === AUTH_LOADER_ID;
     return matched;
   };
-  yield* takeEvery(act, onRefreshData);
+  const task = yield* takeEvery(act, onRefreshData);
+  yield* task;
 }
 
 export const sagas = { watchRefreshData };

--- a/src/deploy/activity-report/index.ts
+++ b/src/deploy/activity-report/index.ts
@@ -87,7 +87,7 @@ export const selectActivityReportsByEnvId = createSelector(
 export const fetchEnvActivityReports = api.get<{ id: string }>(
   "/accounts/:id/activity_reports",
   {
-    saga: cacheTimer(),
+    supervisor: cacheTimer(),
   },
 );
 export const downloadActivityReports = api.get<

--- a/src/deploy/app-service-definitions/index.ts
+++ b/src/deploy/app-service-definitions/index.ts
@@ -78,7 +78,7 @@ export const selectServiceDefinitionsByAppId = createSelector(
 
 export const fetchServiceDefinitionsByAppId = api.get<{ appId: string }>(
   "/apps/:appId/service_definitions",
-  { saga: cacheTimer() },
+  { supervisor: cacheTimer() },
 );
 
 export const deleteServiceDefinition = api.delete<{

--- a/src/deploy/backup-retention-policy/index.ts
+++ b/src/deploy/backup-retention-policy/index.ts
@@ -1,4 +1,4 @@
-import { put } from "saga-query";
+import { put } from "@app/fx";
 
 import { api } from "@app/api";
 import { defaultEntity, defaultHalHref, extractIdFromLink } from "@app/hal";

--- a/src/deploy/backup/index.ts
+++ b/src/deploy/backup/index.ts
@@ -1,4 +1,5 @@
 import { api } from "@app/api";
+import { poll } from "@app/fx";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import {
   createReducerMap,
@@ -8,7 +9,6 @@ import {
 import { dateDescSort } from "@app/sort";
 import { AppState, DeployBackup, LinkResponse } from "@app/types";
 import { createAction, createSelector } from "@reduxjs/toolkit";
-import { poll } from "saga-query";
 import { selectDatabases } from "../database";
 import { DeployOperationResponse } from "../operation";
 import { selectDeploy } from "../slice";
@@ -133,7 +133,7 @@ export const fetchDatabaseBackups = api.get<{ id: string }>(
 export const cancelPollDatabaseBackups = createAction("cancel-poll-db-backups");
 export const pollDatabaseBackups = api.get<{ id: string }>(
   ["/databases/:id/backups", "poll"],
-  { saga: poll(10 * 1000, `${cancelPollDatabaseBackups}`) },
+  { supervisor: poll(10 * 1000, `${cancelPollDatabaseBackups}`) },
 );
 
 export const fetchBackup = api.get<{ id: string }>("/backups/:id");

--- a/src/deploy/database-images/index.ts
+++ b/src/deploy/database-images/index.ts
@@ -106,7 +106,7 @@ export const selectDatabaseImagesVisible = createSelector(
 );
 
 export const fetchDatabaseImages = api.get("/database_images?per_page=5000", {
-  saga: cacheTimer(),
+  supervisor: cacheTimer(),
 });
 
 export const databaseImageEntities = {

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -2,8 +2,8 @@ import { ThunkCtx, api, cacheMinTimer, cacheTimer, thunks } from "@app/api";
 import {
   FetchJson,
   Payload,
-  all,
   call,
+  parallel,
   poll,
   put,
   select,
@@ -356,7 +356,7 @@ export const selectDatabasesCountByStack = createSelector(
 export const fetchDatabases = api.get(
   "/databases?per_page=5000&no_embed=true",
   {
-    saga: cacheMinTimer(),
+    supervisor: cacheMinTimer(),
   },
   function* (ctx, next) {
     yield* next();
@@ -445,26 +445,26 @@ export const provisionDatabaseList = thunks.create<{
   const { dbs, envId } = ctx.payload;
   const id = ctx.key;
   yield* put(setLoaderStart({ id }));
-  const results = yield* all(
+  const group = yield* parallel(
     dbs.map((db) => {
-      return call(
-        provisionDatabase.run,
-        provisionDatabase(mapCreatorToProvision(envId, db)),
-      );
+      return () => provisionDatabase.run(provisionDatabase(mapCreatorToProvision(envId, db)));
     }),
   );
+  const results = yield* group;
 
   const errors = [];
   for (let i = 0; i < results.length; i += 1) {
     const res = results[i];
-    if (!res.json) continue;
+    if (!res.ok) continue;
+    const json = res.value.json;
+    if (!json) continue;
 
-    if (res.json.error) {
-      errors.push(res.json.error);
+    if (json.error) {
+      errors.push(json.error);
       continue;
     }
 
-    const { opCtx, dbCtx } = res.json;
+    const { opCtx, dbCtx } = json;
     if (opCtx && !opCtx.json.ok) {
       errors.push(opCtx.json.data.message);
       continue;
@@ -488,21 +488,24 @@ export const provisionDatabase = thunks.create<
   CreateDatabaseProps,
   ThunkCtx<CreateDatabaseProps, CreateDbResult>
 >("database-provision", function* (ctx, next) {
-  yield put(setLoaderStart({ id: ctx.key }));
+  yield* put(setLoaderStart({ id: ctx.key }));
 
-  const dbAlreadyExists = yield* select(selectDatabaseByHandle, {
-    handle: ctx.payload.handle,
-    envId: ctx.payload.envId,
-  });
+  const dbAlreadyExists = yield* select((s: AppState) =>
+    selectDatabaseByHandle(s, {
+      handle: ctx.payload.handle,
+      envId: ctx.payload.envId,
+    }),
+  );
 
   let dbId = dbAlreadyExists.id;
   let dbCtx = null;
   if (!hasDeployDatabase(dbAlreadyExists)) {
-    dbCtx = yield* call(createDatabase.run, createDatabase(ctx.payload));
+    dbCtx = yield* call(() => createDatabase.run(createDatabase(ctx.payload)));
 
     if (!dbCtx.json.ok) {
-      const message = dbCtx.json.data.message;
-      yield put(setLoaderError({ id: ctx.key, message }));
+      const data = dbCtx.json.data as any;
+      const message = data.message;
+      yield* put(setLoaderError({ id: ctx.key, message }));
       ctx.json = {
         error: message,
         dbId,
@@ -517,7 +520,9 @@ export const provisionDatabase = thunks.create<
 
   yield* next();
 
-  const dbOps = yield* select(selectOperationsByDatabaseId, { dbId });
+  const dbOps = yield* select((s: AppState) =>
+    selectOperationsByDatabaseId(s, { dbId }),
+  );
   const alreadyProvisioned = dbOps.find((op) => op.type === "provision");
   if (alreadyProvisioned) {
     const message = `Database (${ctx.payload.handle}) already provisioned`;
@@ -536,15 +541,16 @@ export const provisionDatabase = thunks.create<
     return;
   }
 
-  const opCtx = yield* call(
-    createDatabaseOperation.run,
-    createDatabaseOperation({
-      dbId,
-      containerSize: 1024,
-      diskSize: 10,
-      type: "provision",
-      envId: ctx.payload.envId,
-    }),
+  const opCtx = yield* call(() =>
+    createDatabaseOperation.run(
+      createDatabaseOperation({
+        dbId,
+        containerSize: 1024,
+        diskSize: 10,
+        type: "provision",
+        envId: ctx.payload.envId,
+      }),
+    ),
   );
 
   ctx.json = {
@@ -555,13 +561,12 @@ export const provisionDatabase = thunks.create<
   };
 
   if (!opCtx.json.ok) {
-    yield put(
-      setLoaderError({ id: ctx.key, message: opCtx.json.data.message }),
-    );
+    const data = opCtx.json.data as any;
+    yield* put(setLoaderError({ id: ctx.key, message: data.message }));
     return;
   }
 
-  yield put(
+  yield* put(
     setLoaderSuccess({
       id: ctx.key,
       meta: { dbId, opId: opCtx.json.data.id },
@@ -622,29 +627,32 @@ export const createDatabaseOperation = api.post<
 
 export const fetchDatabaseOperations = api.get<{ id: string }>(
   "/databases/:id/operations",
-  { saga: cacheTimer() },
+  { supervisor: cacheTimer() },
   api.cache(),
 );
 
 export const cancelDatabaseOpsPoll = createAction("cancel-db-ops-poll");
 export const pollDatabaseOperations = api.get<{ id: string }>(
   ["/databases/:id/operations", "poll"],
-  { saga: poll(10 * 1000, `${cancelDatabaseOpsPoll}`) },
+  { supervisor: poll(10 * 1000, `${cancelDatabaseOpsPoll}`) },
 );
 export const pollDatabaseAndServiceOperations = thunks.create<{ id: string }>(
   "db-service-op-poll",
-  { saga: poll(10 * 1000, `${cancelDatabaseOpsPoll}`) },
+  { supervisor: poll(10 * 1000, `${cancelDatabaseOpsPoll}`) },
   function* (ctx, next) {
     yield* put(setLoaderStart({ id: ctx.key }));
-    const db = yield* select(selectDatabaseById, ctx.payload);
+    const db = yield* select((s: AppState) =>
+      selectDatabaseById(s, ctx.payload),
+    );
 
-    yield* all([
-      call(fetchDatabaseOperations.run, fetchDatabaseOperations(ctx.payload)),
-      call(
-        fetchServiceOperations.run,
-        fetchServiceOperations({ id: db.serviceId }),
-      ),
+    const group = yield* parallel([
+      () => fetchDatabaseOperations.run(fetchDatabaseOperations(ctx.payload)),
+      () =>
+        fetchServiceOperations.run(
+          fetchServiceOperations({ id: db.serviceId }),
+        ),
     ]);
+    yield* group;
 
     yield* next();
     yield* put(setLoaderSuccess({ id: ctx.key }));
@@ -677,18 +685,20 @@ export const deprovisionDatabase = thunks.create<{
   dbId: string;
 }>("deprovision-database", function* (ctx, next) {
   const { dbId } = ctx.payload;
-  yield* select(selectDatabaseById, { id: dbId });
+  yield* select((s: AppState) => selectDatabaseById(s, { id: dbId }));
 
-  const deprovisionCtx = yield* call(
-    createDatabaseOperation.run,
-    createDatabaseOperation({
-      type: "deprovision",
-      dbId,
-    }),
+  const deprovisionCtx = yield* call(() =>
+    createDatabaseOperation.run(
+      createDatabaseOperation({
+        type: "deprovision",
+        dbId,
+      }),
+    ),
   );
 
   if (!deprovisionCtx.json.ok) return;
-  yield* call(waitForOperation, { id: `${deprovisionCtx.json.data.id}` });
+  const data = deprovisionCtx.json.data;
+  yield* call(() => waitForOperation({ id: `${data.id}` }));
   yield* next();
 });
 

--- a/src/deploy/endpoint/index.ts
+++ b/src/deploy/endpoint/index.ts
@@ -1,5 +1,3 @@
-import { createAction, createSelector } from "@reduxjs/toolkit";
-
 import { api, cacheMinTimer, cacheShortTimer, thunks } from "@app/api";
 import {
   call,
@@ -12,6 +10,7 @@ import {
 } from "@app/fx";
 import { defaultEntity, defaultHalHref, extractIdFromLink } from "@app/hal";
 import {
+  createAction,
   createReducerMap,
   createTable,
   mustSelectEntity,
@@ -27,6 +26,7 @@ import type {
 } from "@app/types";
 
 import { selectEnv } from "@app/env";
+import { createSelector } from "@reduxjs/toolkit";
 import { findAppById, selectApps, selectAppsByEnvId } from "../app";
 import { createCertificate } from "../certificate";
 import {
@@ -437,31 +437,31 @@ export const selectAppsByCertId = createSelector(
 
 export const fetchEndpointsByAppId = api.get<{ appId: string }>(
   "/apps/:appId/vhosts",
-  { saga: cacheShortTimer() },
+  { supervisor: cacheShortTimer() },
 );
 export const fetchEndpointsByDatabaseId = api.get<{ dbId: string }>(
   "/databases/:dbId/vhosts",
-  { saga: cacheShortTimer() },
+  { supervisor: cacheShortTimer() },
 );
 export const fetchEndpointsByEnvironmentId = api.get<{ id: string }>(
   "/accounts/:id/vhosts",
-  { saga: cacheShortTimer() },
+  { supervisor: cacheShortTimer() },
 );
 export const fetchEndpointsByServiceId = api.get<{ id: string }>(
   "/services/:id/vhosts",
   {
-    saga: cacheShortTimer(),
+    supervisor: cacheShortTimer(),
   },
 );
 
 export const fetchEndpoint = api.get<{ id: string }>("/vhosts/:id", {
-  saga: cacheShortTimer(),
+  supervisor: cacheShortTimer(),
 });
 
 export const fetchEndpoints = api.get(
   "/vhosts?per_page=5000",
   {
-    saga: cacheMinTimer(),
+    supervisor: cacheMinTimer(),
   },
   function* (ctx, next) {
     yield* next();
@@ -477,13 +477,13 @@ export const cancelFetchEndpointPoll = createAction(
 );
 export const pollFetchEndpoint = api.get<{ id: string }>(
   ["/vhosts/:id", "poll"],
-  { saga: poll(5 * 1000, `${cancelFetchEndpointPoll}`) },
+  { supervisor: poll(5 * 1000, `${cancelFetchEndpointPoll}`) },
 );
 
 export const cancelEndpointOpsPoll = createAction("cancel-enp-ops-poll");
 export const pollEndpointOperations = api.get<{ id: string }>(
   ["/vhosts/:id/operations", "poll"],
-  { saga: poll(10 * 1000, `${cancelEndpointOpsPoll}`) },
+  { supervisor: poll(10 * 1000, `${cancelEndpointOpsPoll}`) },
   api.cache(),
 );
 
@@ -625,25 +625,26 @@ export const deprovisionEndpoint = api.post<
 export const provisionEndpoint = thunks.create<CreateEndpointProps>(
   "provision-endpoint",
   function* (ctx, next) {
-    yield put(setLoaderStart({ id: ctx.key }));
+    yield* put(setLoaderStart({ id: ctx.key }));
 
     let certId = "";
-    if (ctx.payload.type === "managed" || ctx.payload.type === "custom") {
-      certId = ctx.payload.certId;
+    const payload = ctx.payload;
+    if (payload.type === "managed" || payload.type === "custom") {
+      certId = payload.certId;
 
-      if (!certId && ctx.payload.cert && ctx.payload.privKey) {
-        const certCtx = yield* call(
-          createCertificate.run,
-          createCertificate({
-            envId: ctx.payload.envId,
-            cert: ctx.payload.cert,
-            privKey: ctx.payload.privKey,
-          }),
+      if (!certId && payload.cert && payload.privKey) {
+        const certCtx = yield* call(() =>
+          createCertificate.run(
+            createCertificate({
+              envId: payload.envId,
+              cert: payload.cert as string,
+              privKey: payload.privKey as string,
+            }),
+          ),
         );
         if (!certCtx.json.ok) {
-          yield* put(
-            setLoaderError({ id: ctx.key, message: certCtx.json.data.message }),
-          );
+          const data = certCtx.json.data as any;
+          yield* put(setLoaderError({ id: ctx.key, message: data.message }));
           return;
         }
 
@@ -651,9 +652,8 @@ export const provisionEndpoint = thunks.create<CreateEndpointProps>(
       }
     }
 
-    const endpointCtx = yield* call(
-      createEndpoint.run,
-      createEndpoint({ ...ctx.payload, certId }),
+    const endpointCtx = yield* call(() =>
+      createEndpoint.run(createEndpoint({ ...ctx.payload, certId })),
     );
 
     if (!endpointCtx.json.ok) {
@@ -665,18 +665,18 @@ export const provisionEndpoint = thunks.create<CreateEndpointProps>(
 
     yield* next();
 
-    const opCtx = yield* call(
-      createEndpointOperation.run,
-      createEndpointOperation({
-        endpointId: `${endpointCtx.json.data.id}`,
-        type: "provision",
-      }),
+    const opCtx = yield* call(() =>
+      createEndpointOperation.run(
+        createEndpointOperation({
+          endpointId: `${endpointCtx.json.data.id}`,
+          type: "provision",
+        }),
+      ),
     );
 
     if (!opCtx.json.ok) {
-      yield* put(
-        setLoaderError({ id: ctx.key, message: opCtx.json.data.message }),
-      );
+      const data = opCtx.json.data as any;
+      yield* put(setLoaderError({ id: ctx.key, message: data.message }));
       return;
     }
 
@@ -699,11 +699,10 @@ export const provisionEndpoint = thunks.create<CreateEndpointProps>(
 export const provisionDatabaseEndpoint = thunks.create<CreateDbEndpointProps>(
   "provision-db-endpoint",
   function* (ctx, next) {
-    yield put(setLoaderStart({ id: ctx.key }));
+    yield* put(setLoaderStart({ id: ctx.key }));
 
-    const endpointCtx = yield* call(
-      createDatabaseEndpoint.run,
-      createDatabaseEndpoint(ctx.payload),
+    const endpointCtx = yield* call(() =>
+      createDatabaseEndpoint.run(createDatabaseEndpoint(ctx.payload)),
     );
 
     if (!endpointCtx.json.ok) {
@@ -715,18 +714,18 @@ export const provisionDatabaseEndpoint = thunks.create<CreateDbEndpointProps>(
 
     yield* next();
 
-    const opCtx = yield* call(
-      createEndpointOperation.run,
-      createEndpointOperation({
-        endpointId: `${endpointCtx.json.data.id}`,
-        type: "provision",
-      }),
+    const opCtx = yield* call(() =>
+      createEndpointOperation.run(
+        createEndpointOperation({
+          endpointId: `${endpointCtx.json.data.id}`,
+          type: "provision",
+        }),
+      ),
     );
 
     if (!opCtx.json.ok) {
-      yield* put(
-        setLoaderError({ id: ctx.key, message: opCtx.json.data.message }),
-      );
+      const data = opCtx.json.data as any;
+      yield* put(setLoaderError({ id: ctx.key, message: data.message }));
       return;
     }
 
@@ -802,13 +801,14 @@ export const updateEndpoint = thunks.create<EndpointUpdateProps>(
 
     let certId = ctx.payload.certId;
     if (!certId && ctx.payload.cert && ctx.payload.privKey) {
-      const certCtx = yield* call(
-        createCertificate.run,
-        createCertificate({
-          envId: ctx.payload.envId,
-          cert: ctx.payload.cert,
-          privKey: ctx.payload.privKey,
-        }),
+      const certCtx = yield* call(() =>
+        createCertificate.run(
+          createCertificate({
+            envId: ctx.payload.envId,
+            cert: ctx.payload.cert || "",
+            privKey: ctx.payload.privKey || "",
+          }),
+        ),
       );
       if (!certCtx.json.ok) {
         yield* put(
@@ -820,30 +820,33 @@ export const updateEndpoint = thunks.create<EndpointUpdateProps>(
       certId = `${certCtx.json.data.id}`;
     }
 
-    const patchCtx = yield* call(
-      patchEndpoint.run,
-      patchEndpoint({
-        id: ctx.payload.id,
-        ipAllowlist: ctx.payload.ipAllowlist,
-        containerPort: ctx.payload.containerPort,
-        certId,
-      }),
+    const patchCtx = yield* call(() =>
+      patchEndpoint.run(
+        patchEndpoint({
+          id: ctx.payload.id,
+          ipAllowlist: ctx.payload.ipAllowlist,
+          containerPort: ctx.payload.containerPort,
+          certId,
+        }),
+      ),
     );
     if (!patchCtx.json.ok) {
       yield* put(setLoaderError({ id, message: patchCtx.json.data.message }));
       return;
     }
 
-    const opCtx = yield* call(
-      createEndpointOperation.run,
-      createEndpointOperation({
-        endpointId: ctx.payload.id,
-        type: "provision",
-      }),
+    const opCtx = yield* call(() =>
+      createEndpointOperation.run(
+        createEndpointOperation({
+          endpointId: ctx.payload.id,
+          type: "provision",
+        }),
+      ),
     );
 
     if (!opCtx.json.ok) {
-      yield* put(setLoaderError({ id, message: opCtx.json.data.message }));
+      const data = opCtx.json.data as any;
+      yield* put(setLoaderError({ id, message: data.message }));
       return;
     }
 
@@ -881,16 +884,16 @@ export const checkDns = thunks.create<{ from: string; to: string }>(
     // we add a random number to the google request so the browser
     // doesn't cache the response
     const rand = Math.floor(Math.random() * 10000);
-    const resp = yield* call(
-      fetch,
-      `https://dns.google.com/resolve?rand=${rand}&name=${ensureTrailingPeriod(
-        from,
-      )}`,
+    const resp = yield* call(() =>
+      fetch(
+        `https://dns.google.com/resolve?rand=${rand}&name=${ensureTrailingPeriod(
+          from,
+        )}`,
+      ),
     );
-    const data: { Status: number; Answer: DnsAnswer[] } = yield* call([
-      resp,
-      "json",
-    ]);
+    const data: { Status: number; Answer: DnsAnswer[] } = yield* call(() =>
+      resp.json(),
+    );
 
     let success = false;
     const answers: DnsAnswer[] = data.Answer || [];

--- a/src/deploy/metric-drain/index.ts
+++ b/src/deploy/metric-drain/index.ts
@@ -167,7 +167,7 @@ export const fetchEnvMetricDrains = api.get<{ id: string }>(
 export const fetchMetricDrains = api.get(
   "/metric_drains?per_page=5000",
   {
-    saga: cacheTimer(),
+    supervisor: cacheTimer(),
   },
   function* (ctx, next) {
     yield* next();
@@ -288,26 +288,24 @@ export const provisionMetricDrain = thunks.create<CreateMetricDrainProps>(
   function* (ctx, next) {
     yield* put(setLoaderStart({ id: ctx.key }));
 
-    const mdCtx = yield* call(
-      createMetricDrain.run,
-      createMetricDrain(ctx.payload),
+    const mdCtx = yield* call(() =>
+      createMetricDrain.run(createMetricDrain(ctx.payload)),
     );
     if (!mdCtx.json.ok) {
-      yield* put(
-        setLoaderError({ id: ctx.key, message: mdCtx.json.data.message }),
-      );
+      const data = mdCtx.json.data as any;
+      yield* put(setLoaderError({ id: ctx.key, message: data.message }));
       return;
     }
 
     const metricDrainId = mdCtx.json.data.id;
-    const opCtx = yield* call(
-      createMetricDrainOperation.run,
-      createMetricDrainOperation({ id: metricDrainId }),
+    const opCtx = yield* call(() =>
+      createMetricDrainOperation.run(
+        createMetricDrainOperation({ id: metricDrainId }),
+      ),
     );
     if (!opCtx.json.ok) {
-      yield* put(
-        setLoaderError({ id: ctx.key, message: opCtx.json.data.message }),
-      );
+      const data = opCtx.json.data as any;
+      yield* put(setLoaderError({ id: ctx.key, message: data.message }));
       return;
     }
 

--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -9,6 +9,7 @@ import {
   combinePages,
   thunks,
 } from "@app/api";
+import { Operation } from "@app/fx";
 import {
   defaultEntity,
   extractIdFromLink,
@@ -26,7 +27,6 @@ import {
 } from "@app/slice-helpers";
 import { capitalize } from "@app/string-utils";
 import type {
-  ApiGen,
   AppState,
   DeployActivityRow,
   DeployOperation,
@@ -362,30 +362,30 @@ interface EnvOpProps extends PaginateProps, EnvIdProps {}
 
 export const fetchEnvOperations = api.get<EnvOpProps>(
   "/accounts/:envId/operations?page=:page&per_page=250",
-  { saga: leading },
+  { supervisor: leading },
 );
 
 export const fetchAllEnvOps = thunks.create<EnvIdProps>(
   "fetch-all-env-ops",
-  { saga: cacheShortTimer() },
+  { supervisor: cacheShortTimer() },
   combinePages(fetchEnvOperations, { max: 2 }),
 );
 
 export const cancelEnvOperationsPoll = createAction("cancel-env-ops-poll");
 export const pollEnvOperations = api.get<EnvIdProps>(
   ["/accounts/:envId/operations", "poll"],
-  { saga: poll(10 * 1000, `${cancelEnvOperationsPoll}`) },
+  { supervisor: poll(10 * 1000, `${cancelEnvOperationsPoll}`) },
 );
 
 export const fetchOrgOperations = api.get<{ orgId: string }>(
   "/organizations/:orgId/operations?per_page=250",
-  { saga: leading },
+  { supervisor: leading },
 );
 
 export const cancelOrgOperationsPoll = createAction("cancel-org-ops-poll");
 export const pollOrgOperations = api.get<{ orgId: string }>(
   "/organizations/:orgId/operations",
-  { saga: poll(10 * 1000, `${cancelOrgOperationsPoll}`) },
+  { supervisor: poll(10 * 1000, `${cancelOrgOperationsPoll}`) },
 );
 
 export const fetchOperationLogs = api.get<{ id: string } & Retryable, string>(
@@ -402,8 +402,8 @@ export const fetchOperationLogs = api.get<{ id: string } & Retryable, string>(
       }
 
       const url = ctx.json.data;
-      const response = yield* call(fetch, url);
-      const data = yield* call([response, "text"]);
+      const response = yield* call(() => fetch(url));
+      const data = yield* call(() => response.text());
 
       if (!response.ok) {
         ctx.json = {
@@ -429,7 +429,9 @@ export const cancelOpByIdPoll = createAction("cancel-op-by-id-poll");
 export const pollOperationById = api.get<
   { id: string },
   DeployOperationResponse
->(["/operations/:id", "poll"], { saga: poll(3 * 1000, `${cancelOpByIdPoll}`) });
+>(["/operations/:id", "poll"], {
+  supervisor: poll(3 * 1000, `${cancelOpByIdPoll}`),
+});
 
 type WaitResult = DeployOperation | undefined;
 
@@ -441,17 +443,16 @@ export function* waitForOperation({
   id: string;
   wait?: number;
   skipFetch?: boolean;
-}): ApiGen<WaitResult> {
+}): Operation<WaitResult> {
   while (true) {
     if (skipFetch) {
-      const op = yield* select(selectOperationById, { id });
+      const op = yield* select((s: AppState) => selectOperationById(s, { id }));
       if (op.status === "succeeded" || op.status === "failed") {
         return op;
       }
     } else {
-      const ctx = yield* call(
-        fetchOperationById.run,
-        fetchOperationById({ id }),
+      const ctx = yield* call(() =>
+        fetchOperationById.run(fetchOperationById({ id })),
       );
 
       if (ctx.json.ok) {
@@ -462,7 +463,9 @@ export function* waitForOperation({
           return deserializeDeployOperation(ctx.json.data);
         }
       } else {
-        const op = yield* select(selectOperationById, { id });
+        const op = yield* select((s: AppState) =>
+          selectOperationById(s, { id }),
+        );
         // When a deprovision happens and it is successful, the API will
         // eventually return a 404 because the operation is "soft" deleted.
         // As a result, we "hack" the FE by checking for this edge case

--- a/src/deploy/service/index.ts
+++ b/src/deploy/service/index.ts
@@ -242,7 +242,7 @@ export const fetchService = api.get<{ id: string }>("/services/:id");
 export const fetchServices = api.get(
   "/services?per_page=5000",
   {
-    saga: cacheMinTimer(),
+    supervisor: cacheMinTimer(),
   },
   function* (ctx, next) {
     yield* next();
@@ -258,7 +258,7 @@ export const fetchEnvironmentServices = api.get<{ id: string }>(
 );
 export const fetchServicesByAppId = api.get<{ id: string }>(
   "/apps/:id/services",
-  { saga: cacheShortTimer() },
+  { supervisor: cacheShortTimer() },
 );
 
 export interface ServiceSizingPolicyResponse {
@@ -317,7 +317,7 @@ export const fetchServiceSizingPoliciesByServiceId = api.get<{
   service_id: string;
 }>(
   "/services/:service_id/service_sizing_policies",
-  { saga: cacheShortTimer() },
+  { supervisor: cacheShortTimer() },
   api.cache(),
 );
 
@@ -363,22 +363,25 @@ export const modifyServiceSizingPolicy =
       let updateCtx;
       if (nextPolicy.scaling_enabled) {
         if (nextPolicy.id === undefined) {
-          updateCtx = yield* call(
-            createServiceSizingPoliciesByServiceId.run,
-            createServiceSizingPoliciesByServiceId(nextPolicy),
+          updateCtx = yield* call(() =>
+            createServiceSizingPoliciesByServiceId.run(
+              createServiceSizingPoliciesByServiceId(nextPolicy),
+            ),
           );
         } else {
-          updateCtx = yield* call(
-            updateServiceSizingPoliciesByServiceId.run,
-            updateServiceSizingPoliciesByServiceId(nextPolicy),
+          updateCtx = yield* call(() =>
+            updateServiceSizingPoliciesByServiceId.run(
+              updateServiceSizingPoliciesByServiceId(nextPolicy),
+            ),
           );
         }
       } else {
-        updateCtx = yield* call(
-          deleteServiceSizingPoliciesByServiceId.run,
-          deleteServiceSizingPoliciesByServiceId({
-            service_id: `${nextPolicy.service_id}`,
-          }),
+        updateCtx = yield* call(() =>
+          deleteServiceSizingPoliciesByServiceId.run(
+            deleteServiceSizingPoliciesByServiceId({
+              service_id: `${nextPolicy.service_id}`,
+            }),
+          ),
         );
       }
 
@@ -398,7 +401,7 @@ export const fetchServiceOperations = api.get<{ id: string }>(
 export const cancelServicesOpsPoll = createAction("cancel-services-ops-poll");
 export const pollServiceOperations = api.get<{ id: string }>(
   ["/services/:id/operations", "poll"],
-  { saga: poll(10 * 1000, `${cancelServicesOpsPoll}`) },
+  { supervisor: poll(10 * 1000, `${cancelServicesOpsPoll}`) },
 );
 
 export const serviceEntities = {

--- a/src/deploy/stack/index.ts
+++ b/src/deploy/stack/index.ts
@@ -274,7 +274,7 @@ export const stackReducers = createReducerMap(slice);
 export const fetchStacks = api.get(
   "/stacks?per_page=5000",
   {
-    saga: cacheMinTimer(),
+    supervisor: cacheMinTimer(),
   },
   function* (ctx, next) {
     yield* next();
@@ -289,7 +289,7 @@ export const fetchStack = api.get<{ id: string }>("/stacks/:id");
 
 export const fetchStackManagedHids = api.get<{ id: string } & PaginateProps>(
   "/stacks/:id/intrusion_detection_reports?page=:page&per_page=10",
-  { saga: cacheShortTimer() },
+  { supervisor: cacheShortTimer() },
   api.cache(),
 );
 

--- a/src/deploy/support/index.ts
+++ b/src/deploy/support/index.ts
@@ -51,25 +51,27 @@ export const queryAlgoliaApi = thunks.create<{
   const { query, debounce } = ctx.payload;
 
   if (!query || debounce) {
+    yield* next();
     return;
   }
 
   yield* put(setLoaderStart({ id: ctx.key }));
-  const resp = yield* call(
-    fetch,
-    "https://6C0QTHJH2V-dsn.algolia.net/1/indexes/docs/query?x-algolia-api-key=b14dbd7f78ae21d0a844c64cecc52cf5&x-algolia-application-id=6C0QTHJH2V",
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json;charset=UTF-8",
+  const resp = yield* call(() =>
+    fetch(
+      "https://6C0QTHJH2V-dsn.algolia.net/1/indexes/docs/query?x-algolia-api-key=b14dbd7f78ae21d0a844c64cecc52cf5&x-algolia-application-id=6C0QTHJH2V",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json;charset=UTF-8",
+        },
+        body: JSON.stringify({
+          query: query,
+          hitsPerPage: 5,
+        }),
       },
-      body: JSON.stringify({
-        query: query,
-        hitsPerPage: 5,
-      }),
-    },
+    ),
   );
-  const data = yield* call([resp, "json"]);
+  const data = yield* call(() => resp.json());
   yield* put(setLoaderSuccess({ id: ctx.key, meta: { hits: data.hits } }));
   yield* next();
 });

--- a/src/fx/index.ts
+++ b/src/fx/index.ts
@@ -1,42 +1,58 @@
 export {
-  selectDataById,
-  defaultLoadingItem,
-  batchActions,
-  resetLoaderById,
-  selectLoaderById,
-  BATCH,
-  prepareStore,
   call,
-  delay,
   fetchRetry,
-  poll,
-  put,
-  select,
-  createThrottle,
-  latest,
-  take,
-  fork,
-  all,
-  setLoaderError,
-  setLoaderStart,
-  setLoaderSuccess,
-  timer,
+  parallel,
   requestMonitor,
   createApi,
   createPipe,
   race,
   fetcher,
-  dispatchActions,
+  sleep,
+  Ok,
+  Err,
+  each,
+  spawn,
+} from "starfx";
+import { sleep } from "starfx";
+export const delay = sleep;
+
+export {
+  timer,
+  poll,
   takeEvery,
+  dispatchActions,
+  selectDataById,
+  batchActions,
+  resetLoaderById,
+  selectLoaderById,
+  BATCH,
+  prepareStore,
+  put,
+  select,
+  take,
+  setLoaderError,
+  setLoaderStart,
+  setLoaderSuccess,
+  selectLoaders,
+  latest,
   leading,
   addData,
-} from "saga-query";
+  reduxMdw,
+} from "starfx/redux";
+import { defaultLoaderItem } from "starfx/redux";
+export const defaultLoadingItem = defaultLoaderItem;
+
+import type { AnyState, LoaderItemState, LoaderState } from "starfx";
+export type LoadingState<M extends AnyState = AnyState> = Omit<
+  LoaderState<M>,
+  "id"
+>;
+export type LoadingItemState<M extends AnyState = AnyState> = Omit<
+  LoaderItemState<M>,
+  "id"
+>;
+
 export type {
-  LoadingState,
-  LoadingItemState,
-  QueryState,
-  SagaIterator,
-  ApiCtx,
   Next,
   CreateActionWithPayload,
   LoaderCtx,
@@ -44,11 +60,13 @@ export type {
   FetchJson,
   Payload,
   Action,
-} from "saga-query";
+  Result,
+  Operation,
+} from "starfx";
 export {
   useApi,
   useQuery,
   useCache,
   useLoader,
   useLoaderSuccess,
-} from "saga-query/react";
+} from "starfx/react";

--- a/src/hal/index.ts
+++ b/src/hal/index.ts
@@ -1,4 +1,4 @@
-import { Next, select } from "@app/fx";
+import { Next, Operation, select } from "@app/fx";
 
 import { createAssign, createReducerMap } from "@app/slice-helpers";
 import type {
@@ -89,14 +89,14 @@ export function defaultEntity<E = any>(e: EmbeddedMap<E>): EmbeddedMap<E> {
 export function* halEntityParser(
   ctx: DeployApiCtx<any, HalEmbedded<{ [key: string]: any }>>,
   next: Next,
-) {
+): Operation<any> {
   yield* next();
 
   if (!ctx.json.ok) {
     return;
   }
 
-  const entityMap: EntityMap = yield select(selectEntities);
+  const entityMap: EntityMap = yield* select(selectEntities);
   const { data } = ctx.json;
 
   const actions: Action<any>[] = [];

--- a/src/invitations/invitations.ts
+++ b/src/invitations/invitations.ts
@@ -5,7 +5,6 @@ import { defaultHalHref, extractIdFromLink } from "@app/hal";
 import { createTable, mustSelectEntity } from "@app/slice-helpers";
 import { selectToken } from "@app/token";
 import type {
-  ApiGen,
   AppState,
   HalEmbedded,
   Invitation,
@@ -88,7 +87,7 @@ export const fetchInvitations = authApi.get<
   { orgId: string },
   HalEmbedded<{ invitations: InvitationResponse[] }>
 >("/organizations/:orgId/invitations", function* onFetchInvitations(ctx, next) {
-  const token: Token = yield select(selectToken);
+  const token: Token = yield* select(selectToken);
   if (!token) {
     return;
   }
@@ -131,7 +130,7 @@ export const fetchInvitation = authApi.get<{ id: string }, InvitationResponse>(
 
 export const resetInvitation = authApi.post<{ invitationId: string }>(
   "/resets",
-  function* onResetInvitation(ctx, next): ApiGen {
+  function* onResetInvitation(ctx, next) {
     const origin = yield* select(selectOrigin);
     ctx.request = ctx.req({
       body: JSON.stringify({

--- a/src/metric-tunnel/index.ts
+++ b/src/metric-tunnel/index.ts
@@ -7,22 +7,28 @@ import {
   selectReleasesByServiceAfterDate,
   selectServiceById,
 } from "@app/deploy";
-import { createReducerMap, createTable } from "@app/slice-helpers";
-import { AppState, ContainerMetrics, MetricHorizons } from "@app/types";
-import { metricHorizonAsSeconds } from "@app/ui/shared/metrics-controls";
-import { createSelector } from "@reduxjs/toolkit";
 import {
-  all,
   call,
   delay,
+  leading,
+  parallel,
   put,
   select,
   selectLoaders,
   setLoaderError,
   setLoaderStart,
   setLoaderSuccess,
-  takeLeading,
-} from "saga-query";
+} from "@app/fx";
+import { createReducerMap, createTable } from "@app/slice-helpers";
+import { AppState, ContainerMetrics, MetricHorizons } from "@app/types";
+import { createSelector } from "@reduxjs/toolkit";
+
+export const metricHorizonAsSeconds = (metricHorizon: MetricHorizons) =>
+  ({
+    "1h": 60 * 60,
+    "1d": 60 * 60 * 24,
+    "1w": 60 * 60 * 24 * 7,
+  })[metricHorizon];
 
 export interface MetricTunnelContainerResponse {
   columns: (string | null | number)[][];
@@ -259,7 +265,7 @@ export const fetchMetricTunnelDataForContainer = metricTunnelApi.get<
   MetricTunnelContainerResponse
 >(
   `/proxy/:containerId?horizon=:metricHorizon&ts=${getUtc()}&metric=:metricName&requestedTicks=300`,
-  { saga: cacheTimer() },
+  { supervisor: cacheTimer() },
   function* (ctx, next) {
     const key = metricsKey(ctx.payload.serviceId, ctx.payload.metricHorizon);
     const id = `${ctx.key}-${ctx.payload.containerId}-${ctx.payload.metricName}-${key}`;
@@ -293,28 +299,32 @@ export const fetchContainersByServiceId = thunks.create<{ serviceId: string }>(
   function* (ctx, next) {
     const { serviceId } = ctx.payload;
     yield* put(setLoaderStart({ id: ctx.key }));
-    const releaseCtx = yield* call(
-      fetchReleasesByServiceWithDeleted.run,
-      fetchReleasesByServiceWithDeleted({ serviceId: ctx.payload.serviceId }),
+    const releaseCtx = yield* call(() =>
+      fetchReleasesByServiceWithDeleted.run(
+        fetchReleasesByServiceWithDeleted({ serviceId: ctx.payload.serviceId }),
+      ),
     );
     if (!releaseCtx.json.ok) {
       yield* put(setLoaderError({ id: ctx.key }));
       yield* next();
       return releaseCtx;
     }
-    const releases = yield* select(selectReleasesByServiceAfterDate, {
-      serviceId,
-      date: dateFromToday(-7).toISOString(),
-    });
+    const releases = yield* select((s: AppState) =>
+      selectReleasesByServiceAfterDate(s, {
+        serviceId,
+        date: dateFromToday(-7).toISOString(),
+      }),
+    );
     const releaseIds = releases.map((release) => release.id);
 
-    const fx = releaseIds.map((releaseId) =>
-      call(
-        fetchContainersByReleaseIdWithDeleted.run,
-        fetchContainersByReleaseIdWithDeleted({ releaseId }),
-      ),
+    const fx = releaseIds.map(
+      (releaseId) => () =>
+        fetchContainersByReleaseIdWithDeleted.run(
+          fetchContainersByReleaseIdWithDeleted({ releaseId }),
+        ),
     );
-    yield* all(fx);
+    const group = yield* parallel(fx);
+    yield* group;
 
     yield* put(setLoaderSuccess({ id: ctx.key }));
     yield* next();
@@ -330,24 +340,30 @@ export const fetchMetricByServiceId = thunks.create<{
 }>("fetch-metric-by-service-id", function* (ctx, next) {
   yield* put(setLoaderStart({ id: ctx.key }));
   const { serviceId, metricHorizon, metricName } = ctx.payload;
-  const service = yield* select(selectServiceById, { id: serviceId });
+  const service = yield* select((s: AppState) =>
+    selectServiceById(s, { id: serviceId }),
+  );
 
   // we always go back exactly one week, though it might be a bit too far for some that way
   // we do not have to refetch this if the component state changes as this is fairly expensive
-  const releases = yield* select(selectReleasesByServiceAfterDate, {
-    serviceId,
-    date: dateFromToday(-7).toISOString(),
-  });
+  const releases = yield* select((s: AppState) =>
+    selectReleasesByServiceAfterDate(s, {
+      serviceId,
+      date: dateFromToday(-7).toISOString(),
+    }),
+  );
   const releaseIds = releases.map((release) => release.id);
 
   const layersToSearchForContainers = ["app", "database"];
   const horizonInSeconds = metricHorizonAsSeconds(metricHorizon);
-  const containers = yield* select(selectContainersByCurrentReleaseAndHorizon, {
-    layers: layersToSearchForContainers,
-    releaseIds,
-    horizonInSeconds,
-    currentReleaseId: service.currentReleaseId,
-  });
+  const containers = yield* select((s: AppState) =>
+    selectContainersByCurrentReleaseAndHorizon(s, {
+      layers: layersToSearchForContainers,
+      releaseIds,
+      horizonInSeconds,
+      currentReleaseId: service.currentReleaseId,
+    }),
+  );
 
   const BATCH_REQUEST_LIMIT = 20;
   const totalRequests = containers.length;
@@ -366,9 +382,8 @@ export const fetchMetricByServiceId = thunks.create<{
         continue;
       }
 
-      fx.push(
-        call(
-          fetchMetricTunnelDataForContainer.run,
+      fx.push(() =>
+        fetchMetricTunnelDataForContainer.run(
           fetchMetricTunnelDataForContainer({
             containerId: container.id,
             metricName,
@@ -379,7 +394,8 @@ export const fetchMetricByServiceId = thunks.create<{
       );
     }
 
-    yield* all(fx);
+    const group = yield* parallel(fx);
+    yield* group;
     yield* delay(250);
   }
 
@@ -416,22 +432,20 @@ export const fetchAllMetricsByServiceId = thunks.create<{
 }>(
   "fetch-all-metrics-by-service-id",
   {
-    saga: takeLeading,
+    supervisor: leading,
   },
   function* (ctx, next) {
     const { serviceId, metrics, metricHorizon } = ctx.payload;
     yield* put(setLoaderStart({ id: ctx.key }));
 
-    yield* call(
-      fetchContainersByServiceId.run,
-      fetchContainersByServiceId({ serviceId }),
+    yield* call(() =>
+      fetchContainersByServiceId.run(fetchContainersByServiceId({ serviceId })),
     );
 
     const fx: any[] = [];
     metrics.forEach((metricName) => {
-      fx.push(
-        call(
-          fetchMetricByServiceId.run,
+      fx.push(() =>
+        fetchMetricByServiceId.run(
           fetchMetricByServiceId({
             serviceId,
             metricName,
@@ -440,7 +454,8 @@ export const fetchAllMetricsByServiceId = thunks.create<{
         ),
       );
     });
-    yield* all(fx);
+    const group = yield* parallel(fx);
+    yield* group;
 
     yield* put(setLoaderSuccess({ id: ctx.key }));
     yield* next();

--- a/src/mfa/index.ts
+++ b/src/mfa/index.ts
@@ -7,14 +7,7 @@ import {
   createReducerMap,
   createTable,
 } from "@app/slice-helpers";
-import {
-  ApiGen,
-  AppState,
-  AuthApiCtx,
-  LinkResponse,
-  Otp,
-  U2fDevice,
-} from "@app/types";
+import { AppState, AuthApiCtx, LinkResponse, Otp, U2fDevice } from "@app/types";
 
 const defaultOtp = (o: Partial<Otp> = {}): Otp => {
   return {
@@ -129,7 +122,7 @@ export const fetchOtpCodes = authApi.get<{ otpId: string }>(
 
 export const setupOtp = authApi.post<SetupOtp, OtpResponse>(
   "/users/:userId/otp_configurations",
-  function* onOtp(ctx, next): ApiGen {
+  function* onOtp(ctx, next) {
     const curOtp = yield* select(selectOtp);
     if (curOtp.id) {
       return;

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,5 +1,5 @@
+import { put, select } from "@app/fx";
 import { createSelector } from "@reduxjs/toolkit";
-import { put, select } from "saga-query";
 
 import { thunks } from "@app/api";
 import {
@@ -187,9 +187,11 @@ export const setResourceStats = thunks.create<
   Pick<ResourceStats, "id" | "type">
 >("add-recent-resource", function* (ctx, next) {
   const id = getResourceStatId(ctx.payload);
-  const resource = yield* select(selectResourceStatsById, {
-    id,
-  });
+  const resource = yield* select((s: AppState) =>
+    selectResourceStatsById(s, {
+      id,
+    }),
+  );
   const now = new Date().toISOString();
   if (!resource) {
     yield* put(

--- a/src/ssh-keys/index.ts
+++ b/src/ssh-keys/index.ts
@@ -34,7 +34,7 @@ export const defaultSshKeyResponse = (
 export const fetchSSHKeys = authApi.get<
   { userId: string },
   HalEmbedded<{ ssh_keys: SshKeyResponse[] }>
->("/users/:userId/ssh_keys", authApi.cache());
+>("/users/:userId/ssh_keys", authApi.cache() as any);
 
 export const addSSHKey = authApi.post<{
   name: string;

--- a/src/system-status/index.ts
+++ b/src/system-status/index.ts
@@ -11,8 +11,8 @@ export const SYSTEM_STATUS_ID = "system-status";
 export const fetchSystemStatus = thunks.create(
   "fetch-system-status",
   function* (_, next) {
-    const resp = yield* call(fetch, STATUSPAGE_URL);
-    const json: StatusResp = yield* call([resp, "json"]);
+    const resp = yield* call(() => fetch(STATUSPAGE_URL));
+    const json: StatusResp = yield* call(() => resp.json());
     yield* put(addData({ [SYSTEM_STATUS_ID]: json.status }));
     yield* next();
   },

--- a/src/test/index.tsx
+++ b/src/test/index.tsx
@@ -1,34 +1,32 @@
-import { prepareStore, selectLoaderById } from "@app/fx";
+import {
+  appRoutes,
+  persistConfig,
+  reducers,
+  rootEntities,
+  tasks,
+} from "@app/app";
+import { bootup } from "@app/bootup";
+import { hasDeployEnvironment, selectEnvironmentById } from "@app/deploy";
+import { parallel, prepareStore, selectLoaderById } from "@app/fx";
+import { testEnv } from "@app/mocks";
+import { resetReducer } from "@app/reset-store";
+import type { AppState } from "@app/types";
 import { Store, configureStore } from "@reduxjs/toolkit";
 import { waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { RouteObject, RouterProvider, createMemoryRouter } from "react-router";
 import { REHYDRATE } from "redux-persist";
 
-import {
-  appRoutes,
-  persistConfig,
-  reducers,
-  rootEntities,
-  sagas,
-} from "@app/app";
-import { bootup } from "@app/bootup";
-import { hasDeployEnvironment, selectEnvironmentById } from "@app/deploy";
-import { testEnv } from "@app/mocks";
-import { resetReducer } from "@app/reset-store";
-import type { AppState } from "@app/types";
-
 export const setupTestStore = (
   initState: Partial<AppState> = {},
 ): { store: Store<AppState> } => {
   const middleware = [];
-  const prepared = prepareStore({
+  const { fx, reducer } = prepareStore({
     reducers: reducers,
-    sagas: sagas,
   });
 
-  middleware.push(...prepared.middleware);
-  const baseReducer = resetReducer(prepared.reducer, persistConfig);
+  middleware.push(fx.middleware as any);
+  const baseReducer = resetReducer(reducer, persistConfig);
 
   const store = configureStore({
     preloadedState: { ...initState, entities: rootEntities },
@@ -37,7 +35,10 @@ export const setupTestStore = (
     middleware: middleware,
   });
 
-  prepared.run();
+  fx.run(function* (): any {
+    const group = yield* parallel(tasks);
+    yield* group;
+  });
 
   return { store: store as any };
 };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,7 +1,8 @@
-import type { ApiCtx } from "@app/fx";
+import type { ApiCtx } from "starfx";
 
 import type { AuthApiError } from "./state";
 
+export type { ApiCtx };
 export type AppCtx<P = any, S = any> = ApiCtx<P, S, { message: string }>;
 export type DeployApiCtx<P = any, S = any> = ApiCtx<P, S, { message: string }>;
 export interface AuthApiCtx<P = any, S = any>

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,5 +1,3 @@
-import type { SagaIterator } from "@app/fx";
-
 // https://stackoverflow.com/a/47636222
 export const excludesFalse = <T>(n?: T): n is T => Boolean(n);
 
@@ -7,8 +5,6 @@ export const excludesFalse = <T>(n?: T): n is T => Boolean(n);
 export type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };
-
-export type ApiGen<RT = void> = SagaIterator<RT>;
 
 export interface Action<T extends string = string> {
   type: T;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,4 +1,4 @@
-import type { QueryState } from "@app/fx";
+import type { QueryState } from "starfx";
 
 import type {
   DeployActivePlan,

--- a/src/ui/hooks/use-env-ops-poller.ts
+++ b/src/ui/hooks/use-env-ops-poller.ts
@@ -1,6 +1,6 @@
+import { useLoader, useQuery } from "@app/fx";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import { useLoader, useQuery } from "saga-query/react";
 
 import {
   cancelEnvOperationsPoll,

--- a/src/ui/hooks/use-latest-code-results.ts
+++ b/src/ui/hooks/use-latest-code-results.ts
@@ -3,9 +3,9 @@ import {
   DeployCodeScanResponse,
   fetchCodeScanResult,
 } from "@app/deploy/code-scan-result";
+import { useCache, useQuery } from "@app/fx";
 import { AppState } from "@app/types";
 import { useSelector } from "react-redux";
-import { useCache, useQuery } from "saga-query/react";
 
 export const useLatestCodeResults = (appId: string) => {
   const appOps = useQuery(fetchAppOperations({ id: appId }));

--- a/src/ui/hooks/use-ssh-key-required.ts
+++ b/src/ui/hooks/use-ssh-key-required.ts
@@ -1,10 +1,10 @@
+import { useCache } from "@app/fx";
 import { fetchSSHKeys } from "@app/ssh-keys";
 import { HalEmbedded } from "@app/types";
 import { selectCurrentUser } from "@app/users";
 import { useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { useCache } from "saga-query/react";
 
 export function useSshKeyRequired(sshKeyUrl: string) {
   const navigate = useNavigate();

--- a/src/ui/hooks/use-trial-notice.ts
+++ b/src/ui/hooks/use-trial-notice.ts
@@ -4,9 +4,9 @@ import {
   selectBillingDetail,
 } from "@app/billing";
 import { timeBetween } from "@app/date";
+import { useCache } from "@app/fx";
 import { HalEmbedded } from "@app/types";
 import { useSelector } from "react-redux";
-import { useCache } from "saga-query/react";
 
 interface StripeSourceResponse {
   id: string;

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,3 +1,3 @@
 export * from "./pages";
 export * from "./layouts";
-export { Loading, ModalPortal } from "./shared";
+export { Loading, ModalPortal, CookieNotice } from "./shared";

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -13,6 +13,7 @@ import {
   selectLatestDeployOp,
   selectServiceById,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import {
   appActivityUrl,
   appConfigUrl,
@@ -28,7 +29,6 @@ import type { AppState, DeployApp } from "@app/types";
 import { useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Outlet, useParams } from "react-router-dom";
-import { useQuery } from "saga-query/react";
 import { usePoller } from "../hooks";
 import {
   ActiveOperationNotice,

--- a/src/ui/layouts/cert-detail-layout.tsx
+++ b/src/ui/layouts/cert-detail-layout.tsx
@@ -5,6 +5,7 @@ import {
   selectCertificateById,
   selectEnvironmentById,
 } from "@app/deploy";
+import { useLoader, useQuery } from "@app/fx";
 import {
   certDetailAppsUrl,
   certDetailEndpointsUrl,
@@ -15,7 +16,6 @@ import type { AppState, DeployCertificate } from "@app/types";
 import { useMemo } from "react";
 import { useSelector } from "react-redux";
 import { Outlet, useParams } from "react-router-dom";
-import { useLoader, useQuery } from "saga-query/react";
 import { usePoller } from "../hooks";
 import {
   CertIssuer,

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -13,6 +13,7 @@ import {
   selectServiceById,
 } from "@app/deploy";
 import { CONTAINER_PROFILES } from "@app/deploy/container/utils";
+import { useQuery } from "@app/fx";
 import {
   databaseActivityUrl,
   databaseBackupsUrl,
@@ -29,7 +30,6 @@ import type { AppState, DeployDatabase, DeployService } from "@app/types";
 import { useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Outlet, useParams } from "react-router-dom";
-import { useQuery } from "saga-query/react";
 import { usePoller } from "../hooks";
 import {
   DetailHeader,

--- a/src/ui/layouts/endpoint-detail-layout.tsx
+++ b/src/ui/layouts/endpoint-detail-layout.tsx
@@ -15,6 +15,7 @@ import {
   selectImageById,
   selectServiceById,
 } from "@app/deploy";
+import { useLoader, useQuery } from "@app/fx";
 import {
   appEndpointsUrl,
   databaseEndpointsUrl,
@@ -34,7 +35,6 @@ import type {
 import { useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, Outlet, useParams } from "react-router-dom";
-import { useLoader, useQuery } from "saga-query/react";
 import { usePoller } from "../hooks";
 import {
   Banner,

--- a/src/ui/layouts/op-detail-layout.tsx
+++ b/src/ui/layouts/op-detail-layout.tsx
@@ -6,12 +6,12 @@ import {
   selectOperationById,
   selectResourceNameByOperationId,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import { activityUrl } from "@app/routes";
 import { capitalize } from "@app/string-utils";
 import type { AppState, DeployOperation } from "@app/types";
 import { useSelector } from "react-redux";
 import { Link, Outlet, useParams } from "react-router-dom";
-import { useQuery } from "saga-query/react";
 import {
   DetailHeader,
   DetailInfoGrid,

--- a/src/ui/layouts/stack-detail-layout.tsx
+++ b/src/ui/layouts/stack-detail-layout.tsx
@@ -1,4 +1,5 @@
 import { fetchStack, getStackType, selectStackById } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import {
   stackDetailEnvsUrl,
   stackDetailHidsUrl,
@@ -12,7 +13,6 @@ import { AppState, DeployStack } from "@app/types";
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Outlet, useParams } from "react-router";
-import { useQuery } from "saga-query/react";
 import {
   CopyText,
   DetailHeader,

--- a/src/ui/pages/app-deploy-configure.tsx
+++ b/src/ui/pages/app-deploy-configure.tsx
@@ -13,6 +13,8 @@ import {
   selectServiceDefinitionsByAppId,
 } from "@app/deploy";
 import { DeployCodeScanResponse } from "@app/deploy";
+import { selectLoaderById } from "@app/fx";
+import { useQuery } from "@app/fx";
 import { idCreator } from "@app/id";
 import {
   DB_ENV_TEMPLATE_KEY,
@@ -26,8 +28,6 @@ import { Reducer, useEffect, useReducer, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
 import { useSearchParams } from "react-router-dom";
-import { selectLoaderById } from "saga-query";
-import { useQuery } from "saga-query/react";
 import {
   useEnvEditor,
   useEnvOpsPoller,

--- a/src/ui/pages/app-deploy-status.test.tsx
+++ b/src/ui/pages/app-deploy-status.test.tsx
@@ -167,7 +167,7 @@ describe("AppDeployStatusPage", () => {
         path: APP_DEPLOY_STATUS_PATH,
         initEntries: [appDeployStatusUrl(`${app.id}`)],
         initState: {
-          "@@saga-query/loaders": {
+          "@@starfx/loaders": {
             [`${deployProject}`]: defaultLoadingItem({
               status: "error",
               message: "Plan limit exceeded",

--- a/src/ui/pages/app-detail-config.tsx
+++ b/src/ui/pages/app-detail-config.tsx
@@ -9,13 +9,13 @@ import {
   selectAppById,
   selectAppConfigById,
 } from "@app/deploy";
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { appActivityUrl } from "@app/routes";
 import { capitalize } from "@app/string-utils";
 import { AppState, DeployApp } from "@app/types";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 import { useEnvEditor, useLatestCodeResults } from "../hooks";
 import {
   AppConfigView,

--- a/src/ui/pages/app-detail-service-metrics.tsx
+++ b/src/ui/pages/app-detail-service-metrics.tsx
@@ -1,31 +1,30 @@
-import { useSelector } from "react-redux";
-import { useParams } from "react-router-dom";
-
+import { dateFromToday } from "@app/date";
 import {
   calcMetrics,
   fetchApp,
   selectReleasesByServiceAfterDate,
   selectServiceById,
 } from "@app/deploy";
+import { selectContainersByCurrentReleaseAndHorizon } from "@app/deploy";
 import { useQuery } from "@app/fx";
-import { AppState, MetricHorizons } from "@app/types";
-
-import { dateFromToday } from "@app/date";
-import { selectContainersByCurrentReleaseAndHorizon } from "@app/deploy/container";
 import {
   fetchAllMetricsByServiceId,
+  metricHorizonAsSeconds,
   selectMetricsLoaded,
 } from "@app/metric-tunnel";
+import { AppState, MetricHorizons } from "@app/types";
 import { useState } from "react";
-import { Loading, LoadingSpinner } from "../shared";
-import { ContainerMetricsChart } from "../shared/container-metrics-chart";
-import { ContainerMetricsDataTable } from "../shared/container-metrics-table";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
 import {
+  ContainerMetricsChart,
+  ContainerMetricsDataTable,
+  Loading,
+  LoadingSpinner,
   MetricTabTypes,
   MetricsHorizonControls,
   MetricsViewControls,
-  metricHorizonAsSeconds,
-} from "../shared/metrics-controls";
+} from "../shared";
 
 const layersToSearchForContainers = ["app"];
 

--- a/src/ui/pages/backup-restore.tsx
+++ b/src/ui/pages/backup-restore.tsx
@@ -1,8 +1,8 @@
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { FormEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
 import { Link } from "react-router-dom";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 
 import { prettyDateTime, prettyDateTimeForBackups } from "@app/date";
 import {

--- a/src/ui/pages/billing-method.tsx
+++ b/src/ui/pages/billing-method.tsx
@@ -10,6 +10,7 @@ import {
   selectPlanByActiveId,
 } from "@app/deploy";
 import { selectEnv } from "@app/env";
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { selectOrganizationSelected } from "@app/organizations";
 import { homeUrl, logoutUrl, plansUrl } from "@app/routes";
 import { AppState } from "@app/types";
@@ -25,7 +26,6 @@ import {
 import { useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useNavigate } from "react-router-dom";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 import { useValidator } from "../hooks";
 import { HeroBgView } from "../layouts";
 import {

--- a/src/ui/pages/cert-detail-apps.tsx
+++ b/src/ui/pages/cert-detail-apps.tsx
@@ -3,10 +3,10 @@ import {
   fetchEndpointsByCertId,
   selectCertificateById,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import { AppState } from "@app/types";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { useQuery } from "saga-query/react";
 import { AppListByCertificate } from "../shared";
 
 export const CertDetailAppsPage = () => {

--- a/src/ui/pages/cert-detail-endpoints.tsx
+++ b/src/ui/pages/cert-detail-endpoints.tsx
@@ -1,6 +1,6 @@
 import { fetchEndpointsByCertId } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import { useParams } from "react-router";
-import { useQuery } from "saga-query/react";
 import { EndpointsByCert } from "../shared";
 
 export const CertDetailEndpointsPage = () => {

--- a/src/ui/pages/cert-detail-settings.tsx
+++ b/src/ui/pages/cert-detail-settings.tsx
@@ -1,7 +1,7 @@
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 
 import {
   deleteCertificate,

--- a/src/ui/pages/create-db.tsx
+++ b/src/ui/pages/create-db.tsx
@@ -1,7 +1,7 @@
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { useEffect, useReducer, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 
 import {
   DbCreatorProps,

--- a/src/ui/pages/create-env-app.tsx
+++ b/src/ui/pages/create-env-app.tsx
@@ -6,6 +6,7 @@ import {
   selectEnvironmentById,
   selectStackById,
 } from "@app/deploy";
+import { useApi, useLoaderSuccess, useQuery } from "@app/fx";
 import { selectOrganizationSelected } from "@app/organizations";
 import {
   appDeployGetStartedUrl,
@@ -21,7 +22,6 @@ import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
-import { useApi, useLoaderSuccess, useQuery } from "saga-query/react";
 import { AppSidebarLayout } from "../layouts";
 import {
   BannerMessages,

--- a/src/ui/pages/create-log-drain.tsx
+++ b/src/ui/pages/create-log-drain.tsx
@@ -4,13 +4,13 @@ import {
   provisionLogDrain,
   selectEnvironmentById,
 } from "@app/deploy";
+import { useLoader, useLoaderSuccess } from "@app/fx";
 import { operationDetailUrl } from "@app/routes";
 import { AppState } from "@app/types";
 import { handleValidator, portValidator } from "@app/validator";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { useLoader, useLoaderSuccess } from "saga-query/react";
 import { useValidator } from "../hooks";
 import { EnvironmentDetailLayout } from "../layouts";
 import {

--- a/src/ui/pages/create-metric-drain.tsx
+++ b/src/ui/pages/create-metric-drain.tsx
@@ -10,10 +10,10 @@ import {
   selectEnvironmentById,
 } from "@app/deploy";
 
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { operationDetailUrl } from "@app/routes";
 import { AppState } from "@app/types";
 import { handleValidator, portValidator } from "@app/validator";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 import { useValidator } from "../hooks";
 import { EnvironmentDetailLayout } from "../layouts";
 import {

--- a/src/ui/pages/create-stack.tsx
+++ b/src/ui/pages/create-stack.tsx
@@ -5,6 +5,8 @@ import {
   selectPlanByActiveId,
 } from "@app/deploy";
 import { createSupportTicket } from "@app/deploy/support";
+import { resetLoaderById } from "@app/fx";
+import { useLoader, useQuery } from "@app/fx";
 import { selectOrganizationSelectedId } from "@app/organizations";
 import { plansUrl, stacksUrl } from "@app/routes";
 import { AppState } from "@app/types";
@@ -13,8 +15,6 @@ import { stackNameRegexExplainer, stackNameValidator } from "@app/validator";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link } from "react-router-dom";
-import { resetLoaderById } from "saga-query";
-import { useLoader, useQuery } from "saga-query/react";
 import { useValidator } from "../hooks";
 import {
   Banner,

--- a/src/ui/pages/db-detail-metrics.tsx
+++ b/src/ui/pages/db-detail-metrics.tsx
@@ -9,24 +9,26 @@ import {
   selectReleasesByServiceAfterDate,
   selectServiceById,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import {
   fetchAllMetricsByServiceId,
+  metricHorizonAsSeconds,
   selectMetricsLoaded,
 } from "@app/metric-tunnel";
 import { AppState, MetricHorizons } from "@app/types";
 import { useState } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { useQuery } from "saga-query/react";
-import { LoadResources, Loading, LoadingSpinner } from "../shared";
-import { ContainerMetricsChart } from "../shared/container-metrics-chart";
-import { ContainerMetricsDataTable } from "../shared/container-metrics-table";
 import {
+  ContainerMetricsChart,
+  ContainerMetricsDataTable,
+  LoadResources,
+  Loading,
+  LoadingSpinner,
   MetricTabTypes,
   MetricsHorizonControls,
   MetricsViewControls,
-  metricHorizonAsSeconds,
-} from "../shared/metrics-controls";
+} from "../shared";
 
 const layersToSearchForContainers = ["database"];
 

--- a/src/ui/pages/endpoint-detail-settings.tsx
+++ b/src/ui/pages/endpoint-detail-settings.tsx
@@ -10,13 +10,13 @@ import {
   selectServiceById,
   updateEndpoint,
 } from "@app/deploy";
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { endpointDetailActivityUrl } from "@app/routes";
 import { AppState } from "@app/types";
 import { ipValidator, portValidator } from "@app/validator";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 import { useValidator } from "../hooks";
 import {
   BannerMessages,

--- a/src/ui/pages/endpoint-detail-setup.tsx
+++ b/src/ui/pages/endpoint-detail-setup.tsx
@@ -1,6 +1,6 @@
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 
 import { checkDns, renewEndpoint, selectEndpointById } from "@app/deploy";
 import { endpointDetailActivityUrl } from "@app/routes";

--- a/src/ui/pages/environment-detail-activity-reports.tsx
+++ b/src/ui/pages/environment-detail-activity-reports.tsx
@@ -4,10 +4,10 @@ import {
   fetchEnvActivityReports,
   selectActivityReportsByEnvId,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import { AppState, DeployActivityReport } from "@app/types";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { useQuery } from "saga-query/react";
 import { usePaginate } from "../hooks";
 import {
   ButtonIcon,

--- a/src/ui/pages/environment-detail-create-cert.tsx
+++ b/src/ui/pages/environment-detail-create-cert.tsx
@@ -1,7 +1,7 @@
+import { useLoader, useLoaderSuccess } from "@app/fx";
 import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate, useParams } from "react-router";
-import { useLoader, useLoaderSuccess } from "saga-query/react";
 
 import { CreateCertProps, createCertificate } from "@app/deploy";
 import { environmentCertificatesUrl } from "@app/routes";

--- a/src/ui/pages/environment-detail-settings.tsx
+++ b/src/ui/pages/environment-detail-settings.tsx
@@ -1,7 +1,7 @@
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 
 import {
   deprovisionEnvironment,

--- a/src/ui/pages/org-picker.tsx
+++ b/src/ui/pages/org-picker.tsx
@@ -1,6 +1,6 @@
+import { batchActions } from "@app/fx";
+import { useQuery } from "@app/fx";
 import { useDispatch, useSelector } from "react-redux";
-import { batchActions } from "saga-query";
-import { useQuery } from "saga-query/react";
 
 import { fetchReauthOrganizations, logout } from "@app/auth";
 import {

--- a/src/ui/pages/settings-add-security-key.tsx
+++ b/src/ui/pages/settings-add-security-key.tsx
@@ -3,7 +3,7 @@ import { useCache, useLoader, useLoaderSuccess } from "@app/fx";
 import { fetchU2fChallenges } from "@app/mfa";
 import { securitySettingsUrl } from "@app/routes";
 import { selectCurrentUserId } from "@app/users";
-import { PublicKeyCredentialCreationOptionsJSON } from "@github/webauthn-json/dist/types/basic/json";
+import { PublicKeyCredentialCreationOptionsJSON } from "node_modules/@github/webauthn-json/dist/types/basic/json";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router";

--- a/src/ui/pages/settings-ssh.tsx
+++ b/src/ui/pages/settings-ssh.tsx
@@ -1,8 +1,8 @@
+import { useCache, useLoader, useLoaderSuccess } from "@app/fx";
 import { SshKeyResponse, fetchSSHKeys, rmSSHKey } from "@app/ssh-keys";
 import { HalEmbedded } from "@app/types";
 import { selectCurrentUser } from "@app/users";
 import { useDispatch, useSelector } from "react-redux";
-import { useCache, useLoader, useLoaderSuccess } from "saga-query/react";
 import {
   AddSSHKeyForm,
   BannerMessages,

--- a/src/ui/pages/settings-team-invite.tsx
+++ b/src/ui/pages/settings-team-invite.tsx
@@ -1,5 +1,6 @@
 import { fetchRoles } from "@app/auth";
 import { selectRolesEditable } from "@app/deploy";
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import { createInvitation } from "@app/invitations";
 import { selectOrganizationSelectedId } from "@app/organizations";
 import { teamMembersUrl, teamPendingInvitesUrl } from "@app/routes";
@@ -8,7 +9,6 @@ import { emailValidator, existValidtor } from "@app/validator";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 import { useValidator } from "../hooks";
 import {
   BannerMessages,

--- a/src/ui/pages/settings-team-members-edit.tsx
+++ b/src/ui/pages/settings-team-members-edit.tsx
@@ -1,6 +1,7 @@
 import { fetchUserRoles, removeUserFromOrg } from "@app/auth";
 import { updateUserMemberships } from "@app/auth/membership";
 import { selectIsAccountOwner, selectRolesEditable } from "@app/deploy";
+import { useCache, useLoader, useLoaderSuccess } from "@app/fx";
 import { selectOrganizationSelected } from "@app/organizations";
 import { RoleResponse } from "@app/roles";
 import { teamMembersUrl } from "@app/routes";
@@ -9,7 +10,6 @@ import { selectCurrentUser, selectUserById } from "@app/users";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
-import { useCache, useLoader, useLoaderSuccess } from "saga-query/react";
 import {
   BannerMessages,
   Box,

--- a/src/ui/pages/settings-team-pending-invites.tsx
+++ b/src/ui/pages/settings-team-pending-invites.tsx
@@ -1,3 +1,4 @@
+import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
 import {
   fetchInvitations,
   resetInvitation,
@@ -7,7 +8,6 @@ import {
 import { selectOrganizationSelectedId } from "@app/organizations";
 import { AppState } from "@app/types";
 import { useDispatch, useSelector } from "react-redux";
-import { useLoader, useLoaderSuccess, useQuery } from "saga-query/react";
 import {
   BannerMessages,
   Button,

--- a/src/ui/pages/sso-token-cli.tsx
+++ b/src/ui/pages/sso-token-cli.tsx
@@ -1,10 +1,10 @@
 import { fetchCurrentToken } from "@app/auth";
 import { selectEnv } from "@app/env";
+import { useApi } from "@app/fx";
 import { selectOrganizationSelectedId } from "@app/organizations";
 import { selectAccessToken } from "@app/token";
 import { useState } from "react";
 import { useSelector } from "react-redux";
-import { useApi } from "saga-query/react";
 import { AppSidebarLayout, HeroBgLayout } from "../layouts";
 import {
   Banner,

--- a/src/ui/pages/stack-detail-hids.tsx
+++ b/src/ui/pages/stack-detail-hids.tsx
@@ -5,12 +5,12 @@ import {
   hasDeployStack,
   selectStackById,
 } from "@app/deploy";
+import { useCache } from "@app/fx";
 import { selectAccessToken } from "@app/token";
 import { AppState, DeployStack, HalEmbedded, LinkResponse } from "@app/types";
 import { useState } from "react";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
-import { useCache } from "saga-query/react";
 import {
   Banner,
   BannerMessages,

--- a/src/ui/pages/stack-detail-vpn-tunnels.tsx
+++ b/src/ui/pages/stack-detail-vpn-tunnels.tsx
@@ -2,12 +2,12 @@ import {
   fetchVpnTunnelsByStackId,
   selectVpnTunnelByStackId,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import { AppState } from "@app/types";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { Link } from "react-router-dom";
-import { useQuery } from "saga-query/react";
 import {
   Box,
   Button,

--- a/src/ui/pages/team-accept-invite.tsx
+++ b/src/ui/pages/team-accept-invite.tsx
@@ -1,6 +1,7 @@
 import { AUTH_LOADER_ID, logout } from "@app/auth";
 import { acceptInvitation } from "@app/auth/accept-invitation";
 import { selectLoaderById } from "@app/fx";
+import { useLoader, useQuery } from "@app/fx";
 import { fetchInvitation, selectInvitationById } from "@app/invitations";
 import { setRedirectPath } from "@app/redirect-path";
 import { homeUrl, loginUrl, teamAcceptInviteUrl } from "@app/routes";
@@ -9,7 +10,6 @@ import { selectCurrentUser } from "@app/users";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router";
-import { useLoader, useQuery } from "saga-query/react";
 import { HeroBgLayout } from "../layouts";
 import { Banner, BannerMessages, Box, Button, Group, Loading } from "../shared";
 

--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -5,6 +5,7 @@ import {
   selectAppById,
   selectServicesByAppId,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import {
   appDeployResumeUrl,
   appServicePathMetricsUrl,
@@ -15,7 +16,6 @@ import { usePaginate } from "@app/ui/hooks";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router";
 import { Link } from "react-router-dom";
-import { useQuery } from "saga-query/react";
 import { ButtonCreate, ButtonLink } from "../button";
 import { Group } from "../group";
 import { PreCode, listToInvertedTextColor } from "../pre-code";

--- a/src/ui/shared/cert-selector.tsx
+++ b/src/ui/shared/cert-selector.tsx
@@ -3,9 +3,9 @@ import {
   getCertLabel,
   selectCertificatesByEnvId,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import { AppState } from "@app/types";
 import { useSelector } from "react-redux";
-import { useQuery } from "saga-query/react";
 import { Select, SelectOption } from "./select";
 
 export const CertSelector = ({

--- a/src/ui/shared/db/backup-list.tsx
+++ b/src/ui/shared/db/backup-list.tsx
@@ -1,5 +1,6 @@
 import { prettyEnglishDateWithTime } from "@app/date";
 import { deleteBackup, selectDatabaseById } from "@app/deploy";
+import { useLoader } from "@app/fx";
 import {
   backupRestoreUrl,
   databaseDetailUrl,
@@ -11,7 +12,6 @@ import cn from "classnames";
 import { ReactElement } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, useNavigate } from "react-router-dom";
-import { useLoader } from "saga-query/react";
 import { BannerMessages } from "../banner";
 import { ButtonCreate, ButtonDestroy } from "../button";
 import { Group } from "../group";

--- a/src/ui/shared/db/credential.tsx
+++ b/src/ui/shared/db/credential.tsx
@@ -4,9 +4,9 @@ import {
   selectCredentialsByDatabaseId,
   selectDatabaseById,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import { AppState, DeployDatabaseCredential } from "@app/types";
 import { useSelector } from "react-redux";
-import { useQuery } from "saga-query/react";
 import { Box } from "../box";
 import { IconAlertTriangle } from "../icons";
 import { Secret } from "../secret";

--- a/src/ui/shared/endpoint/endpoint-list.tsx
+++ b/src/ui/shared/endpoint/endpoint-list.tsx
@@ -15,6 +15,7 @@ import {
   selectEndpointsForTableSearch,
   selectServiceById,
 } from "@app/deploy";
+import { useQuery } from "@app/fx";
 import {
   appDetailUrl,
   appEndpointCreateUrl,
@@ -28,7 +29,6 @@ import { usePaginate } from "@app/ui/hooks";
 import { useSelector } from "react-redux";
 import { useNavigate } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
-import { useQuery } from "saga-query/react";
 import { Button, ButtonCreate } from "../button";
 import { CopyText, CopyTextButton } from "../copy";
 import { Group } from "../group";

--- a/src/ui/shared/endpoint/util.tsx
+++ b/src/ui/shared/endpoint/util.tsx
@@ -1,7 +1,7 @@
+import { useLoader, useLoaderSuccess } from "@app/fx";
 import cn from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router";
-import { useLoader, useLoaderSuccess } from "saga-query/react";
 
 import {
   deprovisionEndpoint,

--- a/src/ui/shared/index.ts
+++ b/src/ui/shared/index.ts
@@ -58,3 +58,7 @@ export * from "./pill";
 export * from "./onboarding-link";
 export * from "./resource-group-box";
 export * from "./csv";
+export * from "./metrics-controls";
+export * from "./cookie-notice";
+export * from "./container-metrics-chart";
+export * from "./container-metrics-table";

--- a/src/ui/shared/load-resources.tsx
+++ b/src/ui/shared/load-resources.tsx
@@ -3,7 +3,7 @@ import type { LoadingState } from "@app/fx";
 import { Loading } from "./loading";
 
 interface LoadResourcesProps {
-  query: LoadingState;
+  query: Omit<LoadingState, "id">;
   children: React.ReactNode;
   isEmpty: boolean;
   empty?: JSX.Element;

--- a/src/ui/shared/metrics-controls.tsx
+++ b/src/ui/shared/metrics-controls.tsx
@@ -4,13 +4,6 @@ import { IconHamburger, IconMetrics } from "./icons";
 
 export type MetricTabTypes = "table" | "chart";
 
-export const metricHorizonAsSeconds = (metricHorizon: MetricHorizons) =>
-  ({
-    "1h": 60 * 60,
-    "1d": 60 * 60 * 24,
-    "1w": 60 * 60 * 24 * 7,
-  })[metricHorizon];
-
 export const MetricsViewControls = ({
   viewMetricTab,
   setViewMetricTab,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
-    "target": "esnext",
     "types": ["vitest/globals"],
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
@@ -11,8 +10,9 @@
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
+    "target": "esnext",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -27,7 +27,7 @@ export default defineConfig(() => {
               "redux",
               "redux-batched-actions",
               "redux-persist",
-              "saga-query",
+              "starfx",
               "qrcode.react",
             ],
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 6
   cacheKey: 8
 
-"@adobe/css-tools@npm:^4.3.0":
+"@adobe/css-tools@npm:^4.3.1":
   version: 4.3.1
   resolution: "@adobe/css-tools@npm:4.3.1"
   checksum: ad43456379ff391132aff687ece190cb23ea69395e23c9b96690eeabe2468da89a4aaf266e4f8b6eaab53db3d1064107ce0f63c3a974e864f4a04affc768da3f
@@ -29,7 +29,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.22.13":
+"@babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.22.13":
   version: 7.22.13
   resolution: "@babel/code-frame@npm:7.22.13"
   dependencies:
@@ -40,32 +40,32 @@ __metadata:
   linkType: hard
 
 "@babel/compat-data@npm:^7.22.9":
-  version: 7.22.9
-  resolution: "@babel/compat-data@npm:7.22.9"
-  checksum: bed77d9044ce948b4327b30dd0de0779fa9f3a7ed1f2d31638714ed00229fa71fc4d1617ae0eb1fad419338d3658d0e9a5a083297451e09e73e078d0347ff808
+  version: 7.23.2
+  resolution: "@babel/compat-data@npm:7.23.2"
+  checksum: d8dc27437d40907b271161d4c88ffe72ccecb034c730deb1960a417b59a14d7c5ebca8cd80dd458a01cd396a7a329eb48cddcc3791b5a84da33d7f278f7bec6a
   languageName: node
   linkType: hard
 
 "@babel/core@npm:^7.22.20":
-  version: 7.23.0
-  resolution: "@babel/core@npm:7.23.0"
+  version: 7.23.2
+  resolution: "@babel/core@npm:7.23.2"
   dependencies:
     "@ampproject/remapping": ^2.2.0
     "@babel/code-frame": ^7.22.13
     "@babel/generator": ^7.23.0
     "@babel/helper-compilation-targets": ^7.22.15
     "@babel/helper-module-transforms": ^7.23.0
-    "@babel/helpers": ^7.23.0
+    "@babel/helpers": ^7.23.2
     "@babel/parser": ^7.23.0
     "@babel/template": ^7.22.15
-    "@babel/traverse": ^7.23.0
+    "@babel/traverse": ^7.23.2
     "@babel/types": ^7.23.0
     convert-source-map: ^2.0.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
     json5: ^2.2.3
     semver: ^6.3.1
-  checksum: cebd9b48dbc970a7548522f207f245c69567e5ea17ebb1a4e4de563823cf20a01177fe8d2fe19b6e1461361f92fa169fd0b29f8ee9d44eeec84842be1feee5f2
+  checksum: 003897718ded16f3b75632d63cd49486bf67ff206cc7ebd1a10d49e2456f8d45740910d5ec7e42e3faf0deec7a2e96b1a02e766d19a67a8309053f0d4e57c0fe
   languageName: node
   linkType: hard
 
@@ -120,7 +120,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.14.5, @babel/helper-module-imports@npm:^7.22.15":
+"@babel/helper-module-imports@npm:^7.22.15":
   version: 7.22.15
   resolution: "@babel/helper-module-imports@npm:7.22.15"
   dependencies:
@@ -176,13 +176,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.22.15, @babel/helper-validator-identifier@npm:^7.22.5":
-  version: 7.22.15
-  resolution: "@babel/helper-validator-identifier@npm:7.22.15"
-  checksum: eb0bee4bda664c0959924bc1ad5611eacfce806f46612202dd164fef1df8fef1a11682a1e7615288987100e9fb304982b6e2a4ff07ffe842ab8765b95ed1118c
-  languageName: node
-  linkType: hard
-
 "@babel/helper-validator-identifier@npm:^7.22.20":
   version: 7.22.20
   resolution: "@babel/helper-validator-identifier@npm:7.22.20"
@@ -197,43 +190,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.23.0":
-  version: 7.23.1
-  resolution: "@babel/helpers@npm:7.23.1"
+"@babel/helpers@npm:^7.23.2":
+  version: 7.23.2
+  resolution: "@babel/helpers@npm:7.23.2"
   dependencies:
     "@babel/template": ^7.22.15
-    "@babel/traverse": ^7.23.0
+    "@babel/traverse": ^7.23.2
     "@babel/types": ^7.23.0
-  checksum: acfc345102045c24ea2a4d60e00dcf8220e215af3add4520e2167700661338e6a80bd56baf44bb764af05ec6621101c9afc315dc107e18c61fa6da8acbdbb893
+  checksum: aaf4828df75ec460eaa70e5c9f66e6dadc28dae3728ddb7f6c13187dbf38030e142194b83d81aa8a31bbc35a5529a5d7d3f3cf59d5d0b595f5dd7f9d8f1ced8e
   languageName: node
   linkType: hard
 
 "@babel/highlight@npm:^7.22.13":
-  version: 7.22.13
-  resolution: "@babel/highlight@npm:7.22.13"
+  version: 7.22.20
+  resolution: "@babel/highlight@npm:7.22.20"
   dependencies:
-    "@babel/helper-validator-identifier": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.20
     chalk: ^2.4.2
     js-tokens: ^4.0.0
-  checksum: 7266d2bff8aa8fc78eb65b6e92a8211e12897a731126a282d2f9bb50d8fcaa4c1b02af2284f990ac7e3ab8d892d448a2cab8f5ed0ea8a90bce2c025b11ebe802
+  checksum: 84bd034dca309a5e680083cd827a766780ca63cef37308404f17653d32366ea76262bd2364b2d38776232f2d01b649f26721417d507e8b4b6da3e4e739f6d134
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.0":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.15, @babel/parser@npm:^7.23.0":
   version: 7.23.0
   resolution: "@babel/parser@npm:7.23.0"
   bin:
     parser: ./bin/babel-parser.js
   checksum: 453fdf8b9e2c2b7d7b02139e0ce003d1af21947bbc03eb350fb248ee335c9b85e4ab41697ddbdd97079698de825a265e45a0846bb2ed47a2c7c1df833f42a354
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.22.15":
-  version: 7.22.16
-  resolution: "@babel/parser@npm:7.22.16"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 944c756b5bdeb07b9fec16ecef6b3c61aff9d4c4b924abadcf01afa1840a740b8e2357ae00482b5b37daad6d2bfd848c947f27ad65138d687b6fdc924bc59edd
   languageName: node
   linkType: hard
 
@@ -259,12 +243,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
-  version: 7.22.15
-  resolution: "@babel/runtime@npm:7.22.15"
+"@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
+  version: 7.23.2
+  resolution: "@babel/runtime@npm:7.23.2"
   dependencies:
     regenerator-runtime: ^0.14.0
-  checksum: 793296df1e41599a935a3d77ec01eb6088410d3fd4dbe4e92f06c6b7bb2f8355024e6d78621a3a35f44e0e23b0b59107f23d585384df4f3123256a1e1492040e
+  checksum: 6c4df4839ec75ca10175f636d6362f91df8a3137f86b38f6cd3a4c90668a0fe8e9281d320958f4fbd43b394988958585a17c3aab2a4ea6bf7316b22916a371fb
   languageName: node
   linkType: hard
 
@@ -279,9 +263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.23.0":
-  version: 7.23.0
-  resolution: "@babel/traverse@npm:7.23.0"
+"@babel/traverse@npm:^7.23.2":
+  version: 7.23.2
+  resolution: "@babel/traverse@npm:7.23.2"
   dependencies:
     "@babel/code-frame": ^7.22.13
     "@babel/generator": ^7.23.0
@@ -293,11 +277,11 @@ __metadata:
     "@babel/types": ^7.23.0
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: 0b17fae53269e1af2cd3edba00892bc2975ad5df9eea7b84815dab07dfec2928c451066d51bc65b4be61d8499e77db7e547ce69ef2a7b0eca3f96269cb43a0b0
+  checksum: 26a1eea0dde41ab99dde8b9773a013a0dc50324e5110a049f5d634e721ff08afffd54940b3974a20308d7952085ac769689369e9127dea655f868c0f6e1ab35d
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.23.0":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.8.3":
   version: 7.23.0
   resolution: "@babel/types@npm:7.23.0"
   dependencies:
@@ -305,17 +289,6 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.22.20
     to-fast-properties: ^2.0.0
   checksum: 215fe04bd7feef79eeb4d33374b39909ce9cad1611c4135a4f7fdf41fe3280594105af6d7094354751514625ea92d0875aba355f53e86a92600f290e77b0e604
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.22.15, @babel/types@npm:^7.22.5, @babel/types@npm:^7.8.3":
-  version: 7.22.17
-  resolution: "@babel/types@npm:7.22.17"
-  dependencies:
-    "@babel/helper-string-parser": ^7.22.5
-    "@babel/helper-validator-identifier": ^7.22.15
-    to-fast-properties: ^2.0.0
-  checksum: 7382220f6eb2548f2c867a98916c3aa8a6063498d5372e5d21d8d184ba354033defb72aeba5858c1b2b42177058b896a34a7dcbae5eccd47fb0104721efa909d
   languageName: node
   linkType: hard
 
@@ -855,65 +828,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redux-saga/core@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "@redux-saga/core@npm:1.2.3"
-  dependencies:
-    "@babel/runtime": ^7.6.3
-    "@redux-saga/deferred": ^1.2.1
-    "@redux-saga/delay-p": ^1.2.1
-    "@redux-saga/is": ^1.1.3
-    "@redux-saga/symbols": ^1.1.3
-    "@redux-saga/types": ^1.2.1
-    redux: ^4.0.4
-    typescript-tuple: ^2.2.1
-  checksum: a18249aa4e771699f103c2e18952d5fc0f65124f88c1fe33f4551b658b5ef7fb2d827091fea3e339c91f324e5d9098f758282d92536e1701bd003812353dd004
-  languageName: node
-  linkType: hard
-
-"@redux-saga/deferred@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@redux-saga/deferred@npm:1.2.1"
-  checksum: 2caca8d2fe559c74889562dbd7fabc6f139cc24871a41122e2ac8e4c98fb1c44a081d0fc762f13c12d6320fd759ee2b799d57141025fef93ae553c09338c3fff
-  languageName: node
-  linkType: hard
-
-"@redux-saga/delay-p@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@redux-saga/delay-p@npm:1.2.1"
-  dependencies:
-    "@redux-saga/symbols": ^1.1.3
-  checksum: 060533ce8ba6b919caa5d47961eb5d8c1d171519fccd5d44208c26a0b94f3f315c8ea440f1b23af70ed53ebd0445b64567d6a0ac9663a6f703dd8088746ce2b5
-  languageName: node
-  linkType: hard
-
-"@redux-saga/is@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@redux-saga/is@npm:1.1.3"
-  dependencies:
-    "@redux-saga/symbols": ^1.1.3
-    "@redux-saga/types": ^1.2.1
-  checksum: 8e24194d365e9a8896fa232a92c09a02a8f881f7a3a0d8004311568762ae3865d40391e4719b789114124f71904160a8942bb285e3fd1611599267bf2ae7d5fc
-  languageName: node
-  linkType: hard
-
-"@redux-saga/symbols@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@redux-saga/symbols@npm:1.1.3"
-  checksum: 65a8ea23c1ab7b122823f1a4d957f881d48fa50f90898c26db65cac6524f22e2f337b768dadfa87324925b41e3279ff1ebce1c4141e53dc19e74855167b49b74
-  languageName: node
-  linkType: hard
-
-"@redux-saga/types@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@redux-saga/types@npm:1.2.1"
-  checksum: 754f183bd1bdd589a29d2b976f666e9ee9e6d28e88268538c11f679d019334999676d5425af14d2a99d5c91c0c87a01e7ac1c4d81a656d93dd529df315bbd0c7
-  languageName: node
-  linkType: hard
-
 "@reduxjs/toolkit@npm:^1.9.6":
-  version: 1.9.6
-  resolution: "@reduxjs/toolkit@npm:1.9.6"
+  version: 1.9.7
+  resolution: "@reduxjs/toolkit@npm:1.9.7"
   dependencies:
     immer: ^9.0.21
     redux: ^4.2.1
@@ -927,7 +844,7 @@ __metadata:
       optional: true
     react-redux:
       optional: true
-  checksum: 61d445f7e084c79f9601f61fcfc4eb65152b850b2a4330239d982297605bd870e63dc1e0211deb3822392cd3bc0c88ca0cdb236a9711a4311dfb199c607b6ac5
+  checksum: ac25dec73a5d2df9fc7fbe98c14ccc73919e5ee1d6f251db0d2ec8f90273f92ef39c26716704bf56b5a40189f72d94b4526dc3a8c7ac3986f5daf44442bcc364
   languageName: node
   linkType: hard
 
@@ -991,83 +908,83 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/tracing@npm:7.73.0":
-  version: 7.73.0
-  resolution: "@sentry-internal/tracing@npm:7.73.0"
+"@sentry-internal/tracing@npm:7.74.0":
+  version: 7.74.0
+  resolution: "@sentry-internal/tracing@npm:7.74.0"
   dependencies:
-    "@sentry/core": 7.73.0
-    "@sentry/types": 7.73.0
-    "@sentry/utils": 7.73.0
+    "@sentry/core": 7.74.0
+    "@sentry/types": 7.74.0
+    "@sentry/utils": 7.74.0
     tslib: ^2.4.1 || ^1.9.3
-  checksum: 7f13f6bfea114310688f664f234e1dd40ca9a9d950f490b613e779bb1a97f49bcf1ad27ced75e7a09294da45e2654155e18e1f03d0b9144170ec65c5a1b7e0e3
+  checksum: 63c220c83f0bb650e8931b1e7a496376ba1cfa0bbd20f9396d25fc888bece7e14fffbc0db71a2ba1aac960b78b788f65ad72d7d931d22b1f3d8dda8792b38239
   languageName: node
   linkType: hard
 
-"@sentry/browser@npm:7.73.0":
-  version: 7.73.0
-  resolution: "@sentry/browser@npm:7.73.0"
+"@sentry/browser@npm:7.74.0":
+  version: 7.74.0
+  resolution: "@sentry/browser@npm:7.74.0"
   dependencies:
-    "@sentry-internal/tracing": 7.73.0
-    "@sentry/core": 7.73.0
-    "@sentry/replay": 7.73.0
-    "@sentry/types": 7.73.0
-    "@sentry/utils": 7.73.0
+    "@sentry-internal/tracing": 7.74.0
+    "@sentry/core": 7.74.0
+    "@sentry/replay": 7.74.0
+    "@sentry/types": 7.74.0
+    "@sentry/utils": 7.74.0
     tslib: ^2.4.1 || ^1.9.3
-  checksum: 315630e884b969459244939275a35b0a1edf4947809916b85670ed32bd497d9e014b9f1940f7e8a2c4cdabf3d11b600a70b1d21e98764f3905692aa15bb34f3e
+  checksum: dafb8e182b41b6afa1e2f44242e2ce91f2ababc2655605e95d664ca48ca913cab9b86033d79ec87e9a71d63d3970dacb1c1ca4e06aa8ed872cf832009f0f48c8
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.73.0":
-  version: 7.73.0
-  resolution: "@sentry/core@npm:7.73.0"
+"@sentry/core@npm:7.74.0":
+  version: 7.74.0
+  resolution: "@sentry/core@npm:7.74.0"
   dependencies:
-    "@sentry/types": 7.73.0
-    "@sentry/utils": 7.73.0
+    "@sentry/types": 7.74.0
+    "@sentry/utils": 7.74.0
     tslib: ^2.4.1 || ^1.9.3
-  checksum: 9f0cd49bb26e7bf59bb5fe8be3f33bf057a0e14ac9adbaa2b4e3a39547f943d1b28a893de2b35eb2166d6d8d4d26ef2d7588893040b217052eabf53773be0434
+  checksum: 8e666f836edc7f76e44329466a16729b3489a27573380261448c623776422f04b1a86f4125cb2fe8617dfcead50e8c45ea0acfecc08f1957afa93acd53ef3111
   languageName: node
   linkType: hard
 
 "@sentry/react@npm:^7.73.0":
-  version: 7.73.0
-  resolution: "@sentry/react@npm:7.73.0"
+  version: 7.74.0
+  resolution: "@sentry/react@npm:7.74.0"
   dependencies:
-    "@sentry/browser": 7.73.0
-    "@sentry/types": 7.73.0
-    "@sentry/utils": 7.73.0
+    "@sentry/browser": 7.74.0
+    "@sentry/types": 7.74.0
+    "@sentry/utils": 7.74.0
     hoist-non-react-statics: ^3.3.2
     tslib: ^2.4.1 || ^1.9.3
   peerDependencies:
     react: 15.x || 16.x || 17.x || 18.x
-  checksum: dcee54e24550f00b53e763f8812b8fc7cb3b2bba6a746eb3f6571f4eeb650c56c712fc255892c701fb4fb6aa7fde6a480bde5ea2fb00bcd15fd4f4df1c81fef9
+  checksum: 5c3905803d87df35e565a63800158d8a8ca42d9ebb800b9e3d089ac0be0420fdf6af986ce26590c871c5bc279bb443d27c7ad4b3ed438ff56f31ff7f682f30a6
   languageName: node
   linkType: hard
 
-"@sentry/replay@npm:7.73.0":
-  version: 7.73.0
-  resolution: "@sentry/replay@npm:7.73.0"
+"@sentry/replay@npm:7.74.0":
+  version: 7.74.0
+  resolution: "@sentry/replay@npm:7.74.0"
   dependencies:
-    "@sentry/core": 7.73.0
-    "@sentry/types": 7.73.0
-    "@sentry/utils": 7.73.0
-  checksum: 4ae9327dd7cb324ac40940bfffedc9d380a346381f1030ea2561fc1549b3b5387874e34fcb62e081c2305290dab5c2b5ac809e4ddb43b0210bf49ec331b51b43
+    "@sentry/core": 7.74.0
+    "@sentry/types": 7.74.0
+    "@sentry/utils": 7.74.0
+  checksum: 9ea0c88d8233c9faccd61873ad83c19c4ece36e29c11dcc896cbe01013652b990ffa32a8c68e87c40c523bc96cd3a190b27a3f960bde4aa894f10e27a9f9a74e
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.73.0":
-  version: 7.73.0
-  resolution: "@sentry/types@npm:7.73.0"
-  checksum: 64f1a52b1fb1e2206a3104021d52704b808a9c021fc7ae6edef18c7024c315595f2bf82f779c665d207ad8af871dbd3cfb1393d451446f907118eb85773ffc67
+"@sentry/types@npm:7.74.0":
+  version: 7.74.0
+  resolution: "@sentry/types@npm:7.74.0"
+  checksum: 2f4b4efaea708f37081d51f8c808afddf0d83680a62730eada655f2155db8c3e0f6b69f7fb48abe46ac2e25f88c611aacfba3d58e4fed592b920b0cbf6fd987e
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.73.0":
-  version: 7.73.0
-  resolution: "@sentry/utils@npm:7.73.0"
+"@sentry/utils@npm:7.74.0":
+  version: 7.74.0
+  resolution: "@sentry/utils@npm:7.74.0"
   dependencies:
-    "@sentry/types": 7.73.0
+    "@sentry/types": 7.74.0
     tslib: ^2.4.1 || ^1.9.3
-  checksum: 02357ff670d58d2152b4f5e81fc26806e7cf75e1693b7df464a3f7dfdf8194fd0bea05ff7babcdca6b81a24faa91265162eb6dfe2bc50d74fe8822516d9ce009
+  checksum: 833d4f83e434448958fbf22585b3661b4b6526b61089813fab5d11ed851f89c20cc2a9ffc9e0292549735563fc1be986f2d593c3bfd5804e8c749c28b6e1ea20
   languageName: node
   linkType: hard
 
@@ -1126,10 +1043,10 @@ __metadata:
   linkType: hard
 
 "@testing-library/jest-dom@npm:^6.1.3":
-  version: 6.1.3
-  resolution: "@testing-library/jest-dom@npm:6.1.3"
+  version: 6.1.4
+  resolution: "@testing-library/jest-dom@npm:6.1.4"
   dependencies:
-    "@adobe/css-tools": ^4.3.0
+    "@adobe/css-tools": ^4.3.1
     "@babel/runtime": ^7.9.2
     aria-query: ^5.0.0
     chalk: ^3.0.0
@@ -1151,7 +1068,7 @@ __metadata:
       optional: true
     vitest:
       optional: true
-  checksum: 5bd14ba31fd3d64cff8ca55cccd335bedadf1db1119643954ca8cd30af835defe6f3a21e7d7617d20205b07abba1b2e668be1b9d6743504800f17fdc4344db75
+  checksum: c6bd9469554136a25d94b55ea16736d56b8c5d200526023774dbf35ca35551a721257e6734f1b404bbd07ae0a1950f1912b5be60e113db2ff2ff50af14f7085c
   languageName: node
   linkType: hard
 
@@ -1186,9 +1103,9 @@ __metadata:
   linkType: hard
 
 "@types/aria-query@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@types/aria-query@npm:5.0.1"
-  checksum: 69fd7cceb6113ed370591aef04b3fd0742e9a1b06dd045c43531448847b85de181495e4566f98e776b37c422a12fd71866e0a1dfd904c5ec3f84d271682901de
+  version: 5.0.2
+  resolution: "@types/aria-query@npm:5.0.2"
+  checksum: 19394fea016e72da39dd5ef1cf1643e3252b7ee99d8f0b3a8740d3b72f874443fc1e00a41935b36fdfaf92cd735d4ae10dc5d6ab8f1192527d4c0471bb8ff8e4
   languageName: node
   linkType: hard
 
@@ -1243,9 +1160,9 @@ __metadata:
   linkType: hard
 
 "@types/chai@npm:*, @types/chai@npm:^4.3.5":
-  version: 4.3.6
-  resolution: "@types/chai@npm:4.3.6"
-  checksum: 32a6c18bf53fb3dbd89d1bfcadb1c6fd45cc0007c34e436393cc37a0a5a556f9e6a21d1e8dd71674c40cc36589d2f30bf4d9369d7787021e54d6e997b0d7300a
+  version: 4.3.8
+  resolution: "@types/chai@npm:4.3.8"
+  checksum: 21431e46fa4a5602641726a24c7631bbf7ba8a41b1a290d0c73dcef6b3521c1d973ee605236b83a978cc918e55470fd04a3109d51aa30dcdf93a8b122e6c3e2c
   languageName: node
   linkType: hard
 
@@ -1256,16 +1173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/debug@npm:^4.1.7":
-  version: 4.1.8
-  resolution: "@types/debug@npm:4.1.8"
-  dependencies:
-    "@types/ms": "*"
-  checksum: a9a9bb40a199e9724aa944e139a7659173a9b274798ea7efbc277cb084bc37d32fc4c00877c3496fac4fed70a23243d284adb75c00b5fdabb38a22154d18e5df
-  languageName: node
-  linkType: hard
-
-"@types/debug@npm:^4.1.9":
+"@types/debug@npm:^4.1.7, @types/debug@npm:^4.1.9":
   version: 4.1.9
   resolution: "@types/debug@npm:4.1.9"
   dependencies:
@@ -1275,12 +1183,12 @@ __metadata:
   linkType: hard
 
 "@types/hoist-non-react-statics@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "@types/hoist-non-react-statics@npm:3.3.1"
+  version: 3.3.3
+  resolution: "@types/hoist-non-react-statics@npm:3.3.3"
   dependencies:
     "@types/react": "*"
     hoist-non-react-statics: ^3.3.0
-  checksum: 2c0778570d9a01d05afabc781b32163f28409bb98f7245c38d5eaf082416fdb73034003f5825eb5e21313044e8d2d9e1f3fe2831e345d3d1b1d20bcd12270719
+  checksum: 107ac20ab36acdc83fb6bfca901e6f4f11307a0a307099c31ecf2a9875f8abffd731a2e1ee793162307e8aaee48fe9fd8d4e034fce88d5da480bc4178a3fc8d7
   languageName: node
   linkType: hard
 
@@ -1292,93 +1200,61 @@ __metadata:
   linkType: hard
 
 "@types/ms@npm:*":
-  version: 0.7.31
-  resolution: "@types/ms@npm:0.7.31"
-  checksum: daadd354aedde024cce6f5aa873fefe7b71b22cd0e28632a69e8b677aeb48ae8caa1c60e5919bb781df040d116b01cb4316335167a3fc0ef6a63fa3614c0f6da
+  version: 0.7.32
+  resolution: "@types/ms@npm:0.7.32"
+  checksum: 610744605c5924aa2657c8a62d307052af4f0e38e2aa015f154ef03391fabb4fd903f9c9baacb41f6e5798b8697e898463c351e5faf638738603ed29137b5254
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 20.6.0
-  resolution: "@types/node@npm:20.6.0"
-  checksum: 52611801af5cf151c6fac1963aa4a8a8ca2e388a9e9ed82b01b70bca762088ded5b32cc789c5564220d5d7dccba2b8dd34446a3d4fc74736805e1f2cf262e29d
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^20.8.2":
-  version: 20.8.2
-  resolution: "@types/node@npm:20.8.2"
-  checksum: 3da73e25d821bfcdb7de98589027e08bb4848e55408671c4a83ec0341e124b5313a0b20e1e4b4eff1168ea17a86f622ad73fcb04b761abd77496b9a27cbd5de5
-  languageName: node
-  linkType: hard
-
-"@types/parse-json@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@types/parse-json@npm:4.0.0"
-  checksum: fd6bce2b674b6efc3db4c7c3d336bd70c90838e8439de639b909ce22f3720d21344f52427f1d9e57b265fcb7f6c018699b99e5e0c208a1a4823014269a6bf35b
+"@types/node@npm:*, @types/node@npm:^20.8.2":
+  version: 20.8.5
+  resolution: "@types/node@npm:20.8.5"
+  dependencies:
+    undici-types: ~5.25.1
+  checksum: 4bca4e4f6307a6f5dc78812015eca9c5a998b35fcf3ba4058c9851d3dde2b22c914fa25a85b804eab5af2ab95375d15943dce8e9ba5e01d15f4bf516ca0d2816
   languageName: node
   linkType: hard
 
 "@types/prop-types@npm:*":
-  version: 15.7.5
-  resolution: "@types/prop-types@npm:15.7.5"
-  checksum: 5b43b8b15415e1f298243165f1d44390403bb2bd42e662bca3b5b5633fdd39c938e91b7fce3a9483699db0f7a715d08cef220c121f723a634972fdf596aec980
+  version: 15.7.8
+  resolution: "@types/prop-types@npm:15.7.8"
+  checksum: 61dfad79da8b1081c450bab83b77935df487ae1cdd4660ec7df6be8e74725c15fa45cf486ce057addc956ca4ae78300b97091e2a25061133d1b9a1440bc896ae
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.0.0":
-  version: 18.2.7
-  resolution: "@types/react-dom@npm:18.2.7"
+"@types/react-dom@npm:^18.0.0, @types/react-dom@npm:^18.2.9":
+  version: 18.2.13
+  resolution: "@types/react-dom@npm:18.2.13"
   dependencies:
     "@types/react": "*"
-  checksum: e02ea908289a7ad26053308248d2b87f6aeafd73d0e2de2a3d435947bcea0422599016ffd1c3e38ff36c42f5e1c87c7417f05b0a157e48649e4a02f21727d54f
+  checksum: 22ba066b141dca5a5a9227fae0afc7c94b470fff8e8a38ade72649da57a8ea04d0cb2ba3e22005e7d8e772d49bddd28855b1dd98e6defd033bba6afb6edff883
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.2.9":
-  version: 18.2.9
-  resolution: "@types/react-dom@npm:18.2.9"
-  dependencies:
-    "@types/react": "*"
-  checksum: d64e58b24549e5b3bb8c792f937061fa80e35a96f0d1757707de5b1377ebce3cf4932f0869bd54cbdf4d321edc7742ae3af03d543306d0f5efb58065b3a0917e
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:*":
-  version: 18.2.21
-  resolution: "@types/react@npm:18.2.21"
+"@types/react@npm:*, @types/react@npm:^18.2.24":
+  version: 18.2.28
+  resolution: "@types/react@npm:18.2.28"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: ffed203bfe7aad772b8286f7953305c9181ac3a8f27d3f5400fbbc2a8e27ca8e5bbff818ee014f39ca0d19d2b3bb154e5bdbec7e232c6f80b59069375aa78349
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^18.2.24":
-  version: 18.2.24
-  resolution: "@types/react@npm:18.2.24"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: ea5d8204e71b1c9c6631f429a93f8e7be0614cdbdb464e92b3181bdccd8a7c45e30ded8b13da726684b6393f651317c36d54832e3d3cdea0da480a3f26268909
+  checksum: 81381bedeba83278f4c9febb0b83e0bd3f42a25897a50b9cb36ef53651d34b3d50f87ebf11211ea57ea575131f85d31e93e496ce46478a00b0f9bf7b26b5917a
   languageName: node
   linkType: hard
 
 "@types/scheduler@npm:*":
-  version: 0.16.3
-  resolution: "@types/scheduler@npm:0.16.3"
-  checksum: 2b0aec39c24268e3ce938c5db2f2e77f5c3dd280e05c262d9c2fe7d890929e4632a6b8e94334017b66b45e4f92a5aa42ba3356640c2a1175fa37bef2f5200767
+  version: 0.16.4
+  resolution: "@types/scheduler@npm:0.16.4"
+  checksum: a57b0f10da1b021e6bd5eeef8a1917dd3b08a8715bd8029e2ded2096d8f091bb1bb1fef2d66e139588a983c4bfbad29b59e48011141725fa83c76e986e1257d7
   languageName: node
   linkType: hard
 
 "@types/set-cookie-parser@npm:^2.4.0":
-  version: 2.4.3
-  resolution: "@types/set-cookie-parser@npm:2.4.3"
+  version: 2.4.4
+  resolution: "@types/set-cookie-parser@npm:2.4.4"
   dependencies:
     "@types/node": "*"
-  checksum: 8c0ded364c5a53598dc58f6c668d6fdbefa3bb78fcb1181202b92f4d8495ca33b4317f54ac0fe42824278e789d730ee5cbd2f7f864466e708589ff4eab2bf457
+  checksum: db6f16639fba5645332d7e1c9c2c35b9466be55622c3e1a376e1dc0d5253c970aa2e67e868788e5c0d3483d7c8b6ab500eca25713717fb674285346959dc5bfd
   languageName: node
   linkType: hard
 
@@ -1641,12 +1517,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:5.1.3, aria-query@npm:^5.0.0":
+"aria-query@npm:5.1.3":
   version: 5.1.3
   resolution: "aria-query@npm:5.1.3"
   dependencies:
     deep-equal: ^2.0.5
   checksum: 929ff95f02857b650fb4cbcd2f41072eee2f46159a6605ea03bf63aa572e35ffdff43d69e815ddc462e16e07de8faba3978afc2813650b4448ee18c9895d982b
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: ^2.0.3
+  checksum: 305bd73c76756117b59aba121d08f413c7ff5e80fa1b98e217a3443fcddb9a232ee790e24e432b59ae7625aebcf4c47cb01c2cac872994f0b426f5bdfcd96ba9
   languageName: node
   linkType: hard
 
@@ -1696,17 +1581,6 @@ __metadata:
   version: 1.0.5
   resolution: "available-typed-arrays@npm:1.0.5"
   checksum: 20eb47b3cefd7db027b9bbb993c658abd36d4edd3fe1060e83699a03ee275b0c9b216cc076ff3f2db29073225fb70e7613987af14269ac1fe2a19803ccc97f1a
-  languageName: node
-  linkType: hard
-
-"babel-plugin-macros@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "babel-plugin-macros@npm:3.1.0"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-    cosmiconfig: ^7.0.0
-    resolve: ^1.19.0
-  checksum: 765de4abebd3e4688ebdfbff8571ddc8cd8061f839bb6c3e550b0344a4027b04c60491f843296ce3f3379fb356cc873d57a9ee6694262547eb822c14a25be9a6
   languageName: node
   linkType: hard
 
@@ -1771,16 +1645,16 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.21.10, browserslist@npm:^4.21.9":
-  version: 4.21.10
-  resolution: "browserslist@npm:4.21.10"
+  version: 4.22.1
+  resolution: "browserslist@npm:4.22.1"
   dependencies:
-    caniuse-lite: ^1.0.30001517
-    electron-to-chromium: ^1.4.477
+    caniuse-lite: ^1.0.30001541
+    electron-to-chromium: ^1.4.535
     node-releases: ^2.0.13
-    update-browserslist-db: ^1.0.11
+    update-browserslist-db: ^1.0.13
   bin:
     browserslist: cli.js
-  checksum: 1e27c0f111a35d1dd0e8fc2c61781b0daefabc2c9471b0b10537ce54843014bceb2a1ce4571af1a82b2bf1e6e6e05d38865916689a158f03bc2c7a4ec2577db8
+  checksum: 7e6b10c53f7dd5d83fd2b95b00518889096382539fed6403829d447e05df4744088de46a571071afb447046abc3c66ad06fbc790e70234ec2517452e32ffd862
   languageName: node
   linkType: hard
 
@@ -1831,13 +1705,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"callsites@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "callsites@npm:3.1.0"
-  checksum: 072d17b6abb459c2ba96598918b55868af677154bec7e73d222ef95a8fdb9bbf7dae96a8421085cdad8cd190d86653b5b6dc55a4484f2e5b2e27d5e0c3fc15b3
-  languageName: node
-  linkType: hard
-
 "camelcase-css@npm:^2.0.1":
   version: 2.0.1
   resolution: "camelcase-css@npm:2.0.1"
@@ -1845,17 +1712,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001517":
-  version: 1.0.30001533
-  resolution: "caniuse-lite@npm:1.0.30001533"
-  checksum: 1ffb2d69f817ee5f13351cb01c26a98ac61515809a6ce355305df3fbc6de6391a58466c1dcad1f322231b1ddc59bdda9bc52b9480cac100c3ff2f5782e859eb1
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001538":
-  version: 1.0.30001543
-  resolution: "caniuse-lite@npm:1.0.30001543"
-  checksum: 1a65c8b0b93913b6241c7d66e1e1f3ea0f194f7e140eefe500512641c2eb4df285991ec9869a1ba2856ea6f6d21e9f3d7bcd91971b5fb1721e3fa0390feec6f1
+"caniuse-lite@npm:^1.0.30001538, caniuse-lite@npm:^1.0.30001541":
+  version: 1.0.30001547
+  resolution: "caniuse-lite@npm:1.0.30001547"
+  checksum: ec0fc2b46721887f6f4aca1f3902f03d9a1a07416d16a86b7cd4bfba60e7b6b03ab3969659d3ea0158cc2f298972c80215c06c9457eb15c649d7780e8f5e91a7
   languageName: node
   linkType: hard
 
@@ -1990,9 +1850,9 @@ __metadata:
   linkType: hard
 
 "cli-spinners@npm:^2.5.0":
-  version: 2.9.0
-  resolution: "cli-spinners@npm:2.9.0"
-  checksum: a9c56e1f44457d4a9f4f535364e729cb8726198efa9e98990cfd9eda9e220dfa4ba12f92808d1be5e29029cdfead781db82dc8549b97b31c907d55f96aa9b0e2
+  version: 2.9.1
+  resolution: "cli-spinners@npm:2.9.1"
+  checksum: 1780618be58309c469205bc315db697934bac68bce78cd5dfd46248e507a533172d623c7348ecfd904734f597ce0a4e5538684843d2cfb7af485d4466699940c
   languageName: node
   linkType: hard
 
@@ -2063,7 +1923,7 @@ __metadata:
     redux: ^4.2.1
     redux-batched-actions: ^0.5.0
     redux-persist: ^6.0.0
-    saga-query: ^9.0.2
+    starfx: ^0.0.33
     tailwindcss: ^3.3.3
     typescript: ^5.2.2
     vite: ^4.4.10
@@ -2154,19 +2014,6 @@ __metadata:
   version: 0.4.2
   resolution: "cookie@npm:0.4.2"
   checksum: a00833c998bedf8e787b4c342defe5fa419abd96b32f4464f718b91022586b8f1bafbddd499288e75c037642493c83083da426c6a9080d309e3bd90fd11baa9b
-  languageName: node
-  linkType: hard
-
-"cosmiconfig@npm:^7.0.0":
-  version: 7.1.0
-  resolution: "cosmiconfig@npm:7.1.0"
-  dependencies:
-    "@types/parse-json": ^4.0.0
-    import-fresh: ^3.2.1
-    parse-json: ^5.0.0
-    path-type: ^4.0.0
-    yaml: ^1.10.0
-  checksum: c53bf7befc1591b2651a22414a5e786cd5f2eeaa87f3678a3d49d6069835a9d8d1aef223728e98aa8fec9a95bf831120d245096db12abe019fecb51f5696c96f
   languageName: node
   linkType: hard
 
@@ -2303,13 +2150,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.1.3, define-properties@npm:^1.1.4, define-properties@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "define-properties@npm:1.2.0"
+"define-data-property@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "define-data-property@npm:1.1.1"
   dependencies:
+    get-intrinsic: ^1.2.1
+    gopd: ^1.0.1
+    has-property-descriptors: ^1.0.0
+  checksum: a29855ad3f0630ea82e3c5012c812efa6ca3078d5c2aa8df06b5f597c1cde6f7254692df41945851d903e05a1668607b6d34e778f402b9ff9ffb38111f1a3f0d
+  languageName: node
+  linkType: hard
+
+"define-properties@npm:^1.1.3, define-properties@npm:^1.1.4, define-properties@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "define-properties@npm:1.2.1"
+  dependencies:
+    define-data-property: ^1.0.1
     has-property-descriptors: ^1.0.0
     object-keys: ^1.1.1
-  checksum: e60aee6a19b102df4e2b1f301816804e81ab48bb91f00d0d935f269bf4b3f79c88b39e4f89eaa132890d23267335fd1140dfcd8d5ccd61031a0a2c41a54e33a6
+  checksum: b4ccd00597dd46cb2d4a379398f5b19fca84a16f3374e2249201992f36b30f6835949a9429669ee6b41b6e837205a163eadd745e472069e70dfc10f03e5fcc12
   languageName: node
   linkType: hard
 
@@ -2324,6 +2183,13 @@ __metadata:
   version: 1.0.0
   resolution: "delegates@npm:1.0.0"
   checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
+  languageName: node
+  linkType: hard
+
+"dequal@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 8679b850e1a3d0ebbc46ee780d5df7b478c23f335887464023a631d1b9af051ad4a6595a44220f9ff8ff95a8ddccf019b5ad778a976fd7bbf77383d36f412f90
   languageName: node
   linkType: hard
 
@@ -2388,10 +2254,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.477":
-  version: 1.4.516
-  resolution: "electron-to-chromium@npm:1.4.516"
-  checksum: e95b1d1d19bcc14f9985a1e76ff06977272a67dd73ab48322cb2828af3d07f7b81c9f796f2ef5d6ccd9b708efba94d2ac5ad60b8c56f4898faf813d6aec1b41c
+"effection@npm:3.0.0-beta.2":
+  version: 3.0.0-beta.2
+  resolution: "effection@npm:3.0.0-beta.2"
+  checksum: 78f0d2dba62f864102b698e31a32a0aeddaaf4ca10cefc39c278d4243b532f9bb6855820517ca3663a5f2ed9d34ff021cdb5cf33cb678423b96ff819de174e57
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.4.535":
+  version: 1.4.553
+  resolution: "electron-to-chromium@npm:1.4.553"
+  checksum: ee1fd847da4277de5630ecfc3fba22e1f429e109d254fed9c798c6d86d0ff97a7655854c4ddc86a814954846d29a912e13f1be7b647d646708c0b4fa69d3d290
   languageName: node
   linkType: hard
 
@@ -2436,15 +2309,6 @@ __metadata:
   version: 2.0.3
   resolution: "err-code@npm:2.0.3"
   checksum: 8b7b1be20d2de12d2255c0bc2ca638b7af5171142693299416e6a9339bd7d88fc8d7707d913d78e0993176005405a236b066b45666b27b797252c771156ace54
-  languageName: node
-  linkType: hard
-
-"error-ex@npm:^1.3.1":
-  version: 1.3.2
-  resolution: "error-ex@npm:1.3.2"
-  dependencies:
-    is-arrayish: ^0.2.1
-  checksum: c1c2b8b65f9c91b0f9d75f0debaa7ec5b35c266c2cac5de412c1a6de86d4cbae04ae44e510378cb14d032d0645a36925d0186f8bb7367bcc629db256b743a001
   languageName: node
   linkType: hard
 
@@ -2736,9 +2600,9 @@ __metadata:
   linkType: hard
 
 "fraction.js@npm:^4.3.6":
-  version: 4.3.6
-  resolution: "fraction.js@npm:4.3.6"
-  checksum: e96ae77e64ebfd442d3a5a01a3f0637b0663fc2440bcf2841b3ad9341ba24c81fb2e3e7142e43ef7d088558c6b3f8609df135b201adc7a1c674aea6a71384162
+  version: 4.3.7
+  resolution: "fraction.js@npm:4.3.7"
+  checksum: e1553ae3f08e3ba0e8c06e43a3ab20b319966dfb7ddb96fd9b5d0ee11a66571af7f993229c88ebbb0d4a816eb813a24ed48207b140d442a8f76f33763b8d1f3f
   languageName: node
   linkType: hard
 
@@ -2798,9 +2662,9 @@ __metadata:
   linkType: hard
 
 "function-bind@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "function-bind@npm:1.1.1"
-  checksum: b32fbaebb3f8ec4969f033073b43f5c8befbb58f1a79e12f1d7490358150359ebd92f49e72ff0144f65f2c48ea2a605bff2d07965f548f6474fd8efd95bf361a
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 2b0ff4ce708d99715ad14a6d1f894e2a83242e4a52ccfcefaee5e40050562e5f6dafc1adbb4ce2d4ab47279a45dc736ab91ea5042d843c3c092820dfe032efb1
   languageName: node
   linkType: hard
 
@@ -2841,14 +2705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-func-name@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "get-func-name@npm:2.0.0"
-  checksum: 8d82e69f3e7fab9e27c547945dfe5cc0c57fc0adf08ce135dddb01081d75684a03e7a0487466f478872b341d52ac763ae49e660d01ab83741f74932085f693c3
-  languageName: node
-  linkType: hard
-
-"get-func-name@npm:^2.0.2":
+"get-func-name@npm:^2.0.1, get-func-name@npm:^2.0.2":
   version: 2.0.2
   resolution: "get-func-name@npm:2.0.2"
   checksum: 3f62f4c23647de9d46e6f76d2b3eafe58933a9b3830c60669e4180d6c601ce1b4aa310ba8366143f55e52b139f992087a9f0647274e8745621fa2af7e0acf13b
@@ -2899,22 +2756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.2":
-  version: 10.3.4
-  resolution: "glob@npm:10.3.4"
-  dependencies:
-    foreground-child: ^3.1.0
-    jackspeak: ^2.0.3
-    minimatch: ^9.0.1
-    minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
-    path-scurry: ^1.10.1
-  bin:
-    glob: dist/cjs/src/bin.js
-  checksum: 176b97c124414401cb51329a93d2ba112cef8814adbed10348481916b9521b677773eee2691cb6b24d66632d8c8bb8913533f5ac4bfb2d0ef5454a1856082361
-  languageName: node
-  linkType: hard
-
-"glob@npm:^10.3.4":
+"glob@npm:^10.2.2, glob@npm:^10.3.4":
   version: 10.3.10
   resolution: "glob@npm:10.3.10"
   dependencies:
@@ -3041,11 +2883,9 @@ __metadata:
   linkType: hard
 
 "has@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "has@npm:1.0.3"
-  dependencies:
-    function-bind: ^1.1.1
-  checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
+  version: 1.0.4
+  resolution: "has@npm:1.0.4"
+  checksum: 8a11ba062e0627c9578a1d08285401e39f1d071a9692ddf793199070edb5648b21c774dd733e2a181edd635bf6862731885f476f4ccf67c998d7a5ff7cef2550
   languageName: node
   linkType: hard
 
@@ -3145,20 +2985,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^10.0.2":
+  version: 10.0.3
+  resolution: "immer@npm:10.0.3"
+  checksum: 76acabe6f40e752028313762ba477a5d901e57b669f3b8fb406b87b9bb9b14e663a6fbbf5a6d1ab323737dd38f4b2494a4e28002045b88948da8dbf482309f28
+  languageName: node
+  linkType: hard
+
 "immer@npm:^9.0.21, immer@npm:^9.0.7":
   version: 9.0.21
   resolution: "immer@npm:9.0.21"
   checksum: 70e3c274165995352f6936695f0ef4723c52c92c92dd0e9afdfe008175af39fa28e76aafb3a2ca9d57d1fb8f796efc4dd1e1cc36f18d33fa5b74f3dfb0375432
-  languageName: node
-  linkType: hard
-
-"import-fresh@npm:^3.2.1":
-  version: 3.3.0
-  resolution: "import-fresh@npm:3.3.0"
-  dependencies:
-    parent-module: ^1.0.0
-    resolve-from: ^4.0.0
-  checksum: 2cacfad06e652b1edc50be650f7ec3be08c5e5a6f6d12d035c440a42a8cc028e60a5b99ca08a77ab4d6b1346da7d971915828f33cdab730d3d42f08242d09baa
   languageName: node
   linkType: hard
 
@@ -3252,13 +3089,6 @@ __metadata:
     get-intrinsic: ^1.2.0
     is-typed-array: ^1.1.10
   checksum: dcac9dda66ff17df9cabdc58214172bf41082f956eab30bb0d86bc0fab1e44b690fc8e1f855cf2481245caf4e8a5a006a982a71ddccec84032ed41f9d8da8c14
-  languageName: node
-  linkType: hard
-
-"is-arrayish@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "is-arrayish@npm:0.2.1"
-  checksum: eef4417e3c10e60e2c810b6084942b3ead455af16c4509959a27e490e7aee87cfb3f38e01bbde92220b528a0ee1a18d52b787e1458ee86174d8c7f0e58cd488f
   languageName: node
   linkType: hard
 
@@ -3489,19 +3319,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jackspeak@npm:^2.0.3":
-  version: 2.3.3
-  resolution: "jackspeak@npm:2.3.3"
-  dependencies:
-    "@isaacs/cliui": ^8.0.2
-    "@pkgjs/parseargs": ^0.11.0
-  dependenciesMeta:
-    "@pkgjs/parseargs":
-      optional: true
-  checksum: 4313a7c0cc44c7753c4cb9869935f0b06f4cf96827515f63f58ff46b3d2f6e29aba6b3b5151778397c3f5ae67ef8bfc48871967bd10343c27e90cff198ec7808
-  languageName: node
-  linkType: hard
-
 "jackspeak@npm:^2.3.5":
   version: 2.3.6
   resolution: "jackspeak@npm:2.3.6"
@@ -3580,13 +3397,6 @@ __metadata:
   bin:
     jsesc: bin/jsesc
   checksum: 4dc190771129e12023f729ce20e1e0bfceac84d73a85bc3119f7f938843fe25a4aeccb54b6494dce26fcf263d815f5f31acdefac7cc9329efb8422a4f4d9fa9d
-  languageName: node
-  linkType: hard
-
-"json-parse-even-better-errors@npm:^2.3.0":
-  version: 2.3.1
-  resolution: "json-parse-even-better-errors@npm:2.3.1"
-  checksum: 798ed4cf3354a2d9ccd78e86d2169515a0097a5c133337807cdf7f1fc32e1391d207ccfc276518cc1d7d8d4db93288b8a50ba4293d212ad1336e52a8ec0a941f
   languageName: node
   linkType: hard
 
@@ -3669,11 +3479,11 @@ __metadata:
   linkType: hard
 
 "loupe@npm:^2.3.6":
-  version: 2.3.6
-  resolution: "loupe@npm:2.3.6"
+  version: 2.3.7
+  resolution: "loupe@npm:2.3.7"
   dependencies:
-    get-func-name: ^2.0.0
-  checksum: cc83f1b124a1df7384601d72d8d1f5fe95fd7a8185469fec48bb2e4027e45243949e7a013e8d91051a138451ff0552310c32aa9786e60b6a30d1e801bdc2163f
+    get-func-name: ^2.0.1
+  checksum: 96c058ec7167598e238bb7fb9def2f9339215e97d6685d9c1e3e4bdb33d14600e11fe7a812cf0c003dfb73ca2df374f146280b2287cae9e8d989e9d7a69a203b
   languageName: node
   linkType: hard
 
@@ -3719,11 +3529,11 @@ __metadata:
   linkType: hard
 
 "magic-string@npm:^0.30.1":
-  version: 0.30.4
-  resolution: "magic-string@npm:0.30.4"
+  version: 0.30.5
+  resolution: "magic-string@npm:0.30.5"
   dependencies:
     "@jridgewell/sourcemap-codec": ^1.4.15
-  checksum: bef57c926d14e9926c142307c1494cc4bdea28a56601a7624f1a5bcd34a63800e2d8a363e826436ce86104460a63ee76c7c185a6ab1f8f7ee5af2de475b98947
+  checksum: da10fecff0c0a7d3faf756913ce62bd6d5e7b0402be48c3b27bfd651b90e29677e279069a63b764bcdc1b8ecdcdb898f29a5c5ec510f2323e8d62ee057a6eb18
   languageName: node
   linkType: hard
 
@@ -3892,9 +3702,9 @@ __metadata:
   linkType: hard
 
 "minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "minipass@npm:7.0.3"
-  checksum: 6f1614f5b5b55568a46bca5fec0e7c46dac027691db27d0e1923a8192866903144cd962ac772c0e9f89b608ea818b702709c042bce98e190d258847d85461531
+  version: 7.0.4
+  resolution: "minipass@npm:7.0.4"
+  checksum: 87585e258b9488caf2e7acea242fd7856bbe9a2c84a7807643513a338d66f368c7d518200ad7b70a508664d408aa000517647b2930c259a8b1f9f0984f344a21
   languageName: node
   linkType: hard
 
@@ -4221,27 +4031,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parent-module@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "parent-module@npm:1.0.1"
-  dependencies:
-    callsites: ^3.0.0
-  checksum: 6ba8b255145cae9470cf5551eb74be2d22281587af787a2626683a6c20fbb464978784661478dd2a3f1dad74d1e802d403e1b03c1a31fab310259eec8ac560ff
-  languageName: node
-  linkType: hard
-
-"parse-json@npm:^5.0.0":
-  version: 5.2.0
-  resolution: "parse-json@npm:5.2.0"
-  dependencies:
-    "@babel/code-frame": ^7.0.0
-    error-ex: ^1.3.1
-    json-parse-even-better-errors: ^2.3.0
-    lines-and-columns: ^1.1.6
-  checksum: 62085b17d64da57f40f6afc2ac1f4d95def18c4323577e1eced571db75d9ab59b297d1d10582920f84b15985cbfc6b6d450ccbf317644cfa176f3ed982ad87e2
-  languageName: node
-  linkType: hard
-
 "parse5@npm:^7.1.2":
   version: 7.1.2
   resolution: "parse5@npm:7.1.2"
@@ -4286,13 +4075,6 @@ __metadata:
   version: 6.2.1
   resolution: "path-to-regexp@npm:6.2.1"
   checksum: f0227af8284ea13300f4293ba111e3635142f976d4197f14d5ad1f124aebd9118783dd2e5f1fe16f7273743cc3dbeddfb7493f237bb27c10fdae07020cc9b698
-  languageName: node
-  linkType: hard
-
-"path-type@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "path-type@npm:4.0.0"
-  checksum: 5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
   languageName: node
   linkType: hard
 
@@ -4419,18 +4201,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.23, postcss@npm:^8.4.27":
-  version: 8.4.29
-  resolution: "postcss@npm:8.4.29"
-  dependencies:
-    nanoid: ^3.3.6
-    picocolors: ^1.0.0
-    source-map-js: ^1.0.2
-  checksum: dd6daa25e781db9ae5b651d9b7bfde0ec6e60e86a37da69a18eb4773d5ddd51e28fc4ff054fbdc04636a31462e6bf09a1e50986f69ac52b10d46b7457cd36d12
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.30, postcss@npm:^8.4.31":
+"postcss@npm:^8.4.23, postcss@npm:^8.4.27, postcss@npm:^8.4.31":
   version: 8.4.31
   resolution: "postcss@npm:8.4.31"
   dependencies:
@@ -4564,7 +4335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-redux@npm:^8.1.3":
+"react-redux@npm:^8.0.5, react-redux@npm:^8.1.3":
   version: 8.1.3
   resolution: "react-redux@npm:8.1.3"
   dependencies:
@@ -4693,15 +4464,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux-saga@npm:^1.2.3":
-  version: 1.2.3
-  resolution: "redux-saga@npm:1.2.3"
-  dependencies:
-    "@redux-saga/core": ^1.2.3
-  checksum: 5c70799272cfbc94e046992d04bbe967e9f86ca3a35aa0c1562e6727e85b96b1a5aae68e180fdbbbc58de453dc22b39d99c81d7c604fbda7c45a8b60a729ef9d
-  languageName: node
-  linkType: hard
-
 "redux-thunk@npm:^2.4.2":
   version: 2.4.2
   resolution: "redux-thunk@npm:2.4.2"
@@ -4711,7 +4473,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:^4.0.4, redux@npm:^4.1.2, redux@npm:^4.2.1":
+"redux@npm:^4.2.1":
   version: 4.2.1
   resolution: "redux@npm:4.2.1"
   dependencies:
@@ -4728,13 +4490,13 @@ __metadata:
   linkType: hard
 
 "regexp.prototype.flags@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "regexp.prototype.flags@npm:1.5.0"
+  version: 1.5.1
+  resolution: "regexp.prototype.flags@npm:1.5.1"
   dependencies:
     call-bind: ^1.0.2
     define-properties: ^1.2.0
-    functions-have-names: ^1.2.3
-  checksum: c541687cdbdfff1b9a07f6e44879f82c66bbf07665f9a7544c5fd16acdb3ec8d1436caab01662d2fbcad403f3499d49ab0b77fbc7ef29ef961d98cc4bc9755b4
+    set-function-name: ^2.0.0
+  checksum: 869edff00288442f8d7fa4c9327f91d85f3b3acf8cbbef9ea7a220345cf23e9241b6def9263d2c1ebcf3a316b0aa52ad26a43a84aa02baca3381717b3e307f47
   languageName: node
   linkType: hard
 
@@ -4759,36 +4521,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-from@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "resolve-from@npm:4.0.0"
-  checksum: f4ba0b8494846a5066328ad33ef8ac173801a51739eb4d63408c847da9a2e1c1de1e6cbbf72699211f3d13f8fc1325648b169bd15eb7da35688e30a5fb0e4a7f
-  languageName: node
-  linkType: hard
-
-"resolve@npm:^1.1.7, resolve@npm:^1.19.0, resolve@npm:^1.22.2":
-  version: 1.22.4
-  resolution: "resolve@npm:1.22.4"
+"resolve@npm:^1.1.7, resolve@npm:^1.22.2":
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
   dependencies:
     is-core-module: ^2.13.0
     path-parse: ^1.0.7
     supports-preserve-symlinks-flag: ^1.0.0
   bin:
     resolve: bin/resolve
-  checksum: 23f25174c2736ce24c6d918910e0d1f89b6b38fefa07a995dff864acd7863d59a7f049e691f93b4b2ee29696303390d921552b6d1b841ed4a8101f517e1d0124
+  checksum: f8a26958aa572c9b064562750b52131a37c29d072478ea32e129063e2da7f83e31f7f11e7087a18225a8561cfe8d2f0df9dbea7c9d331a897571c0a2527dbb4c
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>":
-  version: 1.22.4
-  resolution: "resolve@patch:resolve@npm%3A1.22.4#~builtin<compat/resolve>::version=1.22.4&hash=c3c19d"
+"resolve@patch:resolve@^1.1.7#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.2#~builtin<compat/resolve>":
+  version: 1.22.8
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#~builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
     is-core-module: ^2.13.0
     path-parse: ^1.0.7
     supports-preserve-symlinks-flag: ^1.0.0
   bin:
     resolve: bin/resolve
-  checksum: c45f2545fdc4d21883861b032789e20aa67a2f2692f68da320cc84d5724cd02f2923766c5354b3210897e88f1a7b3d6d2c7c22faeead8eed7078e4c783a444bc
+  checksum: 5479b7d431cacd5185f8db64bfcb7286ae5e31eb299f4c4f404ad8aa6098b77599563ac4257cb2c37a42f59dfc06a1bec2bcf283bb448f319e37f0feb9a09847
   languageName: node
   linkType: hard
 
@@ -4837,21 +4592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^3.27.1":
-  version: 3.29.1
-  resolution: "rollup@npm:3.29.1"
-  dependencies:
-    fsevents: ~2.3.2
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  bin:
-    rollup: dist/bin/rollup
-  checksum: eb92dbb83842f46782257c93e864dd12e9eef72eb98485a70a08026e50f7b557cfff7da71f677a4bd62906e597cc99284bf152b876f814a95b61f5a618a0f43e
-  languageName: node
-  linkType: hard
-
-"rollup@npm:^3.29.2":
+"rollup@npm:^3.27.1, rollup@npm:^3.29.4":
   version: 3.29.4
   resolution: "rollup@npm:3.29.4"
   dependencies:
@@ -4911,30 +4652,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"saga-query@npm:^9.0.2":
-  version: 9.0.2
-  resolution: "saga-query@npm:9.0.2"
-  dependencies:
-    redux: ^4.1.2
-    redux-batched-actions: ^0.5.0
-    redux-saga: ^1.2.3
-    robodux: ^15.0.2
-    typed-redux-saga: ^1.5.0
-  peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-    react-redux: ">=7.2.0"
-  peerDependenciesMeta:
-    react:
-      optional: true
-    react-dom:
-      optional: true
-    react-redux:
-      optional: true
-  checksum: 8b0553a80109c0e977e30d415ea001cee4c05edd42127c24c271d76c9c52884c0242cd75c9d739e150f2591c17fde2526f5fc49d98e7024151ef6ecf7092d942
-  languageName: node
-  linkType: hard
-
 "saxes@npm:^6.0.0":
   version: 6.0.0
   resolution: "saxes@npm:6.0.0"
@@ -4984,6 +4701,17 @@ __metadata:
   version: 2.6.0
   resolution: "set-cookie-parser@npm:2.6.0"
   checksum: bf11ebc594c53d84588f1b4c04f1b8ce14e0498b1c011b3d76b5c6d5aac481bbc3f7c5260ec4ce99bdc1d9aed19f9fc315e73166a36ca74d0f12349a73f6bdc9
+  languageName: node
+  linkType: hard
+
+"set-function-name@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "set-function-name@npm:2.0.1"
+  dependencies:
+    define-data-property: ^1.0.1
+    functions-have-names: ^1.2.3
+    has-property-descriptors: ^1.0.0
+  checksum: 4975d17d90c40168eee2c7c9c59d023429f0a1690a89d75656306481ece0c3c1fb1ebcc0150ea546d1913e35fbd037bace91372c69e543e51fc5d1f31a9fa126
   languageName: node
   linkType: hard
 
@@ -5083,6 +4811,23 @@ __metadata:
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
   checksum: 2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
+  languageName: node
+  linkType: hard
+
+"starfx@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "starfx@npm:0.0.33"
+  dependencies:
+    effection: 3.0.0-beta.2
+    immer: ^10.0.2
+    react-redux: ^8.0.5
+    redux: ^4.2.1
+    redux-batched-actions: ^0.5.0
+    reselect: ^4.1.8
+    robodux: ^15.0.2
+  peerDependencies:
+    react: ^18.2.0
+  checksum: b10792954ba15e0ea370ecf1a9697da7220bad2c5ddc3557899f6b7e4d7aa60d3c239a8dbe5a78705e90a65164799a8bd52c4ea6d26876fffa24835a0a19db35
   languageName: node
   linkType: hard
 
@@ -5430,48 +5175,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typed-redux-saga@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "typed-redux-saga@npm:1.5.0"
-  dependencies:
-    "@babel/helper-module-imports": ^7.14.5
-    babel-plugin-macros: ^3.1.0
-  peerDependencies:
-    redux-saga: ^1.1.3
-  dependenciesMeta:
-    "@babel/helper-module-imports":
-      optional: true
-    babel-plugin-macros:
-      optional: true
-  checksum: 9abf3ae98003e42a09dd0252b00339c6bd3074de2ce7cf1d6b9bc57cf496e7ffe81fc645bb3388bce90aca421204f5f081ba5932f4c63185c96ffafc4d43624e
-  languageName: node
-  linkType: hard
-
-"typescript-compare@npm:^0.0.2":
-  version: 0.0.2
-  resolution: "typescript-compare@npm:0.0.2"
-  dependencies:
-    typescript-logic: ^0.0.0
-  checksum: d6c43213e7689f8519438b6deceb9877cdc83b4f64677bbc07e6d88d8b63bee713035731678facfd3f81b019b93131a876a230194b4f8d31737bfc5af71594d2
-  languageName: node
-  linkType: hard
-
-"typescript-logic@npm:^0.0.0":
-  version: 0.0.0
-  resolution: "typescript-logic@npm:0.0.0"
-  checksum: 84506bd58b7e15455b3233ded7f43f2ff8667500dca94f8e96e61aa16fa5a78bd9c45455f27c49f0e4aee7322c3e5a4b270e68bf8ba29fdf1571256fe2607152
-  languageName: node
-  linkType: hard
-
-"typescript-tuple@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "typescript-tuple@npm:2.2.1"
-  dependencies:
-    typescript-compare: ^0.0.2
-  checksum: 7f9620d6b5c895b2b2a61817b27c6fb32c23fd3f47fef6aef202f387b7d82f2d49a2bab96f9a25b512b8718a70d38a2898a0dfdca623136f7aa9a5b17331da71
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^5.2.2":
   version: 5.2.2
   resolution: "typescript@npm:5.2.2"
@@ -5493,9 +5196,16 @@ __metadata:
   linkType: hard
 
 "ufo@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "ufo@npm:1.3.0"
-  checksum: 01f0be86cd5c205ad1b49ebea985e000a4542c503ee75398302b0f5e4b9a6d9cd8e77af2dc614ab7bea08805fdfd9a85191fb3b5ee3df383cb936cf65e9db30d
+  version: 1.3.1
+  resolution: "ufo@npm:1.3.1"
+  checksum: 2db2f9d24e3f572ddb9b2f4415eda679fd366cbb9eec4c56996651323737f17528b4aab2bb45c5f2effff2304f9b0c46e0981aee3e48f38ac51106a8993dff31
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~5.25.1":
+  version: 5.25.3
+  resolution: "undici-types@npm:5.25.3"
+  checksum: ec9d2cc36520cbd9fbe3b3b6c682a87fe5be214699e1f57d1e3d9a2cb5be422e62735f06e0067dc325fd3dd7404c697e4d479f9147dc8a804e049e29f357f2ff
   languageName: node
   linkType: hard
 
@@ -5531,9 +5241,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.0.11":
-  version: 1.0.11
-  resolution: "update-browserslist-db@npm:1.0.11"
+"update-browserslist-db@npm:^1.0.13":
+  version: 1.0.13
+  resolution: "update-browserslist-db@npm:1.0.13"
   dependencies:
     escalade: ^3.1.1
     picocolors: ^1.0.0
@@ -5541,7 +5251,7 @@ __metadata:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: b98327518f9a345c7cad5437afae4d2ae7d865f9779554baf2a200fdf4bac4969076b679b1115434bd6557376bdd37ca7583d0f9b8f8e302d7d4cc1e91b5f231
+  checksum: 1e47d80182ab6e4ad35396ad8b61008ae2a1330221175d0abd37689658bdb61af9b705bfc41057fd16682474d79944fb2d86767c5ed5ae34b6276b9bed353322
   languageName: node
   linkType: hard
 
@@ -5617,13 +5327,13 @@ __metadata:
   linkType: hard
 
 "vite@npm:^3.0.0 || ^4.0.0 || ^5.0.0-0, vite@npm:^3.1.0 || ^4.0.0 || ^5.0.0-0":
-  version: 5.0.0-beta.4
-  resolution: "vite@npm:5.0.0-beta.4"
+  version: 5.0.0-beta.7
+  resolution: "vite@npm:5.0.0-beta.7"
   dependencies:
     esbuild: ^0.19.3
     fsevents: ~2.3.3
-    postcss: ^8.4.30
-    rollup: ^3.29.2
+    postcss: ^8.4.31
+    rollup: ^3.29.4
   peerDependencies:
     "@types/node": ^18.0.0 || >=20.0.0
     less: "*"
@@ -5652,13 +5362,13 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 98077ffe7b63fa14bf3c9c9e5161e3d5604cadd805ab6ff2a03acad9723283f2eedd362e009f2c8145b70fd90a38453171c927a11847f63e7c1af551196067fd
+  checksum: 0ecd301f279977dbbcc6062eafb1b6f4ffbfa13f49093d9c088087ffbc8ea941cfc37bd2a12b18c29ea42c53943d3ad4a5e4c3167607cf97c37301dfa1693b75
   languageName: node
   linkType: hard
 
 "vite@npm:^4.4.10":
-  version: 4.4.10
-  resolution: "vite@npm:4.4.10"
+  version: 4.4.11
+  resolution: "vite@npm:4.4.11"
   dependencies:
     esbuild: ^0.18.10
     fsevents: ~2.3.2
@@ -5692,7 +5402,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: b5ab3fff97644321a9efd425d54cd841d619abcc4d3167f2c098253f4ed5d92d532a5c72ea0dad2cde3239b5613558a33c62ee77bb7b0ebce608d8e6d4f8a13d
+  checksum: c22145c8385343a629cd546054b9da6eee60327540102bdfd1ad897fd2e78e0763ce6a18a9d84fdefde9da8fd2427d3bec9eb2697b47cf4068c7b4b52f7e3e6a
   languageName: node
   linkType: hard
 
@@ -5955,8 +5665,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.13.0":
-  version: 8.14.1
-  resolution: "ws@npm:8.14.1"
+  version: 8.14.2
+  resolution: "ws@npm:8.14.2"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -5965,7 +5675,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 9e310be2b0ff69e1f87d8c6d093ecd17a1ed4c37f281d17c35e8c30e2bd116401775b3d503249651374e6e0e1e9905db62fff096b694371c77561aee06bc3466
+  checksum: 3ca0dad26e8cc6515ff392b622a1467430814c463b3368b0258e33696b1d4bed7510bc7030f7b72838b9fdeb8dbd8839cbf808367d6aae2e1d668ce741d4308b
   languageName: node
   linkType: hard
 
@@ -6001,13 +5711,6 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
-  languageName: node
-  linkType: hard
-
-"yaml@npm:^1.10.0":
-  version: 1.10.2
-  resolution: "yaml@npm:1.10.2"
-  checksum: ce4ada136e8a78a0b08dc10b4b900936912d15de59905b2bf415b4d33c63df1d555d23acb2a41b23cf9fb5da41c256441afca3d6509de7247daa062fd2c5ea5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR introduces `starfx` into the codebase.  This library intends to replace `redux` and `saga-query`.  This first PR will replace `saga-query`.  The followup PRs will be any bug fixes.  Then we will remove `redux`.

# Why?

While `redux-saga` and `saga-query` work great for our use cases, it's an old codebase with ideas that aren't super relevant in 2023.  So `starfx` was designed from the ground-up to be used for modern web apps.

We also plan on advertising this library and having a production web app using `starfx` will help us harden and figure out the final 1.0 API contract.

https://bower.sh/what-is-starfx

https://github.com/neurosnap/starfx
