### PR TITLE
style: label tweaks

### DIFF
--- a/src/ui/layouts/service-detail-layout.tsx
+++ b/src/ui/layouts/service-detail-layout.tsx
@@ -88,7 +88,7 @@ export function ServiceHeader({
       </DetailInfoGrid>
       {service.command ? (
         <div>
-          <div className="-ml-2 flex justify-between items-center">
+          <div className="-ml-2 flex justify-between items-center pt-1">
             <div className="flex flex-1">
               <div
                 className="font-semibold flex items-center cursor-pointer"
@@ -96,7 +96,7 @@ export function ServiceHeader({
                 onKeyUp={() => setOpen(!isOpen)}
               >
                 {isOpen ? <IconChevronDown /> : <IconChevronRight />}
-                <p>Command</p>
+                <p>Show Command</p>
               </div>
             </div>
           </div>

--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -164,7 +164,7 @@ const VerticalAutoscalingSection = ({
                   onKeyUp={() => setOpen(!advancedIsOpen)}
                 >
                   {advancedIsOpen ? <IconChevronDown /> : <IconChevronRight />}
-                  <p>{advancedIsOpen ? "Hide" : "Show"} Advanced settings</p>
+                  <p>{advancedIsOpen ? "Hide" : "Show"} Advanced Settings</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Changes
• Add the word `Show` before `Command` to pattern match
• Capitalize the word `Settings` in `Show Advanced Settings`

BEFORE

<img width="317" alt="Screenshot 2023-12-05 at 1 42 35 PM" src="https://github.com/aptible/app-ui/assets/4295811/7d9bf9cd-79f9-4f3d-a418-703c9a89a361">


AFTER
<img width="352" alt="Screenshot 2023-12-05 at 1 43 07 PM" src="https://github.com/aptible/app-ui/assets/4295811/fa699f6a-2ec4-43a0-a4aa-54c68263cce0">

