### PR TITLE
Feat(app) env vars tooltip

### DIFF
--- a/src/ui/layouts/op-detail-layout.tsx
+++ b/src/ui/layouts/op-detail-layout.tsx
@@ -18,7 +18,9 @@ import {
   DetailInfoItem,
   DetailPageHeaderView,
   DetailTitleBar,
+  IconInfo,
   OpStatus,
+  Tooltip,
 } from "../shared";
 import { AppSidebarLayout } from "./app-sidebar-layout";
 
@@ -42,7 +44,17 @@ export function OpHeader({
       />
 
       <DetailInfoGrid>
-        <DetailInfoItem title="Type">{capitalize(op.type)}</DetailInfoItem>
+        <DetailInfoItem title="Type">
+          <div className="flex items-center">
+            {capitalize(op.type)}
+            <Tooltip
+              className="text-sm w-[100vw]"
+              text="Env Vars: VALUE, VALUE, VALUE"
+            >
+              <IconInfo className="h-5 opacity-50 hover:opacity-100" />
+            </Tooltip>
+          </div>
+        </DetailInfoItem>
         <DetailInfoItem title="Created">
           {capitalize(prettyEnglishDateWithTime(op.createdAt))}
         </DetailInfoItem>

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -42,6 +42,7 @@ import { ResourceHeader, ResourceListView } from "./resource-list-view";
 import { EnvStackCell } from "./resource-table";
 import { TableHead, Td } from "./table";
 import { tokens } from "./tokens";
+import { Pill } from "./pill";
 
 interface OpCellProps {
   op: DeployActivityRow;
@@ -80,7 +81,8 @@ const getImageForResourceType = (resourceType: ResourceType) => {
 
 const OpTypeCell = ({ op }: OpCellProps) => {
   return (
-    <Td className="flex-1">
+    <Td className="flex gap-2 items-start flex-row align-top">
+      <div>
       <Link
         to={operationDetailUrl(op.id)}
         className={tokens.type["table link"]}
@@ -88,6 +90,14 @@ const OpTypeCell = ({ op }: OpCellProps) => {
         {capitalize(op.type)}
       </Link>
       <div>ID: {op.id}</div>
+      </div>
+      <Tooltip
+                  text="Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases."
+                >
+      <Pill>
+          ENV
+        </Pill>
+        </Tooltip>
     </Td>
   );
 };

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -38,11 +38,11 @@ import { InputSearch } from "./input";
 import { LoadResources } from "./load-resources";
 import { LoadingSpinner } from "./loading";
 import { OpStatus } from "./op-status";
+import { Pill } from "./pill";
 import { ResourceHeader, ResourceListView } from "./resource-list-view";
 import { EnvStackCell } from "./resource-table";
 import { TableHead, Td } from "./table";
 import { tokens } from "./tokens";
-import { Pill } from "./pill";
 
 interface OpCellProps {
   op: DeployActivityRow;
@@ -81,23 +81,19 @@ const getImageForResourceType = (resourceType: ResourceType) => {
 
 const OpTypeCell = ({ op }: OpCellProps) => {
   return (
-    <Td className="flex gap-2 items-start flex-row align-top">
-      <div>
+    <Td>
       <Link
         to={operationDetailUrl(op.id)}
         className={tokens.type["table link"]}
       >
-        {capitalize(op.type)}
+        <div className="flex items-center">
+          {capitalize(op.type)}
+          <Tooltip fluid text="Env Vars: VALUE, VALUE, VALUE">
+            <IconInfo className="h-5 -mt-0.5 opacity-50 hover:opacity-100" />
+          </Tooltip>
+        </div>
       </Link>
       <div>ID: {op.id}</div>
-      </div>
-      <Tooltip
-                  text="Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases.Operations show real-time changes to resources, such as Apps and Databases."
-                >
-      <Pill>
-          ENV
-        </Pill>
-        </Tooltip>
     </Td>
   );
 };


### PR DESCRIPTION
**DO NOT MERGE**
• Should only show for **Configure** operations

Design Exploration for showing ENV VARS in-app on the activity page

Activity Page
<img width="381" alt="Screenshot 2023-09-27 at 12 46 39 PM" src="https://github.com/aptible/app-ui/assets/4295811/d6f3abe5-3e0c-47af-86b7-05a7f462cae5">

Operation Details Page
<img width="360" alt="Screenshot 2023-09-27 at 12 46 55 PM" src="https://github.com/aptible/app-ui/assets/4295811/ac27d3d3-cbba-4d9b-bbb3-d5c84741c000">

