### PR TITLE
fix: including `date-fns` into our vendor bundle breaks the app

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -10,6 +10,7 @@ export default defineConfig(() => {
         output: {
           manualChunks: {
             chart: ["react-chartjs-2", "chart.js", "chartjs-adapter-date-fns"],
+            // NOTICE: do not include `date-fns` it breaks the build
             vendor: [
               "@github/webauthn-json",
               "@reduxjs/toolkit",
@@ -17,7 +18,6 @@ export default defineConfig(() => {
               "@stripe/react-stripe-js",
               "@stripe/stripe-js",
               "classnames",
-              "date-fns",
               "debug",
               "react",
               "react-dom",
@@ -36,6 +36,9 @@ export default defineConfig(() => {
     },
     plugins: [react(), tsconfigPaths()],
     server: {
+      port: 4200,
+    },
+    preview: {
       port: 4200,
     },
     test: {


### PR DESCRIPTION
It's unclear why so I just added a notice to make it clear to never include it in our vendor bundle.

We might want to investigate a different library for our date formatting