### PR TITLE
fix(poll): cancel pollers when switching pages

### DIFF
--- a/src/ui/hooks/use-env-ops-poller.ts
+++ b/src/ui/hooks/use-env-ops-poller.ts
@@ -29,6 +29,10 @@ export const useEnvOpsPoller = ({
     } else {
       dispatch(cancelEnvOperationsPoll());
     }
+
+    return () => {
+      dispatch(cancelEnvOperationsPoll());
+    };
   }, [isTabActive, appId, envId]);
 
   return pollLoader;

--- a/src/ui/hooks/use-poller.ts
+++ b/src/ui/hooks/use-poller.ts
@@ -21,5 +21,9 @@ export const usePoller = ({
     } else {
       dispatch(cancel);
     }
+
+    return () => {
+      dispatch(cancel);
+    };
   }, [isTabActive, action, cancel]);
 };


### PR DESCRIPTION
A recent change to the way we poll operations caused pollers to run even when the user leaves the page -- including when the user is logged out.  This is a regression.  I'm going to focus on re-implementing polling app-wide to prevent us from hitting these endpoints so much.  For now, this should fix the immediate problem.