### PR TITLE
fix(settings): email must be verified

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,5 +1,6 @@
 import * as routes from "@app/routes";
 import {
+  AccountOwnerRequired,
   ActivityPage,
   AddSecurityKeyPage,
   AllRequired,
@@ -654,7 +655,9 @@ export const appRoutes: RouteObject[] = [
     path: routes.SETTINGS_PATH,
     element: (
       <AuthRequired>
-        <SettingsLayout />
+        <VerifyEmailRequired>
+          <SettingsLayout />
+        </VerifyEmailRequired>
       </AuthRequired>
     ),
     children: [
@@ -674,9 +677,11 @@ export const appRoutes: RouteObject[] = [
     path: routes.SETTINGS_PATH,
     element: (
       <AuthRequired>
-        <ElevateRequired>
-          <SettingsLayout />
-        </ElevateRequired>
+        <VerifyEmailRequired>
+          <ElevateRequired>
+            <SettingsLayout />
+          </ElevateRequired>
+        </VerifyEmailRequired>
       </AuthRequired>
     ),
     children: [
@@ -711,44 +716,59 @@ export const appRoutes: RouteObject[] = [
     path: routes.TEAM_PATH,
     element: (
       <AuthRequired>
-        <SettingsLayout>
-          <TeamPage />
-        </SettingsLayout>
+        <VerifyEmailRequired>
+          <SettingsLayout />
+        </VerifyEmailRequired>
       </AuthRequired>
     ),
-  },
+    children: [
+      {
+        index: true,
+        element: <TeamPage />,
+      },
 
-  {
-    path: routes.TEAM_MEMBERS_PATH,
-    element: (
-      <AuthRequired>
-        <SettingsLayout>
-          <TeamMembersPage />
-        </SettingsLayout>
-      </AuthRequired>
-    ),
-  },
+      {
+        path: routes.TEAM_MEMBERS_PATH,
+        element: <TeamMembersPage />,
+      },
 
-  {
-    path: routes.TEAM_MEMBERS_EDIT_PATH,
-    element: (
-      <AuthRequired>
-        <SettingsLayout>
-          <TeamMembersEditPage />
-        </SettingsLayout>
-      </AuthRequired>
-    ),
-  },
+      {
+        path: routes.TEAM_MEMBERS_EDIT_PATH,
+        element: <TeamMembersEditPage />,
+      },
 
-  {
-    path: routes.TEAM_INVITE_PATH,
-    element: (
-      <AuthRequired>
-        <SettingsLayout>
-          <TeamInvitePage />
-        </SettingsLayout>
-      </AuthRequired>
-    ),
+      {
+        path: routes.TEAM_INVITE_PATH,
+        element: <TeamInvitePage />,
+      },
+      {
+        path: routes.TEAM_ROLES_PATH,
+        element: <TeamRolesPage />,
+      },
+
+      {
+        path: routes.TEAM_PENDING_INVITES_PATH,
+        element: <TeamPendingInvitesPage />,
+      },
+
+      {
+        path: routes.TEAM_SSO_PATH,
+        element: (
+          <AccountOwnerRequired>
+            <TeamSsoPage />
+          </AccountOwnerRequired>
+        ),
+      },
+
+      {
+        path: routes.TEAM_CONTACTS_PATH,
+        element: (
+          <AccountOwnerRequired>
+            <TeamContactsPage />
+          </AccountOwnerRequired>
+        ),
+      },
+    ],
   },
 
   {
@@ -756,50 +776,6 @@ export const appRoutes: RouteObject[] = [
     element: (
       <AuthRequired>
         <TeamAcceptInvitePage />
-      </AuthRequired>
-    ),
-  },
-
-  {
-    path: routes.TEAM_ROLES_PATH,
-    element: (
-      <AuthRequired>
-        <SettingsLayout>
-          <TeamRolesPage />
-        </SettingsLayout>
-      </AuthRequired>
-    ),
-  },
-
-  {
-    path: routes.TEAM_PENDING_INVITES_PATH,
-    element: (
-      <AuthRequired>
-        <SettingsLayout>
-          <TeamPendingInvitesPage />
-        </SettingsLayout>
-      </AuthRequired>
-    ),
-  },
-
-  {
-    path: routes.TEAM_SSO_PATH,
-    element: (
-      <AuthRequired>
-        <SettingsLayout>
-          <TeamSsoPage />
-        </SettingsLayout>
-      </AuthRequired>
-    ),
-  },
-
-  {
-    path: routes.TEAM_CONTACTS_PATH,
-    element: (
-      <AuthRequired>
-        <SettingsLayout>
-          <TeamContactsPage />
-        </SettingsLayout>
       </AuthRequired>
     ),
   },

--- a/src/app/test/security.test.tsx
+++ b/src/app/test/security.test.tsx
@@ -1,0 +1,109 @@
+import {
+  server,
+  testElevatedToken,
+  testEnv,
+  testUserNotVerified,
+  testUserVerified,
+  verifiedUserHandlers,
+} from "@app/mocks";
+import {
+  securitySettingsUrl,
+  settingsUrl,
+  sshSettingsUrl,
+  teamSsoUrl,
+} from "@app/routes";
+import { setupAppIntegrationTest, waitForBootup } from "@app/test";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+
+describe("Settings", () => {
+  it("should not allow unverified users to access security page", async () => {
+    server.use(...verifiedUserHandlers({ user: testUserNotVerified }));
+    const { App, store } = setupAppIntegrationTest({
+      initEntries: [securitySettingsUrl()],
+    });
+
+    await waitForBootup(store);
+
+    render(<App />);
+
+    await screen.findByRole("heading", { name: /Check your Email/ });
+  });
+
+  it("should have elevated token to access security page", async () => {
+    server.use(
+      ...verifiedUserHandlers(),
+      rest.post(`${testEnv.authUrl}/tokens`, (_, res, ctx) => {
+        return res(ctx.json(testElevatedToken));
+      }),
+    );
+    const { App, store } = setupAppIntegrationTest({
+      initEntries: [securitySettingsUrl()],
+    });
+
+    await waitForBootup(store);
+
+    render(<App />);
+
+    const email = await screen.findByRole("textbox", { name: "email" });
+    await act(() => userEvent.type(email, testUserVerified.email));
+    const pass = await screen.findByLabelText("Password");
+    await act(() => userEvent.type(pass, "1234"));
+    const btn = await screen.findByRole("button", { name: /Confirm/ });
+    fireEvent.click(btn);
+
+    await screen.findByRole("heading", { name: /Security Settings/ });
+  });
+
+  it("should have elevated token to access security page", async () => {
+    server.use(
+      ...verifiedUserHandlers(),
+      rest.post(`${testEnv.authUrl}/tokens`, (_, res, ctx) => {
+        return res(ctx.json(testElevatedToken));
+      }),
+    );
+    const { App, store } = setupAppIntegrationTest({
+      initEntries: [sshSettingsUrl()],
+    });
+
+    await waitForBootup(store);
+
+    render(<App />);
+
+    const email = await screen.findByRole("textbox", { name: "email" });
+    await act(() => userEvent.type(email, testUserVerified.email));
+    const pass = await screen.findByLabelText("Password");
+    await act(() => userEvent.type(pass, "1234"));
+    const btn = await screen.findByRole("button", { name: /Confirm/ });
+    fireEvent.click(btn);
+
+    await screen.findByRole("heading", { name: /SSH Keys/ });
+  });
+
+  it("should not allow unverified users to access settings page", async () => {
+    server.use(...verifiedUserHandlers({ user: testUserNotVerified }));
+    const { App, store } = setupAppIntegrationTest({
+      initEntries: [settingsUrl()],
+    });
+
+    await waitForBootup(store);
+
+    render(<App />);
+
+    await screen.findByRole("heading", { name: /Check your Email/ });
+  });
+
+  it("should not allow non-account owners to access SSO settings page", async () => {
+    server.use(...verifiedUserHandlers());
+    const { App, store } = setupAppIntegrationTest({
+      initEntries: [teamSsoUrl()],
+    });
+
+    await waitForBootup(store);
+
+    render(<App />);
+
+    await screen.findByRole("heading", { name: /Environments/ });
+  });
+});

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -85,6 +85,12 @@ export const testUser = defaultUserResponse({
   email: testEmail,
   verified: false,
 });
+export const testUserNotVerified = defaultUserResponse({
+  id: testUserId,
+  name: "not-verified",
+  email: testEmail,
+  verified: false,
+});
 export const testUserVerified = defaultUserResponse({
   id: testUserId,
   name: "verified",

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -171,6 +171,17 @@ const authHandlers = [
       );
     },
   ),
+  rest.get(`${testEnv.authUrl}/users/:id/u2f_devices`, (_, res, ctx) => {
+    return res(ctx.json({ _embedded: { u2f_devices: [] } }));
+  }),
+  rest.get(
+    `${testEnv.authUrl}/users/:id/email_verification_challenges`,
+    (_, res, ctx) => {
+      return res(
+        ctx.json({ _embedded: { email_verification_challenges: [] } }),
+      );
+    },
+  ),
 ];
 
 export const verifiedUserHandlers = (
@@ -184,7 +195,7 @@ export const verifiedUserHandlers = (
 ) => {
   return [
     rest.get(`${testEnv.authUrl}/organizations/:orgId/users`, (_, res, ctx) => {
-      return res(ctx.json({ _embedded: [user] }));
+      return res(ctx.json({ _embedded: { users: [user] } }));
     }),
     rest.get(`${testEnv.authUrl}/users/:userId`, (_, res, ctx) => {
       return res(ctx.json(user));

--- a/src/ui/layouts/perm-required.tsx
+++ b/src/ui/layouts/perm-required.tsx
@@ -1,12 +1,28 @@
 import { fetchCurrentToken } from "@app/auth";
-import { selectUserHasPerms } from "@app/deploy";
+import { selectIsAccountOwner, selectUserHasPerms } from "@app/deploy";
 import { useLoader } from "@app/fx";
+import { selectOrganizationSelectedId } from "@app/organizations";
 import { homeUrl } from "@app/routes";
 import { AppState, PermissionScope } from "@app/types";
 import { useEffect } from "react";
 import { useSelector } from "react-redux";
-import { Outlet, useNavigate } from "react-router-dom";
+import { Navigate, Outlet, useNavigate } from "react-router-dom";
 import { Loading } from "../shared";
+
+export const AccountOwnerRequired = ({
+  children,
+}: { children?: React.ReactNode }) => {
+  const orgId = useSelector(selectOrganizationSelectedId);
+  const isAccountOwner = useSelector((s: AppState) =>
+    selectIsAccountOwner(s, { orgId }),
+  );
+
+  if (!isAccountOwner) {
+    return <Navigate to={homeUrl()} />;
+  }
+
+  return children ? children : <Outlet />;
+};
 
 export const PermRequired = ({
   scope,


### PR DESCRIPTION
https://aptible.slack.com/archives/C0237PYRF6D/p1702585423015649?thread_ts=1702584496.093159&cid=C0237PYRF6D

Some of our pages did not have the verify email check so I have reviewed the pages and applied the check where needed.  I also added integration tests to ensure those pages cannot be accessed unless they meet the requirements for access.

We also were not checking for account ownership permissions on some pages so I have enforced that as well -- with tests.