### PR TITLE
style(app): tighten spacing on how to deploy changes box

### DIFF
--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -233,11 +233,11 @@ export const AppSettingsPage = () => {
   return (
     <BoxGroup>
       <Box>
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-start">
           <h3 className="text-lg text-gray-500">How To Deploy Changes</h3>
           <ButtonLinkDocs href="https://www.aptible.com/docs/deployment-guides" />
         </div>
-        <div className="mt-4">
+        <div className="mt-1">
           <h4 className={tokens.type.h4}>Clone project code</h4>
           <PreCode
             allowCopy

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -267,7 +267,7 @@ export const DatabaseSettingsPage = () => {
   return (
     <BoxGroup>
       <Box>
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-start">
           <h1 className="text-lg text-gray-500 mb-4">Database Settings</h1>
           <ButtonLinkDocs href="https://www.aptible.com/docs/managing-databases" />
         </div>

--- a/src/ui/pages/stack-detail-vpc-peering.tsx
+++ b/src/ui/pages/stack-detail-vpc-peering.tsx
@@ -85,7 +85,7 @@ export const StackDetailVpcPeeringPage = () => {
   return (
     <div className="mb-4">
       <Box className="mb-4">
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-start">
           <p className="flex mb-4 text-gray-500 text-md">
             Contact support to edit or add new VPC Peers.
           </p>

--- a/src/ui/pages/stack-detail-vpn-tunnels.tsx
+++ b/src/ui/pages/stack-detail-vpn-tunnels.tsx
@@ -29,7 +29,7 @@ export const StackDetailVpnTunnelsPage = () => {
   return (
     <div className="mb-4">
       <Box className="mb-4">
-        <div className="flex justify-between items-center">
+        <div className="flex justify-between items-start">
           <p className="flex mb-4 text-gray-500 text-md">
             Contact support to edit or add new VPN Tunnels.
           </p>


### PR DESCRIPTION
Tighten spacing on How to Deploy Changes block

BEFORE
<img width="1147" alt="Screenshot 2023-09-28 at 10 38 36 AM" src="https://github.com/aptible/app-ui/assets/4295811/3c361ef2-cc4a-4cd8-a96f-fca3b1e50191">

AFTER
<img width="1138" alt="Screenshot 2023-09-28 at 10 37 20 AM" src="https://github.com/aptible/app-ui/assets/4295811/97c84bc4-e069-4152-a666-9bf163764733">

