### PR TITLE
fix: capitalize operation banners

### DIFF
--- a/src/ui/shared/active-operation-notice.tsx
+++ b/src/ui/shared/active-operation-notice.tsx
@@ -90,7 +90,7 @@ export const ActiveOperationNotice = ({
       <BannerWrapper>
         <Banner variant={operationStatusToBannerStatus(operation.status)}>
           <p>
-            {gerundOfOpType} <b>{resourceType}</b> (
+            {capitalize(gerundOfOpType)} <b>{resourceType}</b> (
             {timeAgo(operation.createdAt)}) -{" "}
             <Link
               className="text-white underline"


### PR DESCRIPTION
Capitalize first letter in operation banners

BEFORE

<img width="406" alt="Screenshot 2023-10-13 at 9 47 20 AM" src="https://github.com/aptible/app-ui/assets/4295811/96aeb1ab-4652-4c50-9ee0-bf232b9e470c">

AFTER
<img width="425" alt="Screenshot 2023-10-13 at 9 47 03 AM" src="https://github.com/aptible/app-ui/assets/4295811/b81f400c-b9df-48c9-9cc4-f13f791b14c1">

