### PR TITLE
feat(app): add notes field to app settings

### DIFF
--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -75,6 +75,9 @@ export function AppHeader({ app }: { app: DeployApp }) {
         </DetailInfoItem>
         <DetailInfoItem title="Docker Image">{image.dockerRepo}</DetailInfoItem>
       </DetailInfoGrid>
+      <DetailInfoItem title="App Note">
+        <div>Can be deprovisioned after 2023-12-01, confirm with Joe</div>
+      </DetailInfoItem>
     </DetailHeader>
   );
 }

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -43,6 +43,7 @@ import {
   Input,
   Label,
   PreCode,
+  TextArea,
   listToInvertedTextColor,
 } from "../shared";
 
@@ -205,6 +206,10 @@ const AppNameChange = ({ app }: AppProps) => {
       </FormGroup>
 
       <BannerMessages {...loader} />
+
+      <FormGroup label="App Note" htmlFor="app-note">
+        <TextArea name="app-note" type="text" id="app-note" />
+      </FormGroup>
 
       <Group variant="horizontal" size="sm">
         <ButtonCreate


### PR DESCRIPTION
**TODO**
• Allow users to save a App Note
• Show App Note in header ONLY if one exists
• Store App Notes in the backend

<img width="966" alt="Screenshot 2023-09-21 at 10 37 32 PM" src="https://github.com/aptible/app-ui/assets/4295811/9ee84862-aeea-4f0c-a44d-c5ed81ae730a">
<img width="966" alt="Screenshot 2023-09-21 at 10 37 40 PM" src="https://github.com/aptible/app-ui/assets/4295811/40a9489f-627f-4ce9-9486-98538deede74">
