### PR TITLE
fix: adjust colspan on empty services table to span full width

### DIFF
--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -261,7 +261,7 @@ export function AppServicesByOrg({
       </THead>
 
       <TBody>
-        {paginated.data.length === 0 ? <EmptyTr colSpan={6} /> : null}
+        {paginated.data.length === 0 ? <EmptyTr colSpan={7} /> : null}
         {paginated.data.map((service) => (
           <AppServiceByOrgRow key={service.id} service={service} />
         ))}

--- a/src/ui/shared/db/backup-list.tsx
+++ b/src/ui/shared/db/backup-list.tsx
@@ -198,7 +198,7 @@ export const DatabaseBackupsList = ({
 
         <TBody>
           {paginated.data.length === 0 ? (
-            <EmptyTr colSpan={showDatabase ? 8 : 7} />
+            <EmptyTr colSpan={showDatabase ? 9 : 8} />
           ) : null}
           {paginated.data.map((backup) => (
             <BackupListRow


### PR DESCRIPTION
**Changes**
• Adjust colspan on empty services table to span full width
• Adjust colspan on empty environment backups table to span full width

BEFORE
<img width="1432" alt="Screenshot 2023-12-19 at 10 38 26 AM" src="https://github.com/aptible/app-ui/assets/4295811/5ae0638a-b3a6-4b98-85bc-c85f9b3a7f35">

AFTER
<img width="1418" alt="Screenshot 2023-12-19 at 10 40 48 AM" src="https://github.com/aptible/app-ui/assets/4295811/5fbdc85c-5ae5-4e66-a98a-29cd025997dd">


