### PR TITLE
fix(app):remove cancel button on backup retention policy form

### DIFF
--- a/src/ui/shared/environment/backup-retention-policy-view.tsx
+++ b/src/ui/shared/environment/backup-retention-policy-view.tsx
@@ -162,10 +162,6 @@ export const BackupRpView = ({ envId }: { envId: string }) => {
           <ButtonAdmin type="submit" envId={envId} isLoading={loader.isLoading}>
             Save Policy
           </ButtonAdmin>
-
-          <Button variant="white" onClick={onReset}>
-            Cancel
-          </Button>
         </div>
       </form>
     </Box>

--- a/src/ui/shared/environment/backup-retention-policy-view.tsx
+++ b/src/ui/shared/environment/backup-retention-policy-view.tsx
@@ -13,7 +13,7 @@ import type { AppState } from "@app/types";
 import { useValidator } from "../../hooks";
 import { BannerMessages } from "../banner";
 import { Box } from "../box";
-import { Button, ButtonAdmin } from "../button";
+import { ButtonAdmin } from "../button";
 import { FormGroup } from "../form-group";
 import { Input } from "../input";
 import { Radio, RadioGroup } from "../select";


### PR DESCRIPTION
Remove Cancel Button on Backup Retention Policy Form

BEFORE
<img width="438" alt="Screenshot 2023-09-28 at 12 18 16 AM" src="https://github.com/aptible/app-ui/assets/4295811/ee56f40e-bf3f-4172-bff7-f825c574422a">


AFTER
<img width="340" alt="Screenshot 2023-09-28 at 12 19 35 AM" src="https://github.com/aptible/app-ui/assets/4295811/d679d00c-6324-41ef-bf16-64a8e514d70c">

