### PR TITLE
Style services header tweaks

### DIFF
--- a/src/ui/layouts/service-detail-layout.tsx
+++ b/src/ui/layouts/service-detail-layout.tsx
@@ -63,27 +63,27 @@ export function ServiceHeader({
         docsUrl="https://www.aptible.com/docs/services"
       />
 
-      <DetailInfoGrid>
+      <DetailInfoGrid columns={3}>
         <DetailInfoItem title="ID">{service.id}</DetailInfoItem>
+        <DetailInfoItem title="Container Size">
+          {metrics.containerSizeGB} GB
+        </DetailInfoItem>
         <DetailInfoItem title="Type">{service.processType}</DetailInfoItem>
         <DetailInfoItem title="App">
           <Link to={appDetailUrl(app.id)}>{app.handle}</Link>
         </DetailInfoItem>
-        <DetailInfoItem title="Environment">
-          <Link to={environmentDetailUrl(env.id)}>{env.handle}</Link>
-        </DetailInfoItem>
-        <DetailInfoItem title="Container Size">
-          {metrics.containerSizeGB} GB
-        </DetailInfoItem>
-        <DetailInfoItem title="CPU Share">{totalCPU}</DetailInfoItem>
         <DetailInfoItem title="Container Count">
           {service.containerCount}
         </DetailInfoItem>
-        <DetailInfoItem title="Container Profile">
-          {metrics.containerProfile.name}
+        <DetailInfoItem title="CPU Share">{totalCPU}</DetailInfoItem>
+        <DetailInfoItem title="Environment">
+          <Link to={environmentDetailUrl(env.id)}>{env.handle}</Link>
         </DetailInfoItem>
         <DetailInfoItem title="Cost">
           ${((metrics.estimatedCostInDollars * 1024) / 1000).toFixed(2)}
+        </DetailInfoItem>
+        <DetailInfoItem title="Container Profile">
+          {metrics.containerProfile.name}
         </DetailInfoItem>
       </DetailInfoGrid>
       {service.command ? (

--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -200,7 +200,7 @@ const ServiceOrgListRow = ({
           {service.appId ? (
             <Link
               to={appDetailUrl(service.appId)}
-              className="text-black group-hover:text-indigo hover:text-indigo w-[130px] h-[16px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
+              className="text-black group-hover:text-indigo hover:text-indigo w-[130px] mb-[-5px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
             >
               {app.handle}
             </Link>
@@ -208,7 +208,7 @@ const ServiceOrgListRow = ({
           {service.databaseId ? (
             <Link
               to={databaseDetailUrl(service.databaseId)}
-              className="text-black group-hover:text-indigo hover:text-indigo w-[130px] h-[16px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
+              className="text-black group-hover:text-indigo hover:text-indigo w-[130px] mb-[-5px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
             >
               {db.handle}
             </Link>

--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -197,24 +197,26 @@ const ServiceOrgListRow = ({
         </Td>
 
         <Td>
-          {service.appId ? (
-            <Link
-              to={appDetailUrl(service.appId)}
-              className="text-black group-hover:text-indigo hover:text-indigo w-[130px] mb-[-5px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
-            >
-              {app.handle}
-            </Link>
-          ) : null}
-          {service.databaseId ? (
-            <Link
-              to={databaseDetailUrl(service.databaseId)}
-              className="text-black group-hover:text-indigo hover:text-indigo w-[130px] mb-[-5px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
-            >
-              {db.handle}
-            </Link>
-          ) : null}
-          <div className={tokens.type["normal lighter"]}>
-            {service.appId ? "App" : "Database"}
+          <div className="flex flex-col gap-0">
+            {service.appId ? (
+              <Link
+                to={appDetailUrl(service.appId)}
+                className="text-black group-hover:text-indigo hover:text-indigo w-[130px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
+              >
+                {app.handle}
+              </Link>
+            ) : null}
+            {service.databaseId ? (
+              <Link
+                to={databaseDetailUrl(service.databaseId)}
+                className="text-black group-hover:text-indigo hover:text-indigo w-[130px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
+              >
+                {db.handle}
+              </Link>
+            ) : null}
+            <div className={tokens.type["normal lighter"]}>
+              {service.appId ? "App" : "Database"}
+            </div>
           </div>
         </Td>
 


### PR DESCRIPTION
Make Service Header Component 3 columns & organize related information together by column

BEFORE

<img width="1191" alt="Screenshot 2023-12-08 at 2 51 17 PM" src="https://github.com/aptible/app-ui/assets/4295811/95a6d873-f312-439b-81a7-2bb9c80dff65">


AFTER

<img width="1133" alt="Screenshot 2023-12-08 at 2 51 23 PM" src="https://github.com/aptible/app-ui/assets/4295811/4b7f4946-3f9a-42b4-86cb-47cc19a5cb74">


**Allow descenders to show and not get cutoff**

BEFORE — g, y, p gets cutoff b/c of the overflow hidden

<img width="192" alt="Screenshot 2023-12-08 at 3 03 47 PM" src="https://github.com/aptible/app-ui/assets/4295811/a31e888f-dad8-4b52-85f4-f28cadbd7b86">

AFTER

<img width="256" alt="Screenshot 2023-12-08 at 3 03 39 PM" src="https://github.com/aptible/app-ui/assets/4295811/3c5a8644-b472-4ca8-8116-878efb601d61">
