### PR TITLE
style: add placeholder values to VAS form

### DIFF
--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -188,6 +188,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.percentile}
                       min="0"
                       max="100"
+                      placeholder="0 (Min), 100 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "percentile",
@@ -209,6 +210,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.minimum_memory}
                       min="0"
                       max="784384"
+                      placeholder="0 (Min), 784384 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "minimum_memory",
@@ -230,6 +232,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.maximum_memory || ""}
                       min="0"
                       max="784384"
+                      placeholder="0 (Min), 784384 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "maximum_memory",
@@ -252,6 +255,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.mem_scale_up_threshold}
                       min="0"
                       max="1"
+                      placeholder="0 (Min), 1 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "mem_scale_up_threshold",
@@ -274,6 +278,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.mem_scale_down_threshold}
                       min="0"
                       max="1"
+                      placeholder="0 (Min), 1 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "mem_scale_down_threshold",
@@ -298,6 +303,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.mem_cpu_ratio_r_threshold}
                       min="0"
                       max="16"
+                      placeholder="0 (Min), 16 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "mem_cpu_ratio_r_threshold",
@@ -320,6 +326,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.mem_cpu_ratio_c_threshold}
                       min="0"
                       max="8"
+                      placeholder="0 (Min), 8 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "mem_cpu_ratio_c_threshold",
@@ -342,6 +349,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.metric_lookback_seconds}
                       min="0"
                       max="3600"
+                      placeholder="0 (Min), 3600 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "metric_lookback_seconds",
@@ -363,6 +371,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.post_scale_up_cooldown_seconds}
                       min="0"
                       max="3600"
+                      placeholder="0 (Min), 3600 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "post_scale_up_cooldown_seconds",
@@ -384,6 +393,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.post_scale_down_cooldown_seconds}
                       min="0"
                       max="3600"
+                      placeholder="0 (Min), 3600 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "post_scale_down_cooldown_seconds",
@@ -405,6 +415,7 @@ const VerticalAutoscalingSection = ({
                       value={nextPolicy.post_release_cooldown_seconds}
                       min="0"
                       max="3600"
+                      placeholder="0 (Min), 3600 (Max)"
                       onChange={(e) =>
                         updatePolicy(
                           "post_release_cooldown_seconds",
@@ -596,6 +607,7 @@ export const AppDetailServiceScalePage = () => {
                 value={containerCount}
                 min="0"
                 max="32"
+                placeholder="0 (Min), 32 (Max)"
                 onChange={(e) =>
                   setContainerCount(parseInt(e.currentTarget.value || "0", 10))
                 }


### PR DESCRIPTION
Add min and max placeholder values to the Autoscaling form

Various Examples:

<img width="1135" alt="Screenshot 2024-01-02 at 11 23 02 AM" src="https://github.com/aptible/app-ui/assets/4295811/02dc9561-f9ad-4e7f-b480-9d9a5a7c85ee">
<img width="1134" alt="Screenshot 2024-01-02 at 11 22 23 AM" src="https://github.com/aptible/app-ui/assets/4295811/a7db0ec0-8870-4304-b152-252d5a6df9a6">
<img width="1126" alt="Screenshot 2024-01-02 at 11 24 17 AM" src="https://github.com/aptible/app-ui/assets/4295811/b6b84d29-b54b-4a6e-b32b-6a9e80627895">
<img width="1131" alt="Screenshot 2024-01-02 at 11 25 38 AM" src="https://github.com/aptible/app-ui/assets/4295811/371ba07b-8f97-4cb1-8de5-eec7a421c206">
<img width="1123" alt="Screenshot 2024-01-02 at 11 26 33 AM" src="https://github.com/aptible/app-ui/assets/4295811/6c232db2-c5c7-42d2-8c2a-5347aa556ae4">
<img width="1125" alt="Screenshot 2024-01-02 at 11 27 26 AM" src="https://github.com/aptible/app-ui/assets/4295811/33603fac-a087-467e-9100-0aade3a1a3ae">
<img width="1127" alt="Screenshot 2024-01-02 at 11 28 45 AM" src="https://github.com/aptible/app-ui/assets/4295811/a0f76c24-dfcc-4715-a734-adbcbb7184de">
<img width="1121" alt="Screenshot 2024-01-02 at 11 29 55 AM" src="https://github.com/aptible/app-ui/assets/4295811/46b0014c-70ef-47bb-98eb-0986350896fc">
