### PR TITLE
Fix: UTC formatting

### DIFF
--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -90,7 +90,10 @@ export const prettyEnglishDate = (dateStr = "") => {
 };
 
 export const prettyUTCTime = (dateStr = "") => {
-  return new Date(dateStr).toISOString().slice(0, 19).replace('T', ' ') + (' UTC');
+  return `${new Date(dateStr)
+    .toISOString()
+    .slice(0, 19)
+    .replace("T", " ")} UTC`;
 };
 
 export const prettyEnglishDateWithTime = (dateStr = "") => {

--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -90,7 +90,7 @@ export const prettyEnglishDate = (dateStr = "") => {
 };
 
 export const prettyUTCTime = (dateStr = "") => {
-  return format(isoToDate(dateStr), "yyyy-MM-dd HH:mm:ss 'UTC'");
+  return new Date(dateStr).toISOString().slice(0, 19).replace('T', ' ') + (' UTC');
 };
 
 export const prettyEnglishDateWithTime = (dateStr = "") => {

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -119,10 +119,10 @@ const LineChartWrapper = ({
               maxTicksLimit: 5,
             },
             time: {
-              tooltipFormat: "yyyy-MM-dd HH:mm:ss 'UTC'",
+              tooltipFormat: "yyyy-MM-dd HH:mm:ss 'UTC'x",
               unit: xAxisUnit,
               displayFormats: {
-                minute: "HH:mm:ss 'UTC'",
+                minute: "HH:mm 'UTC'x",
                 day: "MMM dd",
               },
             },


### PR DESCRIPTION
Fix UTC Formatting on pages to show true UTC

**Shows in true UTC format so all dates match with our Logs and CLI**
<img width="248" alt="Screenshot 2023-12-22 at 3 32 14 PM" src="https://github.com/aptible/app-ui/assets/4295811/48659df1-d285-450c-afe9-d7bb7d79c044">

**Shows the offset (ex. -06) so its more clear that this is local time** 
<img width="666" alt="Screenshot 2023-12-22 at 3 31 59 PM" src="https://github.com/aptible/app-ui/assets/4295811/101f870c-8948-4c37-be8b-8fb03c8f7e33">
