### PR TITLE
Fix: Cookie Notice Banner Z-Index

### DIFF
--- a/src/ui/shared/cookie-notice.tsx
+++ b/src/ui/shared/cookie-notice.tsx
@@ -71,7 +71,7 @@ export const CookieNotice = () => {
   return (
     <div>
       {showNotice && (
-        <div className="sm:fixed bottom-5 right-5 w-96 px-8 py-8 z-100 bg-white border border-gray-200 rounded-lg">
+        <div className="sm:fixed bottom-5 right-5 w-96 px-8 py-8 z-50 bg-white border border-gray-200 rounded-lg">
           <p className="text-sm">
             This site uses cookies to store information on your computer. Some
             are essential to make our site work; others help us improve the user


### PR DESCRIPTION
In Tailwind the highest non-customized z-index value is `z-50`. So `z-100` is invalid & gets ignored.

BEFORE
<img width="602" alt="Screenshot 2024-01-09 at 10 30 24 AM" src="https://github.com/aptible/app-ui/assets/4295811/7b3f07cb-61aa-4bae-b318-744a335d08e2">

AFTER
<img width="602" alt="Screenshot 2024-01-09 at 10 30 19 AM" src="https://github.com/aptible/app-ui/assets/4295811/a24fff6b-ae29-48c5-a9b5-6337a3afc8dc">

