### PR TITLE
style: make checkbox click targets fit their content width

### DIFF
--- a/src/ui/shared/input.tsx
+++ b/src/ui/shared/input.tsx
@@ -73,7 +73,7 @@ export const CheckBox = ({
   label,
   ...props
 }: InputProps & { label: React.ReactNode }) => (
-  <label className="flex">
+  <label className="flex w-fit">
     <Input
       type="checkbox"
       className={`rounded-lg h-6 ${className}`}


### PR DESCRIPTION
Changes
• Currently checkbox click targets span beyond the label text length into empty whitespace
• This change makes only the checkbox + the label text clickable to prevent accidental clicks

BEFORE

https://github.com/aptible/app-ui/assets/4295811/3e02c341-0868-4b6d-bdf1-1f2c6000456a

AFTER

https://github.com/aptible/app-ui/assets/4295811/e6dc1595-7c42-4ce2-a0d6-e223e8f285e1

