### PR TITLE
refactor(services): top-level tab should be apps only

### DIFF
--- a/src/deploy/service/index.ts
+++ b/src/deploy/service/index.ts
@@ -37,9 +37,7 @@ import { CONTAINER_PROFILES, GB } from "../container/utils";
 import {
   cancelDatabaseOpsPoll,
   fetchDatabaseOperations,
-  findDatabaseById,
   selectDatabaseById,
-  selectDatabases,
 } from "../database";
 import {
   findEnvById,

--- a/src/ui/pages/app-detail-services.tsx
+++ b/src/ui/pages/app-detail-services.tsx
@@ -2,7 +2,7 @@ import { selectAppById } from "@app/deploy";
 import { AppState } from "@app/types";
 import { useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
-import { AppServicesOverview, DetailPageSections } from "../shared";
+import { AppServicesByApp, DetailPageSections } from "../shared";
 
 export function AppDetailServicesPage() {
   const { id = "" } = useParams();
@@ -10,7 +10,7 @@ export function AppDetailServicesPage() {
 
   return (
     <DetailPageSections>
-      <AppServicesOverview appId={app.id} />
+      <AppServicesByApp appId={app.id} />
     </DetailPageSections>
   );
 }

--- a/src/ui/pages/services.tsx
+++ b/src/ui/pages/services.tsx
@@ -6,13 +6,13 @@ import { useQuery, useSelector } from "starfx/react";
 import { usePaginate } from "../hooks";
 import { AppSidebarLayout } from "../layouts";
 import {
+  AppServicesByOrg,
   DescBar,
   FilterBar,
   Group,
   InputSearch,
   LoadingBar,
   PaginateBar,
-  ServiceByOrgTable,
   TitleBar,
 } from "../shared";
 
@@ -56,7 +56,7 @@ export function ServicesPage() {
           </FilterBar>
         </Group>
 
-        <ServiceByOrgTable
+        <AppServicesByOrg
           paginated={paginated}
           onSort={(key) => {
             if (key === sortBy) {

--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -3,18 +3,15 @@ import {
   calcServiceMetrics,
   fetchServicesByAppId,
   selectAppById,
-  selectDatabaseById,
   selectServicesByAppId,
+  serviceCommandText,
 } from "@app/deploy";
 import { useQuery } from "@app/fx";
 import {
   appDeployResumeUrl,
   appDetailUrl,
-  appServicePathMetricsUrl,
   appServiceScalePathUrl,
   appServiceUrl,
-  databaseDetailUrl,
-  databaseScaleUrl,
 } from "@app/routes";
 import { AppState, DeployService, DeployServiceRow } from "@app/types";
 import { PaginateProps, usePaginate } from "@app/ui/hooks";
@@ -26,7 +23,6 @@ import { Code } from "../code";
 import { CopyTextButton } from "../copy";
 import { Group } from "../group";
 import { IconChevronDown } from "../icons";
-import { PreCode, listToInvertedTextColor } from "../pre-code";
 import {
   ActionBar,
   DescBar,
@@ -38,117 +34,86 @@ import { EmptyTr, TBody, THead, Table, Td, Th, Tr } from "../table";
 import { tokens } from "../tokens";
 import { Tooltip } from "../tooltip";
 
-const AppServiceListRow = ({
-  service,
-}: {
-  service: DeployService;
-}) => {
-  const app = useSelector((s: AppState) =>
-    selectAppById(s, { id: service.appId }),
-  );
-  const metrics = calcServiceMetrics(service);
-  const { totalCPU } = calcMetrics([service]);
-
+const NameCell = ({ service }: { service: DeployService }) => {
   return (
-    <>
-      <Tr>
-        <Td>
-          <Link to={appServicePathMetricsUrl(app.id, service.id)}>
-            <div className="text-base font-semibold text-gray-900">
-              {service.processType}
-            </div>
+    <Td className="w-[180px]">
+      <div className="flex items-center">
+        <img
+          src="/resource-types/logo-service.png"
+          className="w-[32px] h-[32px] mr-2 align-middle"
+          aria-label="App"
+        />
+        <div>
+          <Link
+            to={appServiceUrl(service.appId, service.id)}
+            className="text-black group-hover:text-indigo hover:text-indigo"
+          >
+            {service.processType}
           </Link>
           <div className={tokens.type["normal lighter"]}>ID: {service.id}</div>
-        </Td>
-
-        <Td>
-          <div className={tokens.type.darker}>{metrics.containerSizeGB} GB</div>
-        </Td>
-
-        <Td>
-          <div className={tokens.type.darker}>{totalCPU}</div>
-        </Td>
-
-        <Td>
-          <div className={tokens.type.darker}>{service.containerCount}</div>
-        </Td>
-
-        <Td>
-          <div className={tokens.type["normal lighter"]}>
-            {metrics.containerProfile.name}
-          </div>
-        </Td>
-
-        <Td>
-          <div className={tokens.type.darker}>
-            ${((metrics.estimatedCostInDollars * 1024) / 1000).toFixed(2)}
-          </div>
-        </Td>
-
-        <Td variant="right">
-          <Group size="sm" variant="horizontal">
-            <ButtonLink
-              className="w-15"
-              size="sm"
-              to={appServicePathMetricsUrl(app.id, service.id)}
-              variant="primary"
-            >
-              Metrics
-            </ButtonLink>
-            <ButtonLink
-              className="w-15"
-              size="sm"
-              to={appServiceScalePathUrl(app.id, service.id)}
-              variant="primary"
-            >
-              Scale
-            </ButtonLink>
-          </Group>
-        </Td>
-      </Tr>
-      {service.command ? (
-        <Tr>
-          <Td colSpan={7} className="pr-4">
-            <span className="text-sm text-gray-500">Command</span>
-            <div>
-              <PreCode
-                allowCopy
-                segments={listToInvertedTextColor(service.command.split(" "))}
-              />
-            </div>
-          </Td>
-        </Tr>
-      ) : null}
-    </>
+        </div>
+      </div>
+    </Td>
   );
 };
 
-function AppServiceTable({
-  paginated,
-}: { paginated: PaginateProps<DeployService> }) {
+const CmdCell = ({
+  service,
+  size = "sm",
+}: { service: DeployService; size?: "sm" | "lg" }) => {
+  const cmd = serviceCommandText(service);
+  const sizes = {
+    sm: 15,
+    lg: 30,
+  };
+  const charLen = sizes[size];
   return (
-    <Table>
-      <THead>
-        <Th>Service</Th>
-        <Th>Memory Limit</Th>
-        <Th>CPU Share</Th>
-        <Th>Container Count</Th>
-        <Th>Profile</Th>
-        <Th>Est. Monthly Cost</Th>
-        <Th variant="right">Actions</Th>
-      </THead>
-
-      <TBody>
-        {paginated.data.length === 0 ? <EmptyTr colSpan={7} /> : null}
-        {paginated.data.map((service) => (
-          <AppServiceListRow key={service.id} service={service} />
-        ))}
-      </TBody>
-    </Table>
+    <Td>
+      <Group size="sm" variant="horizontal" className="items-center">
+        <div>
+          {cmd.length > charLen ? (
+            <Group variant="horizontal" size="sm" className="items-center">
+              <Tooltip text={cmd} fluid>
+                <Code className="text-ellipsis">{cmd.slice(0, charLen)}</Code>
+              </Tooltip>
+              <CopyTextButton text={cmd} />
+            </Group>
+          ) : (
+            <Group variant="horizontal" size="sm" className="items-center">
+              <Code>{cmd}</Code>
+              <CopyTextButton text={cmd} />
+            </Group>
+          )}
+        </div>
+      </Group>
+    </Td>
   );
-}
+};
 
-const ServiceOrgListRow = ({
+const DetailsCell = ({ service }: { service: DeployService }) => {
+  const metrics = calcServiceMetrics(service);
+  const { totalCPU } = calcMetrics([service]);
+  return (
+    <Td className={tokens.type.darker}>
+      <div className={tokens.type.darker}>
+        {service.containerCount} Container
+      </div>
+      <div className={tokens.type["normal lighter"]}>
+        {metrics.containerSizeGB} GB · {totalCPU} CPU
+      </div>
+    </Td>
+  );
+};
+
+const CostCell = ({ service }: { service: DeployServiceRow }) => {
+  return (
+    <Td>
+      <div className={tokens.type.darker}>${service.cost.toFixed(2)}</div>
+    </Td>
+  );
+};
+
+const AppServiceByAppRow = ({
   service,
 }: {
   service: DeployServiceRow;
@@ -156,46 +121,45 @@ const ServiceOrgListRow = ({
   const app = useSelector((s: AppState) =>
     selectAppById(s, { id: service.appId }),
   );
-  const db = useSelector((s: AppState) =>
-    selectDatabaseById(s, { id: service.databaseId }),
-  );
-  const metrics = calcServiceMetrics(service);
-  const { totalCPU } = calcMetrics([service]);
-  const cmd = service.command || "Docker CMD";
 
   return (
     <>
       <Tr>
-        <Td className="w-[180px]">
-          <div className="flex items-center">
-            <img
-              src="/resource-types/logo-service.png"
-              className="w-[32px] h-[32px] mr-2 align-middle"
-              aria-label="App"
-            />
-            <div>
-              {service.appId ? (
-                <Link
-                  to={appServiceUrl(service.appId, service.id)}
-                  className="text-black group-hover:text-indigo hover:text-indigo"
-                >
-                  {service.processType}
-                </Link>
-              ) : null}
-              {service.databaseId ? (
-                <Link
-                  to={databaseDetailUrl(service.databaseId)}
-                  className="text-black group-hover:text-indigo hover:text-indigo"
-                >
-                  {service.processType}
-                </Link>
-              ) : null}
-              <div className={tokens.type["normal lighter"]}>
-                ID: {service.id}
-              </div>
-            </div>
+        <NameCell service={service} />
+
+        <CmdCell service={service} size="lg" />
+        <DetailsCell service={service} />
+        <CostCell service={service} />
+
+        <Td variant="right">
+          <div className="h-[40px] flex items-center">
+            <ButtonLink
+              size="sm"
+              to={appServiceScalePathUrl(app.id, service.id)}
+              variant="primary"
+            >
+              Scale
+            </ButtonLink>
           </div>
         </Td>
+      </Tr>
+    </>
+  );
+};
+
+const AppServiceByOrgRow = ({
+  service,
+}: {
+  service: DeployServiceRow;
+}) => {
+  const app = useSelector((s: AppState) =>
+    selectAppById(s, { id: service.appId }),
+  );
+
+  return (
+    <>
+      <Tr>
+        <NameCell service={service} />
 
         <Td>
           <div className="flex flex-col gap-0">
@@ -207,61 +171,19 @@ const ServiceOrgListRow = ({
                 {app.handle}
               </Link>
             ) : null}
-            {service.databaseId ? (
-              <Link
-                to={databaseDetailUrl(service.databaseId)}
-                className="text-black group-hover:text-indigo hover:text-indigo w-[130px] text-ellipsis inline-block whitespace-nowrap overflow-hidden"
-              >
-                {db.handle}
-              </Link>
-            ) : null}
-            <div className={tokens.type["normal lighter"]}>
-              {service.appId ? "App" : "Database"}
-            </div>
           </div>
         </Td>
 
         <EnvStackCell environmentId={service.environmentId} />
-
-        <Td>
-          <Group size="sm" variant="horizontal" className="items-center">
-            <div className="w-[150px]">
-              {cmd.length > 15 ? (
-                <Group variant="horizontal" size="sm">
-                  <Tooltip text={cmd} fluid>
-                    <Code className="text-ellipsis">{cmd.slice(0, 15)}</Code>
-                  </Tooltip>
-                  <CopyTextButton text={cmd} />
-                </Group>
-              ) : (
-                <Code>{cmd}</Code>
-              )}
-            </div>
-          </Group>
-        </Td>
-
-        <Td className={tokens.type.darker}>
-          <div className={tokens.type.darker}>
-            {service.containerCount} Container
-          </div>
-          <div className={tokens.type["normal lighter"]}>
-            {metrics.containerSizeGB} GB · {totalCPU} CPU
-          </div>
-        </Td>
-
-        <Td>
-          <div className={tokens.type.darker}>${service.cost.toFixed(2)}</div>
-        </Td>
+        <CmdCell service={service} />
+        <DetailsCell service={service} />
+        <CostCell service={service} />
 
         <Td variant="right">
           <div className="h-[40px] flex items-center">
             <ButtonLink
               size="sm"
-              to={
-                service.appId
-                  ? appServiceScalePathUrl(app.id, service.id)
-                  : databaseScaleUrl(service.databaseId)
-              }
+              to={appServiceScalePathUrl(app.id, service.id)}
               variant="primary"
             >
               Scale
@@ -273,7 +195,7 @@ const ServiceOrgListRow = ({
   );
 };
 
-export function ServiceByOrgTable({
+export function AppServicesByOrg({
   paginated,
   onSort,
 }: {
@@ -299,7 +221,7 @@ export function ServiceByOrgTable({
           className="cursor-pointer hover:text-black group"
           onClick={() => onSort("resourceHandle")}
         >
-          Resource{" "}
+          App{" "}
           <div className="inline-block">
             <IconChevronDown
               variant="sm"
@@ -328,14 +250,14 @@ export function ServiceByOrgTable({
       <TBody>
         {paginated.data.length === 0 ? <EmptyTr colSpan={6} /> : null}
         {paginated.data.map((service) => (
-          <ServiceOrgListRow key={service.id} service={service} />
+          <AppServiceByOrgRow key={service.id} service={service} />
         ))}
       </TBody>
     </Table>
   );
 }
 
-export function AppServicesOverview({
+export function AppServicesByApp({
   appId,
 }: {
   appId: string;
@@ -372,7 +294,22 @@ export function AppServicesOverview({
         </FilterBar>
       </Group>
 
-      <AppServiceTable paginated={paginated} />
+      <Table>
+        <THead>
+          <Th>Service</Th>
+          <Th>Command</Th>
+          <Th>Details</Th>
+          <Th>Estimated Monthly Cost</Th>
+          <Th variant="right">Actions</Th>
+        </THead>
+
+        <TBody>
+          {paginated.data.length === 0 ? <EmptyTr colSpan={5} /> : null}
+          {paginated.data.map((service) => (
+            <AppServiceByAppRow key={service.id} service={service} />
+          ))}
+        </TBody>
+      </Table>
     </Group>
   );
 }


### PR DESCRIPTION
I also updated the app-detail page's services tab to match.  I removed the `Metrics` button because it's not an action and the Service column already points to it.
