### PR TITLE
style: add break-all to header info items

### DIFF
--- a/src/ui/shared/detail-page-header-view.tsx
+++ b/src/ui/shared/detail-page-header-view.tsx
@@ -122,7 +122,7 @@ export function DetailInfoItem({
   return (
     <div>
       <h3 className="text-base font-semibold text-gray-900">{title}</h3>
-      <div>{children}</div>
+      <div className="break-all">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
Make sure header items break on small screens

BEFORE
<img width="909" alt="Screenshot 2023-10-19 at 4 41 16 PM" src="https://github.com/aptible/app-ui/assets/4295811/df6f2d2d-683f-4820-b0b3-b17340b01b89">

AFTER
<img width="907" alt="Screenshot 2023-10-19 at 4 41 10 PM" src="https://github.com/aptible/app-ui/assets/4295811/f5da3177-7081-44ee-a4da-a4d00a3e177e">