### PR TITLE
refactor(chart): remove lazy loading

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,5 +1,3 @@
-import { RouteObject, createBrowserRouter } from "react-router-dom";
-
 import * as routes from "@app/routes";
 import {
   ActivityPage,
@@ -107,13 +105,16 @@ import {
   VerifyEmailPage,
   VerifyEmailRequired,
 } from "@app/ui";
+import { AppDetailServiceMetricsPage } from "@app/ui/pages/app-detail-service-metrics";
 import { AppDetailServiceScalePage } from "@app/ui/pages/app-detail-service-scale";
 import { CertDetailAppsPage } from "@app/ui/pages/cert-detail-apps";
 import { CertDetailEndpointsPage } from "@app/ui/pages/cert-detail-endpoints";
+import { DatabaseMetricsPage } from "@app/ui/pages/db-detail-metrics";
 import { DeployPage } from "@app/ui/pages/deploy";
 import { EnvironmentDetailPage } from "@app/ui/pages/environment-detail";
 import { EnvironmentActivityReportsPage } from "@app/ui/pages/environment-detail-activity-reports";
 import { StackDetailPage } from "@app/ui/pages/stack-detail";
+import { RouteObject, createBrowserRouter } from "react-router-dom";
 import { Tuna } from "./tuna";
 
 const trackingPatch = (appRoute: RouteObject) => ({
@@ -239,8 +240,7 @@ export const appRoutes: RouteObject[] = [
                 children: [
                   {
                     path: routes.APP_SERVICE_METRICS_PATH,
-                    lazy: () =>
-                      import("@app/ui/pages/app-detail-service-metrics"),
+                    element: <AppDetailServiceMetricsPage />,
                   },
                   {
                     path: routes.APP_SERVICE_SCALE_PATH,
@@ -316,7 +316,7 @@ export const appRoutes: RouteObject[] = [
               },
               {
                 path: routes.DATABASE_METRICS_PATH,
-                lazy: () => import("@app/ui/pages/db-detail-metrics"),
+                element: <DatabaseMetricsPage />,
               },
               {
                 path: routes.DATABASE_CLUSTER_PATH,


### PR DESCRIPTION
# Issue
- User is using the app
- We deploy a new ui release
- User navigates to a page that was lazy loaded (any page with charts)
- The lazy loaded that was for their current running app has disappeared
- User gets an error

# Sentry

- https://aptible.sentry.io/issues/4396767688/?project=4504990894391296&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=0
- https://aptible.sentry.io/issues/4536245328/?project=4504990894391296&query=is%3Aunresolved&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=5