### PR TITLE
fix: update billing page and how it works copy

### DIFF
--- a/src/ui/pages/billing-method.tsx
+++ b/src/ui/pages/billing-method.tsx
@@ -33,7 +33,6 @@ import {
   Banner,
   BannerMessages,
   Button,
-  CreateProjectFooter,
   FormGroup,
   Group,
   IconArrowRight,
@@ -218,19 +217,33 @@ export const BillingMethodPage = () => {
       <HeroBgView className="flex gap-6">
         <div className="bg-white/90 shadow p-16 lg:block hidden lg:w-[500px] h-fit min-h-screen">
           <div className="text-xl text-black font-bold">
-            Launch, grow, and scale your app without worrying about
-            infrastructure
+            Try the platform hundreds of scaling engineering teams use to
+            achieve enterprise best practices for their infrastructure
           </div>
-          <div className="text-lg text-gold font-bold pt-5 pb-1">Launch</div>
-          <p>Get up and running without any work or config.</p>
-          <hr className="mt-5 mb-4" />
-          <div className="text-lg text-gold font-bold pb-1">Grow</div>
-          <p>Aptible handles all the infrastructure operations.</p>
-          <hr className="mt-5 mb-4" />
-          <div className="text-lg text-gold font-bold pb-1">Scale</div>
+          <div className="text-lg text-gold font-bold pt-5 pb-1">
+            Control your Infrastructure
+          </div>
           <p>
-            Enterprise requirements such as performance, security, and
-            reliability are baked in from day one.
+            Manage your entire infrastructure, optimize cloud spending, and
+            prevent vendor lock-in.
+          </p>
+          <hr className="mt-5 mb-4" />
+          <div className="text-lg text-gold font-bold pb-1">
+            Ensure Reliability
+          </div>
+          <p>
+            Aptible fully monitors your entire compute and data resources, and
+            holds the pager 24x7 for your infrastructure.
+          </p>
+          <hr className="mt-5 mb-4" />
+          <div className="text-lg text-gold font-bold pb-1">
+            Achieve Best Practices
+          </div>
+          <p>
+            Get the flexibility that scaling companies need: support non-HTTPS
+            services; enforce fine-grained RBAC; comply with security
+            frameworks; and scale to the limits of AWS for containers, disks, or
+            backups.
           </p>
           <p className="text-md text-black pt-8 pb-4 text-center font-semibold">
             Companies that have scaled with Aptible
@@ -240,9 +253,6 @@ export const BillingMethodPage = () => {
             className="text-center scale-90"
             aria-label="Customer Logos"
           />
-          <div className="pt-8 lg:px-0 px-10">
-            <CreateProjectFooter />
-          </div>
         </div>
 
         <div className="flex-1 mx-auto max-w-[500px]">

--- a/src/ui/shared/how-it-works-footer.tsx
+++ b/src/ui/shared/how-it-works-footer.tsx
@@ -48,6 +48,10 @@ export const CreateProjectFooter = () => {
 
       <div>
         <HelpTextAccordion title="How do I deploy an App?">
+          <p className="mb-2">
+            Click <strong>Get Started</strong> and we'll guide you through each
+            step:
+          </p>
           <ol className="list-decimal list-inside">
             <li>Sign up for an Aptible account</li>
             <li>Add an SSH key</li>


### PR DESCRIPTION
**Add more context to How It Works section to make it clear clicking Get Started guides users through steps.**
• We only show this on the `/create` pages now 

<img width="698" alt="Screenshot 2023-11-09 at 10 45 59 PM" src="https://github.com/aptible/app-ui/assets/4295811/75914005-5f96-414f-9d2b-398bd2ef7694">

---

**Update Billing page to match the new sign up messaging**

<img width="1346" alt="Screenshot 2023-11-10 at 12 31 09 PM" src="https://github.com/aptible/app-ui/assets/4295811/ece11f71-1041-48be-b842-74088114e861">

