### PR TITLE
support-link-tweaks

### DIFF
--- a/src/ui/shared/application-sidebar.tsx
+++ b/src/ui/shared/application-sidebar.tsx
@@ -165,21 +165,21 @@ export const ApplicationSidebar = () => {
         <UserMenu hideName={collapsed} />
 
         {collapsed ? null : (
-          <div className="my-6 flex justify-between text-xs text-gray-500">
+          <div className="mb-6 mt-4 flex justify-between text-sm text-gray-500">
             <a
-              className="text-gray-500 hover:text-indigo px-3"
+              className="text-gray-500 hover:text-indigo px-2"
               href="https://aptible.com/docs"
             >
               DOCS
             </a>
             <Link
               to={supportUrl()}
-              className="text-gray-500 hover:text-indigo px-3"
+              className="text-gray-500 hover:text-indigo px-2"
             >
               SUPPORT
             </Link>
             <a
-              className="text-gray-500 hover:text-indigo px-3"
+              className="text-gray-500 hover:text-indigo px-2"
               href="https://www.aptible.com/docs/cli"
             >
               INSTALL CLI

--- a/src/ui/shared/application-sidebar.tsx
+++ b/src/ui/shared/application-sidebar.tsx
@@ -165,21 +165,21 @@ export const ApplicationSidebar = () => {
         <UserMenu hideName={collapsed} />
 
         {collapsed ? null : (
-          <div className="mb-6 mt-4 flex justify-between text-sm text-gray-500">
+          <div className="mb-6 mt-4 flex justify-between text-sm text-black-500">
             <a
-              className="text-gray-500 hover:text-indigo px-2"
+              className="text-black-500 hover:text-indigo px-2"
               href="https://aptible.com/docs"
             >
               DOCS
             </a>
             <Link
               to={supportUrl()}
-              className="text-gray-500 hover:text-indigo px-2"
+              className="text-black-500 hover:text-indigo px-2"
             >
               SUPPORT
             </Link>
             <a
-              className="text-gray-500 hover:text-indigo px-2"
+              className="text-black-500 hover:text-indigo px-2"
               href="https://www.aptible.com/docs/cli"
             >
               INSTALL CLI


### PR DESCRIPTION
Make Support link easier to click

BEFORE
<img width="442" alt="Screenshot 2023-09-22 at 2 27 26 PM" src="https://github.com/aptible/app-ui/assets/4295811/425df1e3-eaa2-4227-b2f4-6e8f334a66b7">

AFTER
<img width="441" alt="Screenshot 2023-09-22 at 2 27 19 PM" src="https://github.com/aptible/app-ui/assets/4295811/4bf4568b-f83e-465a-9797-40c6d5d1ea3a">
