### PR TITLE
fix: truncate commands on all services page

### DIFF
--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -65,7 +65,7 @@ const CmdCell = ({
 }: { service: DeployService; size?: "sm" | "lg" }) => {
   const cmd = serviceCommandText(service);
   const sizes = {
-    sm: 15,
+    sm: 30,
     lg: 30,
   };
   const charLen = sizes[size];


### PR DESCRIPTION
Quick Fix to truncate commands on all services page too 