### PR TITLE
fix: logs button alignment

### DIFF
--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -125,8 +125,11 @@ const OpResourceCell = ({ op }: OpCellProps) => {
 
 const OpActionsCell = ({ op }: OpCellProps) => {
   return (
-    <Td variant="right">
-      <Link to={operationDetailUrl(op.id)} className="hover:no-underline">
+    <Td>
+      <Link
+        to={operationDetailUrl(op.id)}
+        className="hover:no-underline flex justify-end mr-4"
+      >
         <Button variant="primary" size="sm">
           Logs
         </Button>


### PR DESCRIPTION
Fix logs button align on activity table

BEFORE

<img width="150" alt="Screenshot 2023-10-26 at 4 01 36 PM" src="https://github.com/aptible/app-ui/assets/4295811/5ed4065b-a8fa-4b48-b5df-3e5ffdeab854">


AFTER
<img width="159" alt="Screenshot 2023-10-26 at 4 01 47 PM" src="https://github.com/aptible/app-ui/assets/4295811/fda021fc-aad1-4f07-a4e5-06059eadba2f">

