### PR TITLE
fix(credit-card): use production stripe key for prod build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,7 @@ jobs:
             VITE_ORIGIN=app
             VITE_METRIC_TUNNEL_URL=https://metrictunnel-nextgen.aptible.com
             VITE_TUNA_ENABLED=true
+            VITE_STRIPE_PUBLISHABLE_KEY=${{ secrets.STRIPE_PUBLISHABLE_KEY }}
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ ARG VITE_API_URL=https://api.aptible.com
 ARG VITE_LEGACY_DASHBOARD_URL=https://dashboard.aptible.com
 ARG VITE_METRIC_TUNNEL_URL=https://metrictunnel.aptible.com
 ARG VITE_ORIGIN=app
-ARG VITE_SENTRY_DSN
 ARG VITE_TUNA_ENABLED=false
 ARG NODE_ENV=production
+ARG VITE_SENTRY_DSN
+ARG VITE_STRIPE_PUBLISHABLE_KEY
 
 RUN corepack enable
 RUN corepack prepare yarn@stable --activate


### PR DESCRIPTION
https://aptible.slack.com/archives/C022BUSF0B1/p1696008899449919

> 'Stripe::InvalidRequestError: No such token: 'xxx'; a similar object exists in test mode, but a live mode key was used to make this request.' 