### PR TITLE
fix(service): set correct container count

### DIFF
--- a/src/deploy/service/index.ts
+++ b/src/deploy/service/index.ts
@@ -95,7 +95,7 @@ export const deserializeDeployService = (
     dockerRef: payload.docker_ref,
     processType: payload.process_type,
     command: payload.command || "",
-    containerCount: payload.container_count || 1,
+    containerCount: payload.container_count ?? 0,
     containerMemoryLimitMb: payload.container_memory_limit_mb || 512,
     currentReleaseId: extractIdFromLink(links.current_release),
     instanceClass: payload.instance_class || DEFAULT_INSTANCE_CLASS,


### PR DESCRIPTION
We were incorrectly coercing 0 into 1 because 1 was our default when `container_count` was `null`.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing

https://aptible.slack.com/archives/C05CMUW3LHX/p1701290462412809