### PR TITLE
fix(environments): race condition overriding stats on detail page

### DIFF
--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -114,17 +114,21 @@ export interface DeployEnvironment extends Timestamps {
   type: "production" | "development";
   handle: string;
   activated: boolean;
+  sweetnessStack: string;
+  stackId: string;
+  onboardingStatus: OnboardingStatus;
+  totalAppCount: number;
+  totalDatabaseCount: number;
+}
+
+export interface DeployEnvironmentStats {
+  id: string;
   containerCount: number;
   domainCount: number;
   totalDiskSize: number;
-  totalAppCount: number;
   appContainerCount: number;
   databaseContainerCount: number;
-  totalDatabaseCount: number;
-  sweetnessStack: string;
   totalBackupSize: number;
-  stackId: string;
-  onboardingStatus: OnboardingStatus;
 }
 
 export interface DeployStack extends Timestamps {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -14,6 +14,7 @@ import type {
   DeployDisk,
   DeployEndpoint,
   DeployEnvironment,
+  DeployEnvironmentStats,
   DeployImage,
   DeployLogDrain,
   DeployMetricDrain,
@@ -190,6 +191,7 @@ export interface AppState extends QueryState {
   certificates: MapEntity<DeployCertificate>;
   endpoints: MapEntity<DeployEndpoint>;
   environments: MapEntity<DeployEnvironment>;
+  environmentStats: MapEntity<DeployEnvironmentStats>;
   serviceDefinitions: MapEntity<DeployServiceDefinition>;
   stacks: MapEntity<DeployStack>;
   disks: MapEntity<DeployDisk>;

--- a/src/ui/pages/styles.tsx
+++ b/src/ui/pages/styles.tsx
@@ -6,6 +6,7 @@ import {
   defaultDeployDatabase,
   defaultDeployEndpoint,
   defaultDeployEnvironment,
+  defaultDeployEnvironmentStats,
   defaultDeployOperation,
   defaultDeployService,
   defaultDeployStack,
@@ -721,15 +722,20 @@ const DetailBoxes = () => {
   const env = defaultDeployEnvironment({
     id: "123",
     stackId: stack.id,
-    appContainerCount: 4,
-    databaseContainerCount: 10,
     totalAppCount: 4,
     totalDatabaseCount: 10,
-    totalBackupSize: 1024,
   });
   const ept = defaultDeployEndpoint({
     id: "333",
     virtualDomain: "https://something.great",
+  });
+  const stats = defaultDeployEnvironmentStats({
+    containerCount: 1,
+    domainCount: 2,
+    totalDiskSize: 3,
+    appContainerCount: 4,
+    databaseContainerCount: 5,
+    totalBackupSize: 6,
   });
 
   return (
@@ -744,6 +750,7 @@ const DetailBoxes = () => {
         environment={env}
         latestOperation={op}
         endpoints={[ept]}
+        stats={stats}
       />
       <AppHeader app={app} />
       <DatabaseHeader database={db} service={service} />


### PR DESCRIPTION
The root `/accounts` endpoint does *not* include any stats besides app and database count for performance reasons.  `/accounts/:id` does include all the stats for an individual account.  This change creates a separate container for stats that we set to our cache only when we fetch an individual account endpoint.  This ensures we always have the correct stats on an account detail page.