### PR TITLE
style: left align app ID column

### DIFF
--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -65,7 +65,7 @@ const AppPrimaryCell = ({ app }: AppCellProps) => {
 };
 
 const AppIdCell = ({ app }: AppCellProps) => {
-  return <Td variant="center">{app.id}</Td>;
+  return <Td>{app.id}</Td>;
 };
 
 const AppServicesCell = ({ app }: AppCellProps) => {
@@ -175,7 +175,7 @@ export const AppListByOrg = () => {
       <Table>
         <THead>
           <Th>Handle</Th>
-          <Th variant="center">ID</Th>
+          <Th>ID</Th>
           <Th>Environment</Th>
           <Th>Services</Th>
           <Th>Est. Monthly Cost</Th>
@@ -251,7 +251,7 @@ export const AppListByEnvironment = ({
       <Table>
         <THead>
           <Th>Handle</Th>
-          <Th variant="center">ID</Th>
+          <Th>ID</Th>
           <Th>Services</Th>
           <Th>Est. Monthly Cost</Th>
         </THead>
@@ -299,7 +299,7 @@ export const AppListByCertificate = ({
       <Table>
         <THead>
           <Th>Handle</Th>
-          <Th variant="center">ID</Th>
+          <Th>ID</Th>
           <Th>Environment</Th>
           <Th>Services</Th>
           <Th>Est. Monthly Cost</Th>


### PR DESCRIPTION
All our ID columns are left aligned, this change matches this behavior for the App List table

BEFORE
<img width="513" alt="Screenshot 2023-11-29 at 2 57 57 PM" src="https://github.com/aptible/app-ui/assets/4295811/499ec920-bc5c-4da2-ad8e-4d5427e4edca">

AFTER
<img width="522" alt="Screenshot 2023-11-29 at 2 58 04 PM" src="https://github.com/aptible/app-ui/assets/4295811/120aeda9-b161-471b-a432-98d3585ca45d">
