### PR TITLE
refactor(ops): redirect to more relevant pages

### DIFF
--- a/src/app/test/app-detail-service-scale.test.tsx
+++ b/src/app/test/app-detail-service-scale.test.tsx
@@ -57,7 +57,10 @@ describe("AppDetailServiceScalePage", () => {
     expect(btn).toBeEnabled();
     fireEvent.click(btn);
 
-    expect(await screen.findByText("Operation Details")).toBeInTheDocument();
+    expect(await screen.findByText("App Details")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Operations show real-time/),
+    ).toBeInTheDocument();
   });
 
   describe("when changing container profile", () => {

--- a/src/app/test/db-detail-scale.test.tsx
+++ b/src/app/test/db-detail-scale.test.tsx
@@ -80,7 +80,10 @@ describe("DatabaseScalePage", () => {
     expect(btn).toBeEnabled();
     fireEvent.click(btn);
 
-    expect(await screen.findByText("Operation Details")).toBeInTheDocument();
+    expect(await screen.findByText("Database Details")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Operations show real-time/),
+    ).toBeInTheDocument();
   });
 
   describe("when changing container profile", () => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -292,6 +292,9 @@ const apiHandlers = [
       ),
     );
   }),
+  rest.get(`${testEnv.apiUrl}/services/:id/operations`, async (_, res, ctx) => {
+    return res(ctx.json({ _embedded: { operations: [] } }));
+  }),
   rest.post(
     `${testEnv.apiUrl}/services/:id/operations`,
     async (req, res, ctx) => {

--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -12,7 +12,7 @@ import {
   selectServiceById,
 } from "@app/deploy";
 import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
-import { operationDetailUrl } from "@app/routes";
+import { appActivityUrl } from "@app/routes";
 import { AppState, InstanceClass } from "@app/types";
 import { SyntheticEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -98,7 +98,7 @@ export const AppDetailServiceScalePage = () => {
     service.containerMemoryLimitMb !== containerSize;
 
   useLoaderSuccess(loader, () => {
-    navigate(operationDetailUrl(loader.meta.opId));
+    navigate(appActivityUrl(app.id));
   });
 
   const currentContainerProfile = getContainerProfileFromType(

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -16,7 +16,7 @@ import {
   updateApp,
 } from "@app/deploy";
 import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
-import { environmentAppsUrl, operationDetailUrl } from "@app/routes";
+import { appActivityUrl, environmentAppsUrl } from "@app/routes";
 import {
   AppState,
   DeployApp,
@@ -119,7 +119,7 @@ const AppRestart = ({ app }: AppProps) => {
     dispatch(action);
   };
   useLoaderSuccess(loader, () => {
-    navigate(operationDetailUrl(loader.meta.opId));
+    navigate(appActivityUrl(app.id));
   });
 
   return (

--- a/src/ui/pages/db-detail-scale.tsx
+++ b/src/ui/pages/db-detail-scale.tsx
@@ -14,7 +14,7 @@ import {
   selectServiceById,
 } from "@app/deploy";
 import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
-import { operationDetailUrl } from "@app/routes";
+import { databaseActivityUrl } from "@app/routes";
 import { AppState, InstanceClass } from "@app/types";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -103,7 +103,7 @@ export const DatabaseScalePage = () => {
   }, [disk.size]);
 
   useLoaderSuccess(loader, () => {
-    navigate(operationDetailUrl(loader.meta.opId));
+    navigate(databaseActivityUrl(database.id));
   });
 
   const changesExist =

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -15,7 +15,7 @@ import {
   updateDatabase,
 } from "@app/deploy";
 import { useLoader, useLoaderSuccess, useQuery } from "@app/fx";
-import { environmentDatabasesUrl, operationDetailUrl } from "@app/routes";
+import { databaseActivityUrl, environmentDatabasesUrl } from "@app/routes";
 import {
   AppState,
   DeployDatabase,
@@ -241,7 +241,7 @@ const DatabaseRestart = ({ database }: DbProps) => {
     dispatch(action);
   };
   useLoaderSuccess(loader, () => {
-    navigate(operationDetailUrl(loader.meta.opId));
+    navigate(databaseActivityUrl(database.id));
   });
   return (
     <>


### PR DESCRIPTION
When a user creates operations we sometimes don't have a good place to send them so we redirect to the operation detail page.

This is fine but not great.  We have some better places to send the user now -- mostly resource detail activity tabs.