### PR TITLE
style: remove Y Axis chart labels

### DIFF
--- a/src/ui/pages/app-detail-service-metrics.tsx
+++ b/src/ui/pages/app-detail-service-metrics.tsx
@@ -107,7 +107,6 @@ export function AppDetailServiceMetricsPage() {
               metricNames={["cpu_pct"]}
               metricHorizon={metricHorizon}
               helpText="Total amount of CPU your container has used from the host system."
-              yAxisLabel="CPU Usage (%)"
               yAxisUnit="%"
             />
             <ContainerMetricsChart
@@ -116,7 +115,6 @@ export function AppDetailServiceMetricsPage() {
               limit={`${service.containerMemoryLimitMb} MB`}
               metricHorizon={metricHorizon}
               helpText="Total amount of memory your container has requested from the host system."
-              yAxisLabel="Memory Usage (MB)"
               yAxisUnit=" MB"
             />
             <ContainerMetricsChart
@@ -124,7 +122,6 @@ export function AppDetailServiceMetricsPage() {
               metricNames={["la"]}
               metricHorizon={metricHorizon}
               helpText="Total runnable and blocked tasks (threads) in your container."
-              yAxisLabel="Load Average (#)"
             />
           </div>
         ) : (

--- a/src/ui/pages/database-detail-metrics.tsx
+++ b/src/ui/pages/database-detail-metrics.tsx
@@ -138,7 +138,7 @@ export function DatabaseMetricsPage() {
               metricNames={["iops"]}
               metricHorizon={metricHorizon}
               helpText="IO activity of your database, compared to the baseline performance of its underlying volume."
-              yAxisLabel="IOPS (#)"
+              yAxisLabel="IOPS"
             />
             <ContainerMetricsChart
               containers={containers}

--- a/src/ui/pages/database-detail-metrics.tsx
+++ b/src/ui/pages/database-detail-metrics.tsx
@@ -113,7 +113,6 @@ export function DatabaseMetricsPage() {
               metricNames={["cpu_pct"]}
               metricHorizon={metricHorizon}
               helpText="Total amount of CPU your container has used from the host system."
-              yAxisLabel="CPU Usage (%)"
               yAxisUnit="%"
             />
             <ContainerMetricsChart
@@ -122,7 +121,6 @@ export function DatabaseMetricsPage() {
               metricNames={["memory_all"]}
               metricHorizon={metricHorizon}
               helpText="Total amount of memory your container has requested from the host system."
-              yAxisLabel="Memory Usage (MB)"
               yAxisUnit=" MB"
             />
             <ContainerMetricsChart
@@ -130,7 +128,6 @@ export function DatabaseMetricsPage() {
               metricNames={["fs"]}
               metricHorizon={metricHorizon}
               helpText="Total used disk space compared to total available space. A small amount is reserved for usage by the system."
-              yAxisLabel="Disk Usage (GB)"
               yAxisUnit=" GB"
             />
             <ContainerMetricsChart
@@ -138,14 +135,12 @@ export function DatabaseMetricsPage() {
               metricNames={["iops"]}
               metricHorizon={metricHorizon}
               helpText="IO activity of your database, compared to the baseline performance of its underlying volume."
-              yAxisLabel="IOPS"
             />
             <ContainerMetricsChart
               containers={containers}
               metricNames={["la"]}
               metricHorizon={metricHorizon}
               helpText="Total runnable and blocked tasks (threads) in your container."
-              yAxisLabel="Load Average (#)"
             />
           </div>
         ) : (


### PR DESCRIPTION
**Remove Y Axis chart labels**
• They don't add additional information
• The Y Axis Units already show (ex. %, MB)
• Gives more room for the chart lines

BEFORE
<img width="1226" alt="Screenshot 2024-01-04 at 2 39 36 PM" src="https://github.com/aptible/app-ui/assets/4295811/11e9f3a6-92c8-48f7-bfb1-c964e42cbbf8">


AFTER
<img width="1225" alt="Screenshot 2024-01-04 at 2 37 15 PM" src="https://github.com/aptible/app-ui/assets/4295811/19f301d4-c547-4d52-aaa2-cd777bc83e41">

