### PR TITLE
style(backups): show server paginated loading spinner

### DIFF
--- a/src/ui/hooks/use-paginate.ts
+++ b/src/ui/hooks/use-paginate.ts
@@ -49,6 +49,7 @@ const usePaginateFilters = (rowsPerPage = ITEMS_PER_PAGE) => {
 };
 
 export interface PaginateProps<T> {
+  isLoading?: boolean;
   page: number;
   totalPages: number;
   totalItems: number;

--- a/src/ui/pages/database-detail-backups.tsx
+++ b/src/ui/pages/database-detail-backups.tsx
@@ -13,7 +13,6 @@ import {
   Group,
   IconEdit,
   IconPlusCircle,
-  LoadingSpinner,
 } from "../shared";
 
 export const DatabaseBackupsPage = () => {
@@ -51,8 +50,6 @@ export const DatabaseBackupsPage = () => {
           <IconEdit variant="sm" className="mr-2" /> Edit Environment Backup
           Policy
         </ButtonLink>
-
-        <LoadingSpinner show={paginated.isLoading} />
       </div>
 
       <BannerMessages className="my-4" {...loader} />

--- a/src/ui/shared/db/backup-list.tsx
+++ b/src/ui/shared/db/backup-list.tsx
@@ -197,7 +197,9 @@ export const DatabaseBackupsList = ({
 
         <TBody>
           {paginated.data.length === 0 ? (
-            <EmptyTr colSpan={showDatabase ? 9 : 8} />
+            <EmptyTr colSpan={showDatabase ? 9 : 8}>
+              {paginated.isLoading ? "Loading ..." : null}
+            </EmptyTr>
           ) : null}
           {paginated.data.map((backup) => (
             <BackupListRow

--- a/src/ui/shared/resource-list-view.tsx
+++ b/src/ui/shared/resource-list-view.tsx
@@ -43,7 +43,10 @@ export const LoadingBar = ({ isLoading = false }: { isLoading?: boolean }) => {
 };
 
 export function PaginateBar<T>(
-  paginate: Pick<PaginateProps<T>, "totalPages" | "page" | "prev" | "next">,
+  paginate: Pick<
+    PaginateProps<T>,
+    "totalPages" | "page" | "prev" | "next" | "isLoading"
+  >,
 ) {
   if (paginate.totalPages === 1) {
     return null;
@@ -80,6 +83,7 @@ export function PaginateBar<T>(
             paginate.next();
           }}
         />
+        <LoadingSpinner show={paginate?.isLoading} />
       </Group>
     </Group>
   );


### PR DESCRIPTION
I moved the loading spinner for backup tables mainly because we didn't have one for environment detail backups and this makes it identical for both.