### PR TITLE
style: add label to edit backup policy state

### DIFF
--- a/src/ui/pages/environment-detail-backups.test.tsx
+++ b/src/ui/pages/environment-detail-backups.test.tsx
@@ -67,7 +67,7 @@ describe("EnvironmentBackupsPage", () => {
     });
 
     const edit = await screen.findByRole("button", {
-      name: /Edit Backup Retention Policy/,
+      name: /Edit Policy/,
     });
     fireEvent.click(edit);
 

--- a/src/ui/shared/environment/backup-retention-policy-view.tsx
+++ b/src/ui/shared/environment/backup-retention-policy-view.tsx
@@ -86,7 +86,8 @@ export const BackupRpView = ({ envId }: { envId: string }) => {
     return (
       <Box>
         <Group>
-          <div className="w-[300px]">
+          <h3 className={tokens.type.h3}>Backup Retention Policy</h3>
+          <div className="w-[260px]">
             <KeyValueGroup data={data} />
           </div>
 
@@ -98,7 +99,7 @@ export const BackupRpView = ({ envId }: { envId: string }) => {
               type="button"
             >
               <IconEdit variant="sm" className="mr-2" />
-              Edit Backup Retention Policy
+              Edit Policy
             </ButtonAdmin>
           </div>
         </Group>


### PR DESCRIPTION
**Changes**
Add label to default edit backup policy state

BEFORE
<img width="930" alt="Screenshot 2023-12-12 at 2 15 56 AM" src="https://github.com/aptible/app-ui/assets/4295811/e0474c9f-61be-486a-b989-96e848cb851d">

AFTER
<img width="926" alt="Screenshot 2023-12-12 at 2 14 27 AM" src="https://github.com/aptible/app-ui/assets/4295811/c0f909ba-ff44-470b-991e-b08a8dd92f6a">

---

**TODO**
• **Make 0 be the default value** for Yearly Backups in the default and edit states
<img width="297" alt="Screenshot 2023-12-12 at 2 20 15 AM" src="https://github.com/aptible/app-ui/assets/4295811/d9567a2a-cbb1-4a7a-96b3-bb90730f8499">
<img width="376" alt="Screenshot 2023-12-12 at 2 20 08 AM" src="https://github.com/aptible/app-ui/assets/4295811/482f31f3-6572-41ed-8713-6ad925ff9349">