### PR TITLE
fix: remove duplicate of service type

### DIFF
--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -40,9 +40,6 @@ const ServiceListRow = ({
             {service.processType}
           </div>
           <div className={tokens.type["normal lighter"]}>ID: {service.id}</div>
-          <div className={tokens.type["normal lighter"]}>
-            {service.processType}
-          </div>
         </Td>
 
         <Td className="flex-1">


### PR DESCRIPTION
No need to show service type 2x

BEFORE

<img width="505" alt="Screenshot 2023-10-06 at 4 29 24 PM" src="https://github.com/aptible/app-ui/assets/4295811/000acb9b-b6aa-4638-9205-47adc39f598a">

AFTER
<img width="504" alt="Screenshot 2023-10-06 at 4 29 04 PM" src="https://github.com/aptible/app-ui/assets/4295811/548d67a7-5c2a-403c-97a0-59b0e73828c3">

