### PR TITLE
fix(token): dont keep token in local storage

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -11,7 +11,7 @@ import { REDIRECT_NAME } from "@app/redirect-path";
 import { resetReducer } from "@app/reset-store";
 import { RESOURCE_STATS_NAME } from "@app/search";
 import { THEME_NAME } from "@app/theme";
-import { ELEVATED_TOKEN_NAME, TOKEN_NAME } from "@app/token";
+import { ELEVATED_TOKEN_NAME } from "@app/token";
 import type { AppState } from "@app/types";
 
 import { reducers, sagas } from "./packages";
@@ -30,7 +30,6 @@ export const persistConfig = {
   key: "root",
   storage,
   whitelist: [
-    TOKEN_NAME,
     ELEVATED_TOKEN_NAME,
     THEME_NAME,
     NAV_NAME,

--- a/src/ui/layouts/auth-required.tsx
+++ b/src/ui/layouts/auth-required.tsx
@@ -80,21 +80,6 @@ At the time of writing this we have 4 forced redirect components:
 - `<EmailVerifyRequired />` -> checks for user.verified
 - `<PaymentMethodRequired />` -> checks for a payment method
 - `<ElevateRequired />` -> checks for an elevated token in our redux store
-
-# Design Principle
-
-We store the user's access token inside local storage.  This allows us
-to check for access token before we fetch `/current_token`.  While that
-request is in-flight and there is an access token in our store, we start
-rendering the app.  Only after `/current_token` returns `401` do we reset
-the store and force the user to `/login`.
-
-This provides us with some unique features:
-- We don't block the user if we already have an access token in our redux store
-- We render the page they are requesting immediately, which means we try
-  to fetch that data first before all of our other preloaded data (e.g.
-  user goes to app-detail page, we fetch that specific app via API before
-  we fetch preloaded data, making the page render faster).
 */
 export const AuthRequired = ({ children }: { children?: React.ReactNode }) => {
   const location = useLocation();


### PR DESCRIPTION
Storing the token is wrought with edge cases.  This commit fixes the current erroneous user flow:

- User has app and dashboard open using the same token
- In dashboard, user deletes the token (by logging out)
- In dashboard, user logs in again (creating new token)
- In app, user refreshes
- EXPECTED: user fetches `/current_token` and is allowed in app
- ACTUAL: user is redirected to login page

This erroneous behavior is caused by us trying to use the expired token stored in local storage -- even before we hit `/current_token`.  Since we used the wrong token the API would return a 401 and we would immediately wipe the redux store which would then send the user to the login page.  This would all happen before `/current_token` had a chance to provide us with the new valid token.

Because we can never assume that the token stored in local storage is valid, it's easier for us to not persist the token at all.