### PR TITLE
add-copy-git-remote-jc

### DIFF
--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -22,7 +22,7 @@ import {
 } from "@app/routes";
 import { setResourceStats } from "@app/search";
 import type { AppState, DeployApp } from "@app/types";
-import { useEffect, useMemo } from "react";
+import { SyntheticEvent, useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Outlet, useParams } from "react-router-dom";
 import { useQuery } from "saga-query/react";
@@ -34,11 +34,18 @@ import {
   DetailInfoItem,
   DetailPageHeaderView,
   DetailTitleBar,
+  IconCopy,
   TabItem,
+  Tooltip,
 } from "../shared";
 import { AppSidebarLayout } from "./app-sidebar-layout";
 
 export function AppHeader({ app }: { app: DeployApp }) {
+  const handleCopy = (e: SyntheticEvent, text: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    navigator.clipboard.writeText(text);
+  };
   const lastDeployOp = useSelector((s: AppState) =>
     selectLatestDeployOp(s, { appId: app.id }),
   );
@@ -64,7 +71,19 @@ export function AppHeader({ app }: { app: DeployApp }) {
       <DetailInfoGrid>
         <DetailInfoItem title="ID">{app.id}</DetailInfoItem>
         <div className="col-span-2">
-          <DetailInfoItem title="Git Remote">{app.gitRepo}</DetailInfoItem>
+          <DetailInfoItem title="Git Remote">
+            <div className="flex flex-row items-center">
+              {app.gitRepo}
+              <Tooltip text="Copy">
+                <IconCopy
+                  variant="sm"
+                  className="ml-2 active:opacity-50"
+                  color="#888C90"
+                  onClick={(e) => handleCopy(e, `${app.gitRepo}`)}
+                />
+              </Tooltip>
+            </div>
+          </DetailInfoItem>
         </div>
         <DetailInfoItem title="Last Deployed">
           {lastDeployOp

--- a/src/ui/layouts/endpoint-detail-layout.tsx
+++ b/src/ui/layouts/endpoint-detail-layout.tsx
@@ -80,7 +80,7 @@ export function EndpointAppHeaderInfo({
             <Tooltip text="Copy">
               <IconCopy
                 variant="sm"
-                className="ml-2"
+                className="ml-2 active:opacity-50"
                 color="#888C90"
                 onClick={(e) => handleCopy(e, `${getEndpointUrl(enp)}`)}
               />

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -618,7 +618,7 @@ const Op = ({
               <IconCopy
                 variant="sm"
                 color="#888C90"
-                className="cursor-pointer"
+                className="cursor-pointer active:opacity-50"
                 onClick={(e) =>
                   handleCopy(e, `aptible operation:logs ${op.id}`)
                 }

--- a/src/ui/shared/endpoint/endpoint-list.tsx
+++ b/src/ui/shared/endpoint/endpoint-list.tsx
@@ -85,7 +85,7 @@ const EndpointRow = ({ endpoint }: { endpoint: DeployEndpointRow }) => {
           <Tooltip text="Copy">
             <IconCopy
               variant="sm"
-              className="ml-2"
+              className="ml-2 active:opacity-50"
               color="#888C90"
               onClick={(e) => handleCopy(e, `${getEndpointUrl(endpoint)}`)}
             />

--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -62,7 +62,11 @@ export const PreCode = ({
           className="absolute cursor-pointer bg-black px-2"
           style={{ right: 0, top: 12 }}
         >
-          <IconCopy color="#888C90" onClick={handleCopy} />
+          <IconCopy
+            color="#888C90"
+            className="active:opacity-50"
+            onClick={handleCopy}
+          />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Adds copy icon to git remotes on the app detail header page
• After click, the icon shows feedback
• added feedback to all existing copy icons

<img width="564" alt="Screenshot 2023-09-19 at 8 38 31 PM" src="https://github.com/aptible/app-ui/assets/4295811/7dc35f59-54d1-4e17-9073-92dca533d5e5">
