### PR TITLE
fix: add title bar to deployments

### DIFF
--- a/src/ui/pages/deployments.tsx
+++ b/src/ui/pages/deployments.tsx
@@ -14,6 +14,7 @@ import {
   OnboardingLink,
   ResourceGroupBox,
   StatusPill,
+  TitleBar,
   resolveOperationStatuses,
   tokens,
 } from "../shared";
@@ -68,7 +69,9 @@ export const DeploymentsPage = () => {
 
   return (
     <div>
-      <h1 className={`${tokens.type.h1} mb-4`}>Deployments</h1>
+      <TitleBar description="Deployments can be in one of the following states: not deployed, queued, pending, or done.">
+        Deployments
+      </TitleBar>
 
       {view()}
 

--- a/src/ui/pages/deployments.tsx
+++ b/src/ui/pages/deployments.tsx
@@ -16,7 +16,6 @@ import {
   StatusPill,
   TitleBar,
   resolveOperationStatuses,
-  tokens,
 } from "../shared";
 
 const DeploymentOverview = ({ app }: { app: DeployApp }) => {


### PR DESCRIPTION
Add title bar to Deployments page to match other pages

<img width="1075" alt="Screenshot 2023-11-11 at 10 35 58 PM" src="https://github.com/aptible/app-ui/assets/4295811/92ef6165-c487-45a9-8f5a-4999bbc29da3">
