### PR TITLE
fix(op): users should be able to select operation logs

### DIFF
--- a/src/ui/pages/op-detail.tsx
+++ b/src/ui/pages/op-detail.tsx
@@ -1,23 +1,35 @@
-import { useMemo } from "react";
-import { useSelector } from "react-redux";
-import { useParams } from "react-router";
-
 import {
   cancelOpByIdPoll,
   pollOperationById,
   selectOperationById,
 } from "@app/deploy";
 import { AppState } from "@app/types";
-
-import { usePoller } from "../hooks";
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+import { batchActions } from "redux-batched-actions";
 import { LogViewer } from "../shared";
 
+const cancel = cancelOpByIdPoll();
 export const OpDetailPage = () => {
   const { id = "" } = useParams();
-  const action = useMemo(() => pollOperationById({ id }), [id]);
-  const cancel = useMemo(() => cancelOpByIdPoll(), []);
-  usePoller({ action, cancel });
+  const dispatch = useDispatch();
   const op = useSelector((s: AppState) => selectOperationById(s, { id }));
+  const action = pollOperationById({ id });
+
+  useEffect(() => {
+    dispatch(batchActions([cancel, action]));
+    return () => {
+      dispatch(cancel);
+    };
+  }, [id]);
+
+  useEffect(() => {
+    if (op.status === "failed" || op.status === "succeeded") {
+      dispatch(cancel);
+    }
+  }, [op.status]);
+
   return (
     <div className="py-2">
       <LogViewer op={op} />


### PR DESCRIPTION
The poller was causing the log viewer to be re-rendered everytime we fetched the operation.  When the operation is in a final state, we don't need to keep fetching it, so I removed the poller in those cases.