### PR TITLE
Fix: show UTC offset globally

### DIFF
--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -90,7 +90,7 @@ export const prettyEnglishDate = (dateStr = "") => {
 };
 
 export const prettyUTCTime = (dateStr = "") => {
-  return format(isoToDate(dateStr), "yyyy-MM-dd HH:mm:ss 'UTC'");
+  return format(isoToDate(dateStr), "yyyy-MM-dd HH:mm:ss 'UTC'x");
 };
 
 export const prettyEnglishDateWithTime = (dateStr = "") => {

--- a/src/ui/shared/container-metrics-chart.tsx
+++ b/src/ui/shared/container-metrics-chart.tsx
@@ -119,10 +119,10 @@ const LineChartWrapper = ({
               maxTicksLimit: 5,
             },
             time: {
-              tooltipFormat: "yyyy-MM-dd HH:mm:ss 'UTC'",
+              tooltipFormat: "yyyy-MM-dd HH:mm:ss 'UTC'x",
               unit: xAxisUnit,
               displayFormats: {
-                minute: "HH:mm:ss 'UTC'",
+                minute: "HH:mm 'UTC'x",
                 day: "MMM dd",
               },
             },


### PR DESCRIPTION
For now we can show the UTC offset to be more accurate and clear to users.

<img width="601" alt="Screenshot 2023-12-22 at 4 47 04 PM" src="https://github.com/aptible/app-ui/assets/4295811/50bca17e-ccbb-41c5-a3f4-f89688b16d76">
<img width="302" alt="Screenshot 2023-12-22 at 4 46 02 PM" src="https://github.com/aptible/app-ui/assets/4295811/8a1bc2f9-30f7-47d1-b077-f71458cb43e4">
