### PR TITLE
fix: time formatting

### DIFF
--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -90,7 +90,10 @@ export const prettyEnglishDate = (dateStr = "") => {
 };
 
 export const prettyUTCTime = (dateStr = "") => {
-  return format(isoToDate(dateStr), "yyyy-MM-dd HH:mm:ss 'UTC'");
+  return `${new Date(dateStr)
+    .toISOString()
+    .slice(0, 19)
+    .replace("T", " ")} UTC`;
 };
 
 export const prettyEnglishDateWithTime = (dateStr = "") => {


### PR DESCRIPTION
The timestamps are 6 hours behind the logs, this makes the timestamps match our logs