### PR TITLE
refactor selectActivityByApp to include services

### DIFF
--- a/src/deploy/service/index.ts
+++ b/src/deploy/service/index.ts
@@ -257,13 +257,11 @@ export const fetchServicesByAppId = api.get<{ id: string }>(
 
 export const fetchServiceOperations = api.get<{ id: string }>(
   "/services/:id/operations",
-  api.cache(),
 );
 export const cancelServicesOpsPoll = createAction("cancel-services-ops-poll");
 export const pollServiceOperations = api.get<{ id: string }>(
   ["/services/:id/operations", "poll"],
   { saga: poll(5 * 1000, `${cancelServicesOpsPoll}`) },
-  api.cache(),
 );
 
 export const serviceEntities = {

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -9,7 +9,6 @@ import {
   fetchDatabase,
   fetchEnvironmentById,
   fetchOrgOperations,
-  fetchServiceOperations,
   fetchServicesByAppId,
   getResourceUrl,
   pollAppOperations,
@@ -358,13 +357,13 @@ export function ActivityByApp({ appId }: { appId: string }) {
 export function ActivityByDatabase({ dbId }: { dbId: string }) {
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
-  const loader = useLoader(pollDatabaseOperations);
+  const action = pollDatabaseOperations({ id: dbId });
+  const loader = useLoader(action);
   const db = useSelector((s: AppState) => selectDatabaseById(s, { id: dbId }));
   useQuery(fetchEnvironmentById({ id: db.environmentId }));
   useQuery(fetchDatabase({ id: dbId }));
-  useQuery(fetchServiceOperations({ id: db.serviceId }));
 
-  const poller = useMemo(() => pollDatabaseOperations({ id: dbId }), [dbId]);
+  const poller = useMemo(() => action, [dbId]);
   const cancel = useMemo(() => cancelDatabaseOpsPoll(), []);
   usePoller({
     action: poller,

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -20,6 +20,7 @@ import {
   selectActivityForTableSearch,
   selectAppById,
   selectDatabaseById,
+  selectServicesByAppId
 } from "@app/deploy";
 import { useLoader, useQuery } from "@app/fx";
 import { operationDetailUrl } from "@app/routes";
@@ -328,7 +329,10 @@ export function ActivityByApp({ appId }: { appId: string }) {
   const onChange = (ev: React.ChangeEvent<HTMLInputElement>) =>
     setParams({ search: ev.currentTarget.value }, { replace: true });
 
-  const resourceIds = useMemo(() => [appId], [appId]);
+  const services = useSelector((s: AppState) =>
+    selectServicesByAppId(s, { appId }),
+  ).map(service => service.id)
+  const resourceIds = [appId, ...services]
   const ops = useSelector((s: AppState) =>
     selectActivityForTableSearch(s, {
       search,

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -20,7 +20,7 @@ import {
   selectActivityForTableSearch,
   selectAppById,
   selectDatabaseById,
-  selectServicesByAppId
+  selectServicesByAppId,
 } from "@app/deploy";
 import { useLoader, useQuery } from "@app/fx";
 import { operationDetailUrl } from "@app/routes";
@@ -331,8 +331,8 @@ export function ActivityByApp({ appId }: { appId: string }) {
 
   const services = useSelector((s: AppState) =>
     selectServicesByAppId(s, { appId }),
-  ).map(service => service.id)
-  const resourceIds = [appId, ...services]
+  ).map((service) => service.id);
+  const resourceIds = [appId, ...services];
   const ops = useSelector((s: AppState) =>
     selectActivityForTableSearch(s, {
       search,


### PR DESCRIPTION
Had a bug (https://aptible.zendesk.com/agent/tickets/49443) where the App's activity page would not show the services activity as well ie the scale operations from the service.

- Refactor `ActivityByApp` to include the App's services as well.