### PR TITLE
fix: don't show loader for local pagination

### DIFF
--- a/src/ui/hooks/use-paginate.ts
+++ b/src/ui/hooks/use-paginate.ts
@@ -77,6 +77,7 @@ export function usePaginate<T>(
     data: paginatedData,
     itemsPerPage,
     setItemsPerPage,
+    isLoading: false,
     prev: () => {
       if (page === 1) {
         return;

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -31,7 +31,6 @@ import {
   ActionBar,
   DescBar,
   FilterBar,
-  LoadingBar,
   PaginateBar,
   TitleBar,
 } from "../resource-list-view";
@@ -162,12 +161,11 @@ export const AppListByOrg = () => {
               search={search}
               onChange={onChange}
             />
-            <LoadingBar isLoading={isLoading} />
           </Group>
 
           <Group variant="horizontal" size="lg" className="items-center mt-1">
             <DescBar>{paginated.totalItems} Apps</DescBar>
-            <PaginateBar {...paginated} />
+            <PaginateBar {...paginated} isLoading={isLoading} />
           </Group>
         </FilterBar>
       </Group>


### PR DESCRIPTION
We made a change late last week to support server-side pagination which shows a loader next to pagination bar.  Well we don't want to show that loader for local pagination.