### PR TITLE
fix: action button placement

### DIFF
--- a/src/ui/pages/stack-detail-hids.tsx
+++ b/src/ui/pages/stack-detail-hids.tsx
@@ -91,7 +91,7 @@ const ReportView = ({
       <Td>{date}</Td>
       <Td>{prettyEnglishDate(report.starts_at)}</Td>
       <Td>{prettyEnglishDate(report.ends_at)}</Td>
-      <Td className="flex gap-2 justify-end mr-4">
+      <Td variant="right">
         <Group variant="horizontal" size="sm">
           <DownloadReport
             filename={`report-${stack.name}-${date}.csv`}

--- a/src/ui/shared/table.tsx
+++ b/src/ui/shared/table.tsx
@@ -60,7 +60,7 @@ export const Td = ({
   variant = "left",
 }: CellProps) => {
   const align = () => {
-    if (variant === "right") return "text-right pr-4";
+    if (variant === "right") return "text-right pr-4 flex gap-2 justify-end";
     if (variant === "center") return "text-center";
     return "text-left";
   };


### PR DESCRIPTION
Make all buttons with Td variant="right" show on the right always

BEFORE

<img width="408" alt="Screenshot 2023-11-15 at 2 52 04 PM" src="https://github.com/aptible/app-ui/assets/4295811/d259c3cb-092f-4e2b-9780-9cc82184be00">
<img width="464" alt="Screenshot 2023-11-15 at 2 52 45 PM" src="https://github.com/aptible/app-ui/assets/4295811/a51d8155-c5a8-4948-b401-5148cd1c8b25">
<img width="359" alt="Screenshot 2023-11-15 at 3 20 08 PM" src="https://github.com/aptible/app-ui/assets/4295811/9d853b47-ef36-4723-9d55-d33893486423">

AFTER


<img width="237" alt="Screenshot 2023-11-15 at 2 59 06 PM" src="https://github.com/aptible/app-ui/assets/4295811/34c74b95-2e0a-4e38-beb6-3344d5a92d93">


