### PR TITLE
fix: signup & billing page scrolling

### DIFF
--- a/src/ui/pages/billing-method.tsx
+++ b/src/ui/pages/billing-method.tsx
@@ -132,6 +132,11 @@ const CreditCardForm = () => {
       {error ? <Banner variant="error">{error}</Banner> : null}
       <BannerMessages {...loader} />
 
+      <div className="flex flex-col gap-0">
+        <Label>Organization</Label>
+        <OrgPicker />
+      </div>
+
       <form className="space-y-4" onSubmit={onSubmitForm}>
         <Label>
           <span>Credit Card Number</span>
@@ -216,7 +221,7 @@ export const BillingMethodPage = () => {
   return (
     <StripeProvider>
       <HeroBgView className="flex gap-6">
-        <div className="bg-white/90 shadow p-16 lg:block hidden lg:w-[500px] h-fit min-h-screen">
+        <div className="bg-white/90 shadow p-12 lg:block hidden lg:w-[500px] h-fit min-h-screen">
           <div className="text-xl text-black font-bold">
             Try the platform hundreds of scaling engineering teams use to
             achieve enterprise best practices for their infrastructure
@@ -251,7 +256,7 @@ export const BillingMethodPage = () => {
           </p>
           <img
             src="/customer-logo-cloud.png"
-            className="text-center scale-90"
+            className="text-center scale-90 pb-[200px]"
             aria-label="Customer Logos"
           />
         </div>
@@ -271,8 +276,6 @@ export const BillingMethodPage = () => {
               <h1 className="text-gray-900 text-3xl font-semibold text-center">
                 Add Payment Information
               </h1>
-
-              <OrgPicker />
             </Group>
 
             <Banner variant="info" className="w-full">

--- a/src/ui/pages/plans.tsx
+++ b/src/ui/pages/plans.tsx
@@ -61,7 +61,7 @@ export const PlansPage = () => {
               <Link to={logoutUrl()}>Log Out</Link>
             </p>
           </div>
-          <div>
+          <div className="min-w-[260px]">
             <OrgPicker />
           </div>
         </Group>

--- a/src/ui/pages/signup.tsx
+++ b/src/ui/pages/signup.tsx
@@ -43,7 +43,7 @@ const validators = {
 
 const SignupMarketing = () => {
   return (
-    <div className="bg-white/90 shadow p-16 lg:block hidden lg:w-[500px] h-fit min-h-screen">
+    <div className="bg-white/90 shadow p-12 lg:block hidden lg:w-[500px] h-fit min-h-screen">
       <div className="text-xl text-black font-bold">
         Try the platform hundreds of scaling engineering teams use to achieve
         enterprise best practices for their infrastructure
@@ -75,7 +75,7 @@ const SignupMarketing = () => {
       </p>
       <img
         src="/customer-logo-cloud.png"
-        className="text-center scale-90"
+        className="text-center scale-90 pb-[200px]"
         aria-label="Customer Logos"
       />
     </div>
@@ -118,7 +118,7 @@ const SignupHeader = () => {
               enterprise best practices without building your own internal
               developer platform.
             </p>
-            <h1 className={`${tokens.type.h1} text-center pt-8`}>
+            <h1 className={`${tokens.type.h1} text-center pt-4`}>
               Get started for free
             </h1>
           </div>
@@ -204,7 +204,7 @@ export const SignupPage = () => {
     <HeroBgView className="flex gap-6">
       <SignupMarketing />
 
-      <div className="flex justify-center w-full">
+      <div className="flex-1 mx-auto max-w-[500px]">
         <Group variant="vertical">
           <SignupHeader />
 


### PR DESCRIPTION
**Changes**
• Make sidebar panel width match on Signup & Billing pages & reduce padding so its less tall
• Make sidebar always reach the bottom of viewports
• Make the Org Picker show in the form, so its super clear its for choosing an org
• Make the Org Picker have a min-width so it looks more clickable
• Reduced padding-top above the Get Started for Free headline to make the page less tall

**BEFORE — Bottom of Viewport**

<img width="1434" alt="Screenshot 2023-11-16 at 12 18 54 PM" src="https://github.com/aptible/app-ui/assets/4295811/1ecc2cd2-7b1c-420f-9048-2a5b38645f31">
<img width="1434" alt="Screenshot 2023-11-16 at 12 18 45 PM" src="https://github.com/aptible/app-ui/assets/4295811/235d3546-bf22-4a88-a661-cca1096a463f">
<img width="577" alt="Screenshot 2023-11-16 at 12 18 38 PM" src="https://github.com/aptible/app-ui/assets/4295811/f63dc87e-8a3c-4af8-9867-a028904ac6fc">


**AFTER  — Bottom of Viewport**

<img width="1434" alt="Screenshot 2023-11-16 at 12 04 46 PM" src="https://github.com/aptible/app-ui/assets/4295811/6fe56d44-2058-44ce-8167-e3b04fa1a784">
<img width="1434" alt="Screenshot 2023-11-16 at 12 05 21 PM" src="https://github.com/aptible/app-ui/assets/4295811/aea63dba-1966-4037-86bb-490b385da4b7">
<img width="652" alt="Screenshot 2023-11-16 at 12 06 55 PM" src="https://github.com/aptible/app-ui/assets/4295811/ab85a639-62c6-427b-9f1c-22f04050a64e">
