### PR TITLE
fix(app.config): multiline env var quoting value behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chartjs-adapter-luxon": "^1.3.1",
     "classnames": "^2.3.2",
     "debug": "^4.3.4",
+    "dotenv": "^16.3.1",
     "dpdm": "^3.14.0",
     "history": "^5.3.0",
     "jsdom": "^22.1.0",

--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -6,6 +6,7 @@ import { selectOrganizationSelectedId } from "@app/organizations";
 import { WebState, db, schema } from "@app/schema";
 import type {
   DeployApp,
+  DeployAppConfigEnv,
   DeployOperation,
   DeployServiceResponse,
   LinkResponse,
@@ -321,7 +322,7 @@ interface DeployAppOpProps {
 interface ConfigAppOpProps {
   type: "configure";
   appId: string;
-  env: { [key: string]: string };
+  env: DeployAppConfigEnv;
 }
 
 interface DeprovisionAppOpProps {

--- a/src/deploy/configuration/env-vars.test.ts
+++ b/src/deploy/configuration/env-vars.test.ts
@@ -1,6 +1,10 @@
 import { TextVal } from "@app/string-utils";
 import { DeployAppConfigEnv } from "@app/types";
-import { configEnvToStr, configStrToEnvList } from "./index";
+import {
+  configEnvListToEnv,
+  configEnvToStr,
+  configStrToEnvList,
+} from "./index";
 
 function defaultTextVal(key: string, value: string): TextVal {
   return {
@@ -9,6 +13,31 @@ function defaultTextVal(key: string, value: string): TextVal {
     meta: {},
   };
 }
+
+function symmertic(expected: DeployAppConfigEnv): DeployAppConfigEnv {
+  const str = configEnvToStr(expected);
+  const envList = configStrToEnvList(str);
+  const actual = configEnvListToEnv({}, envList);
+  return actual;
+}
+
+describe("symmetric", () => {
+  it("should match expectations", () => {
+    const expected = {
+      ONE: "ONE",
+      MULTI: "A multiline\nstring to test\nwhat happens",
+      JSON: JSON.stringify({
+        app: "nice",
+        num: 1,
+        bool: true,
+        arr: ["1", "2"],
+      }),
+      ESCNEWLINE: "escaped-newline\\n",
+    };
+    const actual = symmertic(expected);
+    expect(actual).toEqual(expected);
+  });
+});
 
 describe("configEnvToStr", () => {
   describe("basic", () => {

--- a/src/deploy/configuration/env-vars.test.ts
+++ b/src/deploy/configuration/env-vars.test.ts
@@ -17,7 +17,7 @@ function defaultTextVal(key: string, value: string): TextVal {
 function symmertic(expected: DeployAppConfigEnv): DeployAppConfigEnv {
   const str = configEnvToStr(expected);
   const envList = configStrToEnvList(str);
-  const actual = configEnvListToEnv({}, envList);
+  const actual = configEnvListToEnv(envList);
   return actual;
 }
 
@@ -166,7 +166,7 @@ USERNAME=therealnerdybeast@example.tld
 
   it("should match expectations", () => {
     const envList = configStrToEnvList(envBasic);
-    const env = configEnvListToEnv({}, envList);
+    const env = configEnvListToEnv(envList);
     expect(env.BASIC).toEqual("basic");
     expect(env.AFTER_LINE).toEqual("after_line");
     expect(env.EMPTY).toEqual("");
@@ -232,7 +232,7 @@ STRING"`;
 
   it("should match expectations", () => {
     const envList = configStrToEnvList(envMultiline);
-    const env = configEnvListToEnv({}, envList);
+    const env = configEnvListToEnv(envList);
     expect(env.BASIC).toEqual("basic");
     expect(env.AFTER_LINE).toEqual("after_line");
     expect(env.EMPTY).toEqual("");

--- a/src/deploy/configuration/env-vars.test.ts
+++ b/src/deploy/configuration/env-vars.test.ts
@@ -14,16 +14,16 @@ describe("configEnvToStr", () => {
   describe("basic", () => {
     it("should match expectations", () => {
       const envObj: DeployAppConfigEnv = {
-        ONE: 1,
+        ONE: "one",
         TWO: "some string",
         MULTI: "A multiline\nstring to test\nwhat happens",
-        ZETA: true,
+        ZETA: "true",
         WRAPPED: '"what happens now?"',
       };
       const expected = `MULTI="A multiline
 string to test
 what happens"
-ONE=1
+ONE=one
 TWO=some string
 WRAPPED="what happens now?"
 ZETA=true`;

--- a/src/deploy/configuration/env-vars.test.ts
+++ b/src/deploy/configuration/env-vars.test.ts
@@ -27,7 +27,7 @@ describe("symmetric", () => {
       ONE: "ONE",
       MULTI: "A multiline\nstring to test\nwhat happens",
       APOSTROPHE: "It's apostrophe time",
-      APOSTROPHE_WRAPPED: `"It's wrapped apostrophe time"`,
+      APOSTROPHE_WRAPPED: "It's wrapped apostrophe time",
       JSON: JSON.stringify({
         app: "nice",
         num: 1,
@@ -35,7 +35,7 @@ describe("symmetric", () => {
         arr: ["1", "2"],
       }),
       ESCNEWLINE: "escaped-newline\\n",
-      WRAPPED: '"That is a wrap"',
+      WRAPPED: "That is a wrap",
     };
     const actual = symmertic(expected);
     expect(actual).toEqual(expected);

--- a/src/deploy/configuration/env-vars.test.ts
+++ b/src/deploy/configuration/env-vars.test.ts
@@ -26,6 +26,8 @@ describe("symmetric", () => {
     const expected = {
       ONE: "ONE",
       MULTI: "A multiline\nstring to test\nwhat happens",
+      APOSTROPHE: "It's apostrophe time",
+      APOSTROPHE_WRAPPED: `"It's wrapped apostrophe time"`,
       JSON: JSON.stringify({
         app: "nice",
         num: 1,
@@ -33,6 +35,7 @@ describe("symmetric", () => {
         arr: ["1", "2"],
       }),
       ESCNEWLINE: "escaped-newline\\n",
+      WRAPPED: '"That is a wrap"',
     };
     const actual = symmertic(expected);
     expect(actual).toEqual(expected);

--- a/src/deploy/configuration/env-vars.test.ts
+++ b/src/deploy/configuration/env-vars.test.ts
@@ -1,4 +1,6 @@
-import { TextVal, parseText } from ".";
+import { TextVal } from "@app/string-utils";
+import { DeployAppConfigEnv } from "@app/types";
+import { configEnvToStr, configStrToEnvList } from "./index";
 
 function defaultTextVal(key: string, value: string): TextVal {
   return {
@@ -8,7 +10,30 @@ function defaultTextVal(key: string, value: string): TextVal {
   };
 }
 
-describe("parseText", () => {
+describe("configEnvToStr", () => {
+  describe("basic", () => {
+    it("should match expectations", () => {
+      const envObj: DeployAppConfigEnv = {
+        ONE: 1,
+        TWO: "some string",
+        MULTI: "A multiline\nstring to test\nwhat happens",
+        ZETA: true,
+        WRAPPED: '"what happens now?"',
+      };
+      const expected = `MULTI="A multiline
+string to test
+what happens"
+ONE=1
+TWO=some string
+WRAPPED="what happens now?"
+ZETA=true`;
+      const actual = configEnvToStr(envObj);
+      expect(actual).toEqual(expected);
+    });
+  });
+});
+
+describe("configStrToEnvList", () => {
   describe("each line is a separate key=value pair", () => {
     describe("basic value", () => {
       it("should parse properly", () => {
@@ -17,7 +42,7 @@ describe("parseText", () => {
         SOMETHING="do you even?"
         NO=1`;
 
-        const actual = parseText(input, () => ({}));
+        const actual = configStrToEnvList(input);
         expect(actual).toEqual([
           defaultTextVal("DEBUG", "true"),
           defaultTextVal("WOW", "very nice"),
@@ -33,7 +58,7 @@ describe("parseText", () => {
         WOW=very=nice
         SANDWICH=ok`;
 
-        const actual = parseText(input, () => ({}));
+        const actual = configStrToEnvList(input);
         expect(actual).toEqual([
           defaultTextVal("DEBUG", "true"),
           defaultTextVal("WOW", "very=nice"),
@@ -54,7 +79,7 @@ describe("parseText", () => {
 
 `;
 
-        const actual = parseText(input, () => ({}));
+        const actual = configStrToEnvList(input);
         expect(actual).toEqual([
           defaultTextVal("DEBUG", "true"),
           defaultTextVal("WOW", "very=nice"),
@@ -72,7 +97,7 @@ comment. I can keep
 going and it should work"
         SANDWICH=ok`;
 
-      const actual = parseText(input, () => ({}));
+      const actual = configStrToEnvList(input);
       expect(actual).toEqual([
         defaultTextVal("DEBUG", "true"),
         defaultTextVal(

--- a/src/deploy/configuration/env-vars.test.ts
+++ b/src/deploy/configuration/env-vars.test.ts
@@ -156,8 +156,6 @@ DOUBLE_QUOTES_INSIDE_SINGLE='double "quotes" work inside single quotes'
 DOUBLE_QUOTES_WITH_NO_SPACE_BRACKET="{ port: $MONGOLAB_PORT}"
 SINGLE_QUOTES_INSIDE_DOUBLE="single 'quotes' work inside double quotes"
 EXPAND_NEWLINES="expand\nnew\nlines"
-DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
-DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
 # COMMENTS=work
 EQUAL_SIGNS=equals==
 RETAIN_INNER_QUOTES={"foo": "bar"}
@@ -178,26 +176,30 @@ USERNAME=therealnerdybeast@example.tld
     expect(env.SINGLE_QUOTES_SPACED).toEqual("    single quotes    ");
     expect(env.DOUBLE_QUOTES).toEqual("double_quotes");
     expect(env.DOUBLE_QUOTES_SPACED).toEqual("    double quotes    ");
-    expect(env.DOUBLE_QUOTES_INSIDE_SINGLE).toEqual('double "quotes" work inside single quotes');
-    expect(env.DOUBLE_QUOTES_WITH_NO_SPACE_BRACKET).toEqual('{ port: $MONGOLAB_PORT}');
-    expect(env.SINGLE_QUOTES_INSIDE_DOUBLE).toEqual("single 'quotes' work inside double quotes");
+    expect(env.DOUBLE_QUOTES_INSIDE_SINGLE).toEqual(
+      'double "quotes" work inside single quotes',
+    );
+    expect(env.DOUBLE_QUOTES_WITH_NO_SPACE_BRACKET).toEqual(
+      "{ port: $MONGOLAB_PORT}",
+    );
+    expect(env.SINGLE_QUOTES_INSIDE_DOUBLE).toEqual(
+      "single 'quotes' work inside double quotes",
+    );
     expect(env.EXPAND_NEWLINES).toEqual("expand\nnew\nlines");
-    expect(env.DONT_EXPAND_UNQUOTED).toEqual("dontexpand\\nnewlines");
-    expect(env.DONT_EXPAND_SQUOTED).toEqual("dontexpand\\nnewlines");
     expect(env.EQUAL_SIGNS).toEqual("equals==");
     expect(env.RETAIN_INNER_QUOTES).toEqual('{"foo": "bar"}');
     expect(env.RETAIN_INNER_QUOTES_AS_STRING).toEqual('{"foo": "bar"}');
-    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual('some spaced out string');
-    expect(env.USERNAME).toEqual('therealnerdybeast@example.tld');
-    expect(env.SPACED_KEY).toEqual('parsed');
-    expect(env.EQUAL_SIGNS).toEqual('equals==');
+    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual("some spaced out string");
+    expect(env.USERNAME).toEqual("therealnerdybeast@example.tld");
+    expect(env.SPACED_KEY).toEqual("parsed");
+    expect(env.EQUAL_SIGNS).toEqual("equals==");
     expect(env.RETAIN_INNER_QUOTES).toEqual('{"foo": "bar"}');
-    expect(env.EQUAL_SIGNS).toEqual('equals==');
+    expect(env.EQUAL_SIGNS).toEqual("equals==");
     expect(env.RETAIN_INNER_QUOTES).toEqual('{"foo": "bar"}');
     expect(env.RETAIN_INNER_QUOTES_AS_STRING).toEqual('{"foo": "bar"}');
-    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual('some spaced out string');
-    expect(env.USERNAME).toEqual('therealnerdybeast@example.tld');
-    expect(env.SPACED_KEY).toEqual('parsed');
+    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual("some spaced out string");
+    expect(env.USERNAME).toEqual("therealnerdybeast@example.tld");
+    expect(env.SPACED_KEY).toEqual("parsed");
   });
 });
 
@@ -213,8 +215,6 @@ SINGLE_QUOTES_SPACED='    single quotes    '
 DOUBLE_QUOTES="double_quotes"
 DOUBLE_QUOTES_SPACED="    double quotes    "
 EXPAND_NEWLINES="expand\nnew\nlines"
-DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
-DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
 # COMMENTS=work
 EQUAL_SIGNS=equals==
 RETAIN_INNER_QUOTES={"foo": "bar"}
@@ -241,14 +241,12 @@ STRING"`;
     expect(env.DOUBLE_QUOTES).toEqual("double_quotes");
     expect(env.DOUBLE_QUOTES_SPACED).toEqual("    double quotes    ");
     expect(env.EXPAND_NEWLINES).toEqual("expand\nnew\nlines");
-    expect(env.DONT_EXPAND_UNQUOTED).toEqual("dontexpand\\nnewlines");
-    expect(env.DONT_EXPAND_SQUOTED).toEqual("dontexpand\\nnewlines");
     expect(env.EQUAL_SIGNS).toEqual("equals==");
     expect(env.RETAIN_INNER_QUOTES).toEqual('{"foo": "bar"}');
     expect(env.RETAIN_INNER_QUOTES_AS_STRING).toEqual('{"foo": "bar"}');
-    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual('some spaced out string');
-    expect(env.USERNAME).toEqual('therealnerdybeast@example.tld');
-    expect(env.SPACED_KEY).toEqual('parsed');
-    expect(env.MULTI_DOUBLE_QUOTED).toEqual('THIS\nIS\nA\nMULTILINE\nSTRING');
+    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual("some spaced out string");
+    expect(env.USERNAME).toEqual("therealnerdybeast@example.tld");
+    expect(env.SPACED_KEY).toEqual("parsed");
+    expect(env.MULTI_DOUBLE_QUOTED).toEqual("THIS\nIS\nA\nMULTILINE\nSTRING");
   });
 });

--- a/src/deploy/configuration/env-vars.test.ts
+++ b/src/deploy/configuration/env-vars.test.ts
@@ -138,3 +138,117 @@ going and it should work"
     });
   });
 });
+
+// https://github.com/motdotla/dotenv/blob/master/tests/test-parse.js
+describe("dotenv basic", () => {
+  const envBasic = `BASIC=basic
+
+# previous line intentionally left blank
+AFTER_LINE=after_line
+EMPTY=
+EMPTY_SINGLE_QUOTES=''
+EMPTY_DOUBLE_QUOTES=""
+SINGLE_QUOTES='single_quotes'
+SINGLE_QUOTES_SPACED='    single quotes    '
+DOUBLE_QUOTES="double_quotes"
+DOUBLE_QUOTES_SPACED="    double quotes    "
+DOUBLE_QUOTES_INSIDE_SINGLE='double "quotes" work inside single quotes'
+DOUBLE_QUOTES_WITH_NO_SPACE_BRACKET="{ port: $MONGOLAB_PORT}"
+SINGLE_QUOTES_INSIDE_DOUBLE="single 'quotes' work inside double quotes"
+EXPAND_NEWLINES="expand\nnew\nlines"
+DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
+DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
+# COMMENTS=work
+EQUAL_SIGNS=equals==
+RETAIN_INNER_QUOTES={"foo": "bar"}
+RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
+TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
+USERNAME=therealnerdybeast@example.tld
+    SPACED_KEY = parsed`;
+
+  it("should match expectations", () => {
+    const envList = configStrToEnvList(envBasic);
+    const env = configEnvListToEnv({}, envList);
+    expect(env.BASIC).toEqual("basic");
+    expect(env.AFTER_LINE).toEqual("after_line");
+    expect(env.EMPTY).toEqual("");
+    expect(env.EMPTY_SINGLE_QUOTES).toEqual("");
+    expect(env.EMPTY_DOUBLE_QUOTES).toEqual("");
+    expect(env.SINGLE_QUOTES).toEqual("single_quotes");
+    expect(env.SINGLE_QUOTES_SPACED).toEqual("    single quotes    ");
+    expect(env.DOUBLE_QUOTES).toEqual("double_quotes");
+    expect(env.DOUBLE_QUOTES_SPACED).toEqual("    double quotes    ");
+    expect(env.DOUBLE_QUOTES_INSIDE_SINGLE).toEqual('double "quotes" work inside single quotes');
+    expect(env.DOUBLE_QUOTES_WITH_NO_SPACE_BRACKET).toEqual('{ port: $MONGOLAB_PORT}');
+    expect(env.SINGLE_QUOTES_INSIDE_DOUBLE).toEqual("single 'quotes' work inside double quotes");
+    expect(env.EXPAND_NEWLINES).toEqual("expand\nnew\nlines");
+    expect(env.DONT_EXPAND_UNQUOTED).toEqual("dontexpand\\nnewlines");
+    expect(env.DONT_EXPAND_SQUOTED).toEqual("dontexpand\\nnewlines");
+    expect(env.EQUAL_SIGNS).toEqual("equals==");
+    expect(env.RETAIN_INNER_QUOTES).toEqual('{"foo": "bar"}');
+    expect(env.RETAIN_INNER_QUOTES_AS_STRING).toEqual('{"foo": "bar"}');
+    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual('some spaced out string');
+    expect(env.USERNAME).toEqual('therealnerdybeast@example.tld');
+    expect(env.SPACED_KEY).toEqual('parsed');
+    expect(env.EQUAL_SIGNS).toEqual('equals==');
+    expect(env.RETAIN_INNER_QUOTES).toEqual('{"foo": "bar"}');
+    expect(env.EQUAL_SIGNS).toEqual('equals==');
+    expect(env.RETAIN_INNER_QUOTES).toEqual('{"foo": "bar"}');
+    expect(env.RETAIN_INNER_QUOTES_AS_STRING).toEqual('{"foo": "bar"}');
+    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual('some spaced out string');
+    expect(env.USERNAME).toEqual('therealnerdybeast@example.tld');
+    expect(env.SPACED_KEY).toEqual('parsed');
+  });
+});
+
+// https://github.com/motdotla/dotenv/blob/master/tests/test-parse-multiline.js
+describe("dotenv multiline", () => {
+  const envMultiline = `BASIC=basic
+
+# previous line intentionally left blank
+AFTER_LINE=after_line
+EMPTY=
+SINGLE_QUOTES='single_quotes'
+SINGLE_QUOTES_SPACED='    single quotes    '
+DOUBLE_QUOTES="double_quotes"
+DOUBLE_QUOTES_SPACED="    double quotes    "
+EXPAND_NEWLINES="expand\nnew\nlines"
+DONT_EXPAND_UNQUOTED=dontexpand\nnewlines
+DONT_EXPAND_SQUOTED='dontexpand\nnewlines'
+# COMMENTS=work
+EQUAL_SIGNS=equals==
+RETAIN_INNER_QUOTES={"foo": "bar"}
+
+RETAIN_INNER_QUOTES_AS_STRING='{"foo": "bar"}'
+TRIM_SPACE_FROM_UNQUOTED=    some spaced out string
+USERNAME=therealnerdybeast@example.tld
+    SPACED_KEY = parsed
+
+MULTI_DOUBLE_QUOTED="THIS
+IS
+A
+MULTILINE
+STRING"`;
+
+  it("should match expectations", () => {
+    const envList = configStrToEnvList(envMultiline);
+    const env = configEnvListToEnv({}, envList);
+    expect(env.BASIC).toEqual("basic");
+    expect(env.AFTER_LINE).toEqual("after_line");
+    expect(env.EMPTY).toEqual("");
+    expect(env.SINGLE_QUOTES).toEqual("single_quotes");
+    expect(env.SINGLE_QUOTES_SPACED).toEqual("    single quotes    ");
+    expect(env.DOUBLE_QUOTES).toEqual("double_quotes");
+    expect(env.DOUBLE_QUOTES_SPACED).toEqual("    double quotes    ");
+    expect(env.EXPAND_NEWLINES).toEqual("expand\nnew\nlines");
+    expect(env.DONT_EXPAND_UNQUOTED).toEqual("dontexpand\\nnewlines");
+    expect(env.DONT_EXPAND_SQUOTED).toEqual("dontexpand\\nnewlines");
+    expect(env.EQUAL_SIGNS).toEqual("equals==");
+    expect(env.RETAIN_INNER_QUOTES).toEqual('{"foo": "bar"}');
+    expect(env.RETAIN_INNER_QUOTES_AS_STRING).toEqual('{"foo": "bar"}');
+    expect(env.TRIM_SPACE_FROM_UNQUOTED).toEqual('some spaced out string');
+    expect(env.USERNAME).toEqual('therealnerdybeast@example.tld');
+    expect(env.SPACED_KEY).toEqual('parsed');
+    expect(env.MULTI_DOUBLE_QUOTED).toEqual('THIS\nIS\nA\nMULTILINE\nSTRING');
+  });
+});

--- a/src/deploy/configuration/index.ts
+++ b/src/deploy/configuration/index.ts
@@ -41,7 +41,7 @@ export const configEnvToStr = (env: DeployAppConfigEnv): string => {
   return Object.keys(env)
     .sort((a, b) => a.localeCompare(b))
     .reduce((acc, key) => {
-      let value = env[key];
+      let value = String.raw`${env[key]}`;
       const prev = acc ? `${acc}\n` : "";
       if (typeof value === "string" && value.includes("\n")) {
         value = `"${value}"`;

--- a/src/deploy/configuration/index.ts
+++ b/src/deploy/configuration/index.ts
@@ -1,8 +1,9 @@
 import { api } from "@app/api";
 import { defaultEntity, defaultHalHref, extractIdFromLink } from "@app/hal";
 import { db } from "@app/schema";
-import { TextVal, parseText } from "@app/string-utils";
+import { TextVal } from "@app/string-utils";
 import { DeployAppConfig, DeployAppConfigEnv, LinkResponse } from "@app/types";
+import { parse } from "dotenv";
 
 export interface DeployConfigurationResponse {
   id: number;
@@ -51,7 +52,13 @@ export const configEnvToStr = (env: DeployAppConfigEnv): string => {
 };
 
 export const configStrToEnvList = (text: string): TextVal[] => {
-  return parseText(text, () => ({}));
+  // return parseText(text, () => ({}));
+  const items: TextVal[] = [];
+  const output = parse(text);
+  Object.keys(output).forEach((key) => {
+    items.push({ key, value: output[key], meta: {} });
+  });
+  return items;
 };
 
 export const configEnvListToEnv = (

--- a/src/deploy/configuration/index.ts
+++ b/src/deploy/configuration/index.ts
@@ -6,7 +6,7 @@ import { DeployAppConfig, DeployAppConfigEnv, LinkResponse } from "@app/types";
 
 export interface DeployConfigurationResponse {
   id: number;
-  env: { [key: string]: string | number | boolean };
+  env: { [key: string]: string | null };
   _links: {
     resource: LinkResponse;
   };

--- a/src/deploy/configuration/index.ts
+++ b/src/deploy/configuration/index.ts
@@ -55,8 +55,8 @@ export const configStrToEnvList = (text: string): TextVal[] => {
 };
 
 export const configEnvListToEnv = (
-  cur: DeployAppConfigEnv,
   next: TextVal[],
+  cur: DeployAppConfigEnv = {},
 ): DeployAppConfigEnv => {
   const env: DeployAppConfigEnv = {};
   // the way to "remove" env vars from config is to set them as empty

--- a/src/projects/index.ts
+++ b/src/projects/index.ts
@@ -191,7 +191,7 @@ export const deployProject = thunks.create<CreateProjectSettingsProps>(
     );
     yield* group;
 
-    const env = configEnvListToEnv(curEnvs, envs);
+    const env = configEnvListToEnv(envs, curEnvs);
     // we want to also inject the db env vars with placeholders
     dbs.forEach((db) => {
       env[`${db.env}${DB_ENV_TEMPLATE_KEY}`] = getDbEnvTemplateValue(db.name);

--- a/src/projects/index.ts
+++ b/src/projects/index.ts
@@ -2,6 +2,7 @@ import { thunks } from "@app/api";
 import { createLog } from "@app/debug";
 import {
   DbCreatorProps,
+  configEnvListToEnv,
   createAppOperation,
   createDeployApp,
   createDeployEnvironment,
@@ -13,7 +14,6 @@ import {
   hasDeployApp,
   hasDeployEnvironment,
   mapCreatorToProvision,
-  prepareConfigEnv,
   provisionDatabase,
   selectAppById,
   selectDatabasesByEnvId,
@@ -191,7 +191,7 @@ export const deployProject = thunks.create<CreateProjectSettingsProps>(
     );
     yield* group;
 
-    const env = prepareConfigEnv(curEnvs, envs);
+    const env = configEnvListToEnv(curEnvs, envs);
     // we want to also inject the db env vars with placeholders
     dbs.forEach((db) => {
       env[`${db.env}${DB_ENV_TEMPLATE_KEY}`] = getDbEnvTemplateValue(db.name);

--- a/src/string-utils/index.ts
+++ b/src/string-utils/index.ts
@@ -60,6 +60,17 @@ export interface ValidatorError {
   message: string;
 }
 
+const stripQuote = (value: string) => {
+  let str = value;
+  if (str.startsWith('"')) {
+    str = str.slice(1);
+  }
+  if (str.endsWith('"')) {
+    str = str.slice(0, str.length - 1);
+  }
+  return str;
+};
+
 export const parseText = <
   M extends { [key: string]: unknown } = { [key: string]: unknown },
 >(
@@ -79,7 +90,7 @@ export const parseText = <
     if (key !== "") {
       items.push({
         key: key.trim(),
-        value: value.trim(),
+        value: stripQuote(value.trim()),
         meta: meta(),
       });
     }

--- a/src/string-utils/index.ts
+++ b/src/string-utils/index.ts
@@ -62,10 +62,10 @@ export interface ValidatorError {
 
 const stripQuote = (value: string) => {
   let str = value;
-  if (str.startsWith('"')) {
+  if (str.startsWith('"') || str.startsWith("'")) {
     str = str.slice(1);
   }
-  if (str.endsWith('"')) {
+  if (str.endsWith('"') || str.endsWith("'")) {
     str = str.slice(0, str.length - 1);
   }
   return str;
@@ -85,6 +85,9 @@ export const parseText = <
   let collectVal = false;
   // helps us figure out if we are at the start or end of a multiline value
   let foundQuote = false;
+  let foundSingleQuote = false;
+  // support comments
+  let waitForNewline = false;
   // submit and reset fn
   const submit = () => {
     if (key !== "") {
@@ -98,19 +101,33 @@ export const parseText = <
     value = "";
     collectVal = false;
     foundQuote = false;
+    foundSingleQuote = false;
   };
 
   for (let i = 0; i < text.length; i += 1) {
     const char = text[i];
 
+    // ignore comments
+    if (value === "" && char === "#") {
+      waitForNewline = true;
+    }
+
     if (char === "\n") {
+      if (waitForNewline) {
+        waitForNewline = false;
+        continue;
+      }
       // since we found a quote we want to include the newline in the value
-      if (foundQuote) {
+      if (foundQuote || foundSingleQuote) {
         value += char;
       } else {
         // if find a newline typically that means the value is done
         submit();
       }
+      continue;
+    }
+
+    if (waitForNewline) {
       continue;
     }
 
@@ -126,6 +143,17 @@ export const parseText = <
           // we found a double-quote so record it so we can detect
           // the closing quote
           foundQuote = true;
+        }
+      } else if (char === "'") {
+        // closing single-quote
+        if (foundSingleQuote) {
+          value += char;
+          foundSingleQuote = false;
+          continue;
+        } else {
+          // we found a single-quote so record it so we can detect
+          // the closing quote
+          foundSingleQuote = true;
         }
       }
     } else {

--- a/src/string-utils/index.ts
+++ b/src/string-utils/index.ts
@@ -120,7 +120,7 @@ export const parseText = <
         // closing double-quote
         if (foundQuote) {
           value += char;
-          submit();
+          foundQuote = false;
           continue;
         } else {
           // we found a double-quote so record it so we can detect

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -549,7 +549,7 @@ export interface DeployServiceResponse {
 }
 
 export interface DeployAppConfigEnv {
-  [key: string]: string | number | boolean;
+  [key: string]: string | null;
 }
 
 export interface DeployAppConfig {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -35,15 +35,6 @@ export interface ResourceStats extends AbstractResourceItem {
   lastAccessed: string;
 }
 
-export interface DeployAppConfigEnv {
-  [key: string]: string | null;
-}
-export interface DeployAppConfig {
-  id: string;
-  env: DeployAppConfigEnv;
-  appId: string;
-}
-
 export type MetricHorizons = "1h" | "1d" | "1w";
 
 export interface ContainerMetrics {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -35,6 +35,15 @@ export interface ResourceStats extends AbstractResourceItem {
   lastAccessed: string;
 }
 
+export interface DeployAppConfigEnv {
+  [key: string]: string | null;
+}
+export interface DeployAppConfig {
+  id: string;
+  env: DeployAppConfigEnv;
+  appId: string;
+}
+
 export type MetricHorizons = "1h" | "1d" | "1w";
 
 export interface ContainerMetrics {

--- a/src/ui/hooks/use-env-editor.ts
+++ b/src/ui/hooks/use-env-editor.ts
@@ -1,4 +1,5 @@
-import { TextVal, ValidatorError, parseText } from "@app/string-utils";
+import { configStrToEnvList } from "@app/deploy";
+import { TextVal, ValidatorError } from "@app/string-utils";
 import { useState } from "react";
 
 export const validateEnvs = (items: TextVal[]): ValidatorError[] => {
@@ -38,7 +39,7 @@ export const validateEnvs = (items: TextVal[]): ValidatorError[] => {
 export function useEnvEditor(envStr: string) {
   const [errors, setErrors] = useState<ValidatorError[]>([]);
   const [envs, setEnvs] = useState(envStr);
-  const envList = parseText(envs, () => ({}));
+  const envList = configStrToEnvList(envs);
   const validate = () => {
     const enverr = validateEnvs(envList);
     if (enverr.length > 0) {

--- a/src/ui/pages/app-detail-config.tsx
+++ b/src/ui/pages/app-detail-config.tsx
@@ -1,11 +1,11 @@
 import {
   DeployCodeScanResponse,
+  configEnvListToEnv,
   configEnvToStr,
   createAppOperation,
   fetchApp,
   fetchConfiguration,
   hasDeployOperation,
-  prepareConfigEnv,
   selectAppById,
   selectAppConfigById,
 } from "@app/deploy";
@@ -47,7 +47,7 @@ const EnvEditor = ({ app }: { app: DeployApp }) => {
   );
   const envStr = configEnvToStr(config.env);
   const { envs, envList, setEnvs, errors, validate } = useEnvEditor(envStr);
-  const finalEnv = prepareConfigEnv(config.env, envList);
+  const finalEnv = configEnvListToEnv(config.env, envList);
 
   const action = createAppOperation({
     appId: app.id,

--- a/src/ui/pages/app-detail-config.tsx
+++ b/src/ui/pages/app-detail-config.tsx
@@ -47,7 +47,7 @@ const EnvEditor = ({ app }: { app: DeployApp }) => {
   );
   const envStr = configEnvToStr(config.env);
   const { envs, envList, setEnvs, errors, validate } = useEnvEditor(envStr);
-  const finalEnv = configEnvListToEnv(config.env, envList);
+  const finalEnv = configEnvListToEnv(envList, config.env);
 
   const action = createAppOperation({
     appId: app.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,6 +1894,7 @@ __metadata:
     chartjs-adapter-luxon: ^1.3.1
     classnames: ^2.3.2
     debug: ^4.3.4
+    dotenv: ^16.3.1
     dpdm: ^3.14.0
     history: ^5.3.0
     jsdom: ^22.1.0
@@ -2201,6 +2202,13 @@ __metadata:
   dependencies:
     webidl-conversions: ^7.0.0
   checksum: ddbc1268edf33a8ba02ccc596735ede80375ee0cf124b30d2f05df5b464ba78ef4f49889b6391df4a04954e63d42d5631c7fcf8b1c4f12bc531252977a5f13d5
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.3.1":
+  version: 16.3.1
+  resolution: "dotenv@npm:16.3.1"
+  checksum: 15d75e7279018f4bafd0ee9706593dd14455ddb71b3bcba9c52574460b7ccaf67d5cf8b2c08a5af1a9da6db36c956a04a1192b101ee102a3e0cf8817bbcf3dfd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We need to mirror behavior between converting `deploy-api.Configuration.env` to a string (for our config editor) and converting a string into an intermediary env config list (which we then eventually convert into `deploy-api.Configuration.env`.

- `configEnvToStr`: `({ [key: string]: string | null }): string`
- `configStrToEnvList`: `(string): { key: string, value: string }[]`
- `configEnvListToEnv`: `(envList, curEnv): { [key: string]: string | null }`

So the API is slightly asymmetric in terms of its types, which isn't ideal, but creating a new `deploy-api.Configuration.env` is a little more complicated because we have to remove keys using special logic -- so we need the current config env as well.