### PR TITLE
fix(elevate): infinite loop

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -193,7 +193,7 @@ function* requestMetricTunnel(ctx: ApiCtx, next: Next): ApiGen {
 function* expiredToken(ctx: ApiCtx, next: Next) {
   yield* next();
   if (!ctx.response) return;
-  if (ctx.response.status === 401) {
+  if (ctx.req().method === "GET" && ctx.response.status === 401) {
     yield* put(resetToken());
     ctx.actions.push(resetToken());
   }


### PR DESCRIPTION
Impacted users:
- Users with OTP; and
- Users without SSH keys

This regression was caused by us trying to fix:
- User goes to app logged in via cookie
- User's token expired while still using app
- User should get sent to `/login` page

Unfortunately this caused an issue for users with OTP trying to elevate their token.  When we try to `POST /tokens` with no otp token the API responds with a `401` which is what we use to determine if the token is not longer valid.

This was not an issue when a user logging in for the first time because they are already on the `/login` page.

Current solution is to only redirect to login when a `GET` request returns a `401`.