### PR TITLE
style: max and min labels

### DIFF
--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -199,7 +199,7 @@ const VerticalAutoscalingSection = ({
                   <FormGroup
                     splitWidthInputs
                     description="The minimum memory that vertical autoscaling can scale this service to"
-                    label="Minimum memory"
+                    label="Minimum Memory (MB)"
                     htmlFor="minimum-memory"
                   >
                     <Input
@@ -220,7 +220,7 @@ const VerticalAutoscalingSection = ({
                   <FormGroup
                     splitWidthInputs
                     description="The maximum memory that vertical autoscaling can scale this service to"
-                    label="Maximum memory"
+                    label="Maximum Memory (MB)"
                     htmlFor="maximum-memory"
                   >
                     <Input


### PR DESCRIPTION
Capitalize `Memory` and show the format `(MB)`

<img width="511" alt="Screenshot 2023-11-28 at 9 56 56 AM" src="https://github.com/aptible/app-ui/assets/4295811/2b0ec1ba-04fb-4688-959d-bf50be463fc8">
