### PR TITLE
fix(db.create): look for existing db only in selected env

### DIFF
--- a/src/app/test/create-db.test.tsx
+++ b/src/app/test/create-db.test.tsx
@@ -1,16 +1,22 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { rest } from "msw";
-
+import { defaultDatabaseResponse, defaultOperationResponse } from "@app/deploy";
+import { defaultHalHref } from "@app/hal";
 import {
+  createId,
   server,
   stacksWithResources,
   testAccount,
   testDatabaseOp,
+  testDatabaseServiceId,
+  testDestroyAccount,
+  testDisk,
   testEnv,
+  testPostgresDatabaseImage,
   verifiedUserHandlers,
 } from "@app/mocks";
 import { setupAppIntegrationTest, waitForBootup } from "@app/test";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
 
 describe("Create Database flow", () => {
   it("should successfully provision a database within an environment", async () => {
@@ -107,5 +113,109 @@ describe("Create Database flow", () => {
       name: /Save/,
     });
     expect(saveBtn).toBeDisabled();
+  });
+
+  describe("when a duplicate db handle already exists in a different environment", () => {
+    it("should create a new database and not try to re-provision that database", async () => {
+      const dupeId = createId();
+      const testDupeDatabaseOp = defaultOperationResponse({
+        id: createId(),
+        type: "provision",
+        status: "succeeded",
+        _links: {
+          resource: defaultHalHref(`${testEnv.apiUrl}/databases/${dupeId}`),
+          account: defaultHalHref(
+            `${testEnv.apiUrl}/accounts/${testDestroyAccount.id}`,
+          ),
+          code_scan_result: defaultHalHref(),
+          self: defaultHalHref(),
+          ssh_portal_connections: defaultHalHref(),
+          ephemeral_sessions: defaultHalHref(),
+          logs: defaultHalHref(),
+          user: defaultHalHref(),
+        },
+      });
+      const dupeDb = defaultDatabaseResponse({
+        id: dupeId,
+        handle: "example-postgres",
+        type: "postgres",
+        connection_url: "postgres://some:val@wow.com:5432",
+        _embedded: {
+          disk: testDisk,
+          last_operation: testDupeDatabaseOp,
+        },
+        _links: {
+          account: defaultHalHref(
+            `${testEnv.apiUrl}/accounts/${testDestroyAccount.id}`,
+          ),
+          initialize_from: defaultHalHref(),
+          database_image: defaultHalHref(
+            `${testEnv.apiUrl}/database_images/${testPostgresDatabaseImage.id}`,
+          ),
+          service: defaultHalHref(
+            `${testEnv.apiUrl}/services/${testDatabaseServiceId}`,
+          ),
+          disk: defaultHalHref(`${testEnv.apiUrl}/disks/${testDisk.id}`),
+        },
+      });
+
+      server.use(
+        ...stacksWithResources({
+          accounts: [testAccount, testDestroyAccount],
+          databases: [dupeDb],
+        }),
+        ...verifiedUserHandlers(),
+        rest.post(
+          `${testEnv.apiUrl}/databases/:id/operations`,
+          async (_, res, ctx) => {
+            return res(ctx.json(testDatabaseOp));
+          },
+        ),
+        rest.get(
+          `${testEnv.apiUrl}/accounts/:envId/operations`,
+          (_, res, ctx) => {
+            return res(
+              ctx.json({
+                _embedded: { operations: [] },
+              }),
+            );
+          },
+        ),
+      );
+
+      const { App, store } = setupAppIntegrationTest({
+        initEntries: [`/create/db?environment_id=${testAccount.id}`],
+      });
+
+      await waitForBootup(store);
+
+      render(<App />);
+
+      await screen.findByText(testAccount.handle);
+      await screen.findByRole("button", { name: /Save/ });
+
+      await screen.findByText(/postgres v14/);
+      const dbSelector = await screen.findByRole("combobox", {
+        name: /new-db/,
+      });
+      await act(() => userEvent.selectOptions(dbSelector, "postgres v14"));
+      const inp = await screen.findByRole("textbox", {
+        name: "dbname",
+      });
+      await act(() => userEvent.clear(inp));
+      await act(() => userEvent.type(inp, "example-postgres"));
+
+      const saveBtn = await screen.findByRole("button", {
+        name: /Save/,
+      });
+
+      // go to next page
+      fireEvent.click(saveBtn);
+
+      // if these two checks fail then that means that an existing database was
+      // re-provisioned in a different environment
+      await screen.findByText(/Operations show real-time/);
+      expect(screen.queryByText(/example-postgres/)).toBeInTheDocument();
+    });
   });
 });

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -199,8 +199,15 @@ export const findDatabaseById = must(selectors.findById);
 
 export const selectDatabaseByHandle = createSelector(
   selectDatabasesAsList,
+  (_: AppState, p: { envId: string }) => p.envId,
   (_: AppState, p: { handle: string }) => p.handle,
-  (dbs, handle) => dbs.find((db) => db.handle === handle) || initDb,
+  (dbs, envId, handle) => {
+    const dbFound = dbs.find((db) => {
+      return db.environmentId === envId && db.handle === handle;
+    });
+
+    return dbFound || initDb;
+  },
 );
 
 export const selectDatabasesByOrgAsList = createSelector(
@@ -485,6 +492,7 @@ export const provisionDatabase = thunks.create<
 
   const dbAlreadyExists = yield* select(selectDatabaseByHandle, {
     handle: ctx.payload.handle,
+    envId: ctx.payload.envId,
   });
 
   let dbId = dbAlreadyExists.id;


### PR DESCRIPTION
When a user tries to create and provision a new database we first perform a check to see if a database with that exact name already exists within the system.  If it does already exist, we skip creating the database and instead move onto provision the database.

We do this because there are cases where a user can create a database but the provision operation fails (e.g. user hits plan limits).  When the user fixes the issue and returns to FTUX to try to reprovision, we would then say validation failed because the database already exists.  So if that database already exists we just try to reprovision.

Creating a database record and provisioning that database are two separate, atomic events.  Coordinating those events rests solely on the UI.  Users can create as many database records as they like, but provisioning a database then performs a plan limit check.

During FTUX the user selects a database and we inject a handle automatically based on env/db-type (the user can modify this).  When db provision fails (because of a plan limit), they have to bail out of the flow entirely to fix the issue.  When they come back to FTUX, their db is still sitting there with a failed provision operation.  At the time FTUX was built, this put the user in a broken state where they needed to delete the database (action we didnt support at the time) and essentially restart.

So instead we try to perform error recovery by looking up the database by handle and then triggering a provision operation on that db.

I will happily entertain the notion that this doesn't work well and we should rip it out for a better solution (e.g. let the user delete the database in the FTUX flow to recover), but this patch should resolve the issue.

https://aptible.slack.com/archives/C022RVCU2CT/p1700065685600039