### PR TITLE
style: change to UTC time format

### DIFF
--- a/src/ui/layouts/operation-detail-layout.tsx
+++ b/src/ui/layouts/operation-detail-layout.tsx
@@ -1,4 +1,4 @@
-import { prettyEnglishDateWithTime } from "@app/date";
+import { prettyEnglishDateWithTime, formatDateToUTC } from "@app/date";
 import {
   fetchOperationById,
   getResourceUrl,
@@ -19,6 +19,7 @@ import {
   DetailPageHeaderView,
   DetailTitleBar,
   OpStatus,
+  Tooltip,
 } from "../shared";
 import { AppSidebarLayout } from "./app-sidebar-layout";
 
@@ -44,14 +45,18 @@ export function OpHeader({
       <DetailInfoGrid>
         <DetailInfoItem title="Type">{capitalize(op.type)}</DetailInfoItem>
         <DetailInfoItem title="Created">
-          {capitalize(prettyEnglishDateWithTime(op.createdAt))}
+          <Tooltip text={capitalize(formatDateToUTC(op.createdAt))}>
+            {capitalize(prettyEnglishDateWithTime(op.createdAt))}
+          </Tooltip>
         </DetailInfoItem>
 
         <DetailInfoItem title="Status">
           <OpStatus status={op.status} />
         </DetailInfoItem>
         <DetailInfoItem title="Last Updated">
-          {capitalize(prettyEnglishDateWithTime(op.updatedAt))}
+          <Tooltip text={capitalize(formatDateToUTC(op.updatedAt))}>
+            {capitalize(prettyEnglishDateWithTime(op.updatedAt))}
+          </Tooltip>
         </DetailInfoItem>
 
         <DetailInfoItem title="Resource">

--- a/src/ui/layouts/operation-detail-layout.tsx
+++ b/src/ui/layouts/operation-detail-layout.tsx
@@ -1,4 +1,4 @@
-import { prettyEnglishDateWithTime, formatDateToUTC } from "@app/date";
+import { formatDateToUTC, prettyEnglishDateWithTime } from "@app/date";
 import {
   fetchOperationById,
   getResourceUrl,

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -1,4 +1,4 @@
-import { prettyEnglishDateWithTime } from "@app/date";
+import { prettyEnglishDateWithTime, formatDateToUTC } from "@app/date";
 import {
   ResourceLookup,
   cancelAppOpsPoll,
@@ -43,6 +43,7 @@ import { Group } from "./group";
 import { InputSearch } from "./input";
 import { LoadingSpinner } from "./loading";
 import { OpStatus } from "./operation-status";
+import { Tooltip } from "./tooltip";
 import {
   DescBar,
   FilterBar,
@@ -195,7 +196,11 @@ const OpActionsCell = ({ op }: OpCellProps) => {
 const OpLastUpdatedCell = ({ op }: OpCellProps) => {
   return (
     <Td>
-      <div>{capitalize(prettyEnglishDateWithTime(op.updatedAt))}</div>
+      <div>
+        <Tooltip text={capitalize(formatDateToUTC(op.updatedAt))}>
+        {capitalize(prettyEnglishDateWithTime(op.updatedAt))}
+        </Tooltip>
+      </div>
     </Td>
   );
 };

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -1,4 +1,4 @@
-import { prettyEnglishDateWithTime, formatDateToUTC } from "@app/date";
+import { formatDateToUTC, prettyEnglishDateWithTime } from "@app/date";
 import {
   ResourceLookup,
   cancelAppOpsPoll,
@@ -43,7 +43,6 @@ import { Group } from "./group";
 import { InputSearch } from "./input";
 import { LoadingSpinner } from "./loading";
 import { OpStatus } from "./operation-status";
-import { Tooltip } from "./tooltip";
 import {
   DescBar,
   FilterBar,
@@ -53,6 +52,7 @@ import {
 import { EnvStackCell } from "./resource-table";
 import { EmptyTr, TBody, THead, Table, Td, Th, Tr } from "./table";
 import { tokens } from "./tokens";
+import { Tooltip } from "./tooltip";
 
 interface OpCellProps {
   op: DeployActivityRow;
@@ -198,7 +198,7 @@ const OpLastUpdatedCell = ({ op }: OpCellProps) => {
     <Td>
       <div>
         <Tooltip text={capitalize(formatDateToUTC(op.updatedAt))}>
-        {capitalize(prettyEnglishDateWithTime(op.updatedAt))}
+          {capitalize(prettyEnglishDateWithTime(op.updatedAt))}
         </Tooltip>
       </div>
     </Td>

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -119,7 +119,7 @@ const LineChartWrapper = ({
               maxTicksLimit: 5,
             },
             time: {
-              tooltipFormat: "yyyy-MM-dd hh:mm:ss aaa (z)",
+              tooltipFormat: "MMM dd, yyyy 'at' hh:mm aaa (z)",
               unit: xAxisUnit,
             },
             type: "time",

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -119,7 +119,7 @@ const LineChartWrapper = ({
               maxTicksLimit: 5,
             },
             time: {
-              tooltipFormat: "MMM dd, yyyy 'at' hh:mm aaa (z)",
+              tooltipFormat: "yyyy-MM-dd'T'HH:mm:ss'Z'",
               unit: xAxisUnit,
             },
             type: "time",

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -119,7 +119,7 @@ const LineChartWrapper = ({
               maxTicksLimit: 5,
             },
             time: {
-              tooltipFormat: "yyyy-MM-dd HH:mm:ss",
+              tooltipFormat: "yyyy-MM-dd hh:mm:ss aaa (z)",
               unit: xAxisUnit,
             },
             type: "time",


### PR DESCRIPTION
Change Tooltip formatting to show Timezone and make it faster to read

BEFORE

<img width="295" alt="Screenshot 2023-12-21 at 1 10 05 PM" src="https://github.com/aptible/app-ui/assets/4295811/ebc6342c-d336-4099-acf2-cb49f3854756">


AFTER

<img width="302" alt="Screenshot 2023-12-21 at 2 36 53 PM" src="https://github.com/aptible/app-ui/assets/4295811/0805715f-0b81-4b62-90b8-6ae3c684e2e3">

Show UTC on hover

<img width="1395" alt="Screenshot 2023-12-21 at 3 15 20 PM" src="https://github.com/aptible/app-ui/assets/4295811/a3e92861-04b3-4f8c-8ba0-3550bdd7ff23">

<img width="1410" alt="Screenshot 2023-12-21 at 3 15 26 PM" src="https://github.com/aptible/app-ui/assets/4295811/4c27e33f-87f8-41f0-ad86-31cc8716841b">

