### PR TITLE
fix: operation toast for app and db

### DIFF
--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -300,10 +300,12 @@ export const selectLatestOpByAppId = createSelector(
 export const selectLatestOpByResourceId = createSelector(
   selectOperationsAsList,
   (_: AppState, p: { resourceId: string }) => p.resourceId,
-  (ops, resourceId) =>
+  (_: AppState, p: { resourceType: ResourceType }) => p.resourceType,
+  (ops, resourceId, resourceType) =>
     ops.find(
       (op) =>
         op.resourceId === resourceId &&
+        op.resourceType === resourceType &&
         ["configure", "provision", "deploy", "deprovision"].includes(op.type),
     ) || initOp,
 );

--- a/src/ui/shared/active-operation-notice.tsx
+++ b/src/ui/shared/active-operation-notice.tsx
@@ -40,7 +40,7 @@ export const ActiveOperationNotice = ({
   resourceType: Extract<ResourceType, "app" | "database">;
 }) => {
   const operation = useSelector((s: AppState) =>
-    selectLatestOpByResourceId(s, { resourceId }),
+    selectLatestOpByResourceId(s, { resourceId, resourceType }),
   );
   const operationTypeAndStatusToDisplay: {
     [key in OperationType]?: OperationStatus[];


### PR DESCRIPTION
We were not filtering by resource type so it would show a toast for the wrong resource