### PR TITLE
fix: add ellipsis to long commands on services page

### DIFF
--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -74,7 +74,9 @@ const CmdCell = ({
           {cmd.length > charLen ? (
             <Group variant="horizontal" size="sm" className="items-center">
               <Tooltip text={cmd} fluid>
-                <Code className="text-ellipsis">{cmd.slice(0, charLen)}</Code>
+                <Code className="text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block">
+                  {cmd.slice(0, charLen)}
+                </Code>
               </Tooltip>
               <CopyTextButton text={cmd} />
             </Group>


### PR DESCRIPTION
**Changes**
• Add ellipsis to commands longer than 30 characters on Services tables