### PR TITLE
[DoNotMerge]style(stacks): add outbound CIDR range to stack header

### DIFF
--- a/src/ui/layouts/stack-detail-layout.tsx
+++ b/src/ui/layouts/stack-detail-layout.tsx
@@ -64,6 +64,18 @@ export function StackHeader({ stack }: { stack: DeployStack }) {
           <CopyText text={stack.outboundIpAddresses.join(", ")} />
         </DetailInfoItem>
         <DetailInfoItem title="Region">{stack.region}</DetailInfoItem>
+        <DetailInfoItem title="">
+          <Tooltip text="Classless Inter-Domain Routing for outbound IP addresses">
+            <IconInfo
+              className="inline-block mb-1 mr-1 opacity-50 hover:opacity-100"
+              variant="sm"
+            />
+            <span className="text-base font-semibold text-gray-900">
+              Outbound CIDR Range
+            </span>
+          </Tooltip>
+          <CopyText text={stack.outboundIpAddresses.join(", ")} />
+        </DetailInfoItem>
       </DetailInfoGrid>
     </DetailHeader>
   );


### PR DESCRIPTION
Todo:
• Make the CIDR Range values real (they currently don't show up)

Q) Do we also want to show VPC CIDR Range for the actual Aptible VPC Private IP range?

<img width="1021" alt="Screenshot 2023-11-01 at 1 55 34 PM" src="https://github.com/aptible/app-ui/assets/4295811/2ef2bb44-cc91-4a8b-a38e-c001f8614b89">
<img width="1022" alt="Screenshot 2023-11-01 at 1 55 38 PM" src="https://github.com/aptible/app-ui/assets/4295811/d58da05c-388c-44c5-9dbf-abdc8274f05e">
