### PR TITLE
style: resize icons

### DIFF
--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -62,7 +62,7 @@ export function AppHeader({ app }: { app: DeployApp }) {
         icon={
           <img
             src="/resource-types/logo-app.png"
-            className="w-8 h-8 mr-3"
+            className="w-[32px] h-[32px] mr-3"
             aria-label="App"
           />
         }

--- a/src/ui/layouts/cert-detail-layout.tsx
+++ b/src/ui/layouts/cert-detail-layout.tsx
@@ -39,7 +39,7 @@ function CertHeader({ cert }: { cert: DeployCertificate }) {
         icon={
           <img
             src={"/resource-types/logo-vhost.png"}
-            className="w-8 h-8 mr-3"
+            className="w-[32px] h-[32px] mr-3"
             aria-label="Certificate"
           />
         }

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -66,7 +66,7 @@ export function DatabaseHeader({
         icon={
           <img
             src={`/database-types/logo-${database.type}.png`}
-            className="w-8 h-8 mr-3"
+            className="w-[32px] h-[32px] mr-3"
             aria-label={`${database.type} Database`}
           />
         }

--- a/src/ui/layouts/endpoint-detail-layout.tsx
+++ b/src/ui/layouts/endpoint-detail-layout.tsx
@@ -71,7 +71,7 @@ export function EndpointAppHeaderInfo({
         icon={
           <img
             src={"/resource-types/logo-vhost.png"}
-            className="w-8 h-8 mr-3"
+            className="w-[32px] h-[32px] mr-3"
             aria-label="App"
           />
         }
@@ -121,7 +121,7 @@ export function EndpointDatabaseHeaderInfo({
         icon={
           <img
             src={"/resource-types/logo-vhost.png"}
-            className="w-8 h-8 mr-3"
+            className="w-[32px] h-[32px] mr-3"
             aria-label="App"
           />
         }

--- a/src/ui/layouts/environment-detail-layout.tsx
+++ b/src/ui/layouts/environment-detail-layout.tsx
@@ -68,7 +68,7 @@ export function EnvHeader({
         icon={
           <img
             src={"/resource-types/logo-environment.png"}
-            className="w-8 h-8 mr-3"
+            className="w-[32px] h-[32px] mr-3"
             aria-label="Environment"
           />
         }

--- a/src/ui/layouts/op-detail-layout.tsx
+++ b/src/ui/layouts/op-detail-layout.tsx
@@ -35,7 +35,7 @@ export function OpHeader({
         icon={
           <img
             src={"/resource-types/logo-activity.png"}
-            className="w-8 h-8 mr-3"
+            className="w-[32px] h-[32px] mr-3"
             aria-label="Operation"
           />
         }

--- a/src/ui/pages/search.tsx
+++ b/src/ui/pages/search.tsx
@@ -36,7 +36,7 @@ import {
 
 const ResourceView = ({ children }: { children: React.ReactNode }) => {
   const className = cn(
-    "my-2 px-3 flex items-center justify-between min-h-[48px]",
+    "my-2 px-2 flex items-center justify-between min-h-[48px]",
     "cursor-pointer",
     "border border-gray-200 rounded-lg",
     "bg-white hover:bg-black-50",

--- a/src/ui/pages/styles.tsx
+++ b/src/ui/pages/styles.tsx
@@ -299,56 +299,56 @@ const Colors = () => (
 
     <h3 className={tokens.type.h3}>Main Colors</h3>
     <div className="flex my-2">
-      <div className="rounded-full bg-black w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-black w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Black</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-white border-solid border border-black w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-white border-solid border border-black w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">White</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-indigo w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-indigo w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Indigo</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-yellow w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-yellow w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Yellow</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-gold w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-gold w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Gold</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-forest w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-forest w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Forest</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-red w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-red w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Red</p>
     </div>
     <h3 className={tokens.type.h3}>Misc. Colors</h3>
     <div className="flex my-2">
-      <div className="rounded-full bg-off-white border-solid border border-black w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-off-white border-solid border border-black w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Off-White</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-lime w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-lime w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Lime</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-cyan w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-cyan w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Cyan</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-brown w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-brown w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Brown</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-lavender w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-lavender w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Lavender</p>
     </div>
     <div className="flex my-2">
-      <div className="rounded-full bg-plum w-8 h-8 block mr-2" />
+      <div className="rounded-full bg-plum w-[32px] h-[32px] block mr-2" />
       <p className="leading-8">Plum</p>
     </div>
   </div>

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -72,7 +72,7 @@ const getImageForResourceType = (resourceType: ResourceType) => {
   return (
     <img
       src={imageToUse}
-      className="w-8 h-8 mr-2 mt-2 align-middle"
+      className="w-[32px] h-[32px] mr-2 mt-2 align-middle"
       aria-label={resourceType}
     />
   );

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -42,7 +42,7 @@ export const AppItemView = ({ app }: { app: DeployApp }) => {
     <Link to={appDetailUrl(app.id)} className="flex">
       <img
         src="/resource-types/logo-app.png"
-        className="w-8 h-8 mr-2 align-middle"
+        className="w-[32px] h-[32px] mr-2 align-middle"
         aria-label="App"
       />
       <p className={`${tokens.type["table link"]} leading-8`}>{app.handle}</p>

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -56,7 +56,7 @@ export const DatabaseItemView = ({
       <Link to={databaseDetailUrl(database.id)} className="flex">
         <img
           src={`/database-types/logo-${database.type}.png`}
-          className="w-8 h-8 mr-2 mt-2 align-middle"
+          className="w-[32px] h-[32px] mr-2 mt-2 align-middle"
           aria-label={`${database.type} Database`}
         />
         <p className="flex flex-col">

--- a/src/ui/shared/detail-page-header-view.tsx
+++ b/src/ui/shared/detail-page-header-view.tsx
@@ -95,7 +95,7 @@ export function DetailTitleBar({
   return (
     <div className="flex justify-between items-center">
       <div className="flex items-center">
-        {icon ? <div className="w-8 h-8 mr-3">{icon}</div> : null}
+        {icon ? <div className="w-[32px] h-[32px] mr-3">{icon}</div> : null}
         <h1 className="text-lg text-gray-500">{title}</h1>
       </div>
 

--- a/src/ui/shared/endpoint/endpoint-list.tsx
+++ b/src/ui/shared/endpoint/endpoint-list.tsx
@@ -55,7 +55,7 @@ export const EndpointItemView = ({
     >
       <img
         src="/resource-types/logo-vhost.png"
-        className="w-8 h-8 mr-2 align-middle"
+        className="w-[32px] h-[32px] mr-2 align-middle"
         aria-label="Endpoint"
       />
       <p className={`${tokens.type["table link"]} leading-8`}>

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -36,7 +36,7 @@ export const EnvironmentItemView = ({
     <Link to={environmentAppsUrl(environment.id)} className="flex">
       <img
         src="/resource-types/logo-environment.png"
-        className="w-8 h-8 mr-2 align-middle"
+        className="w-[32px] h-[32px] mr-2 align-middle"
         aria-label="Environment"
       />
       <p className={`${tokens.type["table link"]} leading-8`}>

--- a/src/ui/shared/stack.tsx
+++ b/src/ui/shared/stack.tsx
@@ -18,7 +18,7 @@ export const StackItemView = ({ stack }: { stack: DeployStack }) => {
               : "/resource-types/logo-stack.png"
           }
           alt="stack icon"
-          className="w-8 h-8 mr-2"
+          className="w-[32px] h-[32px] mr-2"
         />
         {stack.name}
       </Link>


### PR DESCRIPTION
Resize icons to fit the space better & match design
• change doesn't increase table row height too

BEFORE
<img width="309" alt="Screenshot 2023-10-23 at 9 24 15 AM" src="https://github.com/aptible/app-ui/assets/4295811/56ae9ca0-5bdc-4d64-8fdf-939ed6ba9df5">

AFTER
<img width="267" alt="Screenshot 2023-10-23 at 9 24 08 AM" src="https://github.com/aptible/app-ui/assets/4295811/e83d4688-893d-4e01-b9dc-8c51f3bc055f">

BEFORE
<img width="252" alt="Screenshot 2023-10-23 at 9 24 37 AM" src="https://github.com/aptible/app-ui/assets/4295811/5ef40f79-8f7a-4150-a798-4b0b8298be3c">

AFTER
<img width="281" alt="Screenshot 2023-10-23 at 9 24 34 AM" src="https://github.com/aptible/app-ui/assets/4295811/6973fc0a-bd4e-4d14-be18-05da3ff84120">

