### PR TITLE
Prevent Disable VAS radio button from wiping settings

### DIFF
--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -31,8 +31,10 @@ import { SyntheticEvent, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { useValidator } from "../hooks";
 import {
+  ButtonIcon,
   IconChevronDown,
   IconChevronRight,
+  IconRefresh,
   Radio,
   RadioGroup,
 } from "../shared";
@@ -121,6 +123,15 @@ const VerticalAutoscalingSection = ({
     value: ServiceSizingPolicyEditProps[K],
   ) => {
     setNextPolicy({ ...nextPolicy, [key]: value });
+  };
+  const resetAdvancedSettings = () => {
+    setNextPolicy(
+      defaultServiceSizingPolicyResponse({
+        id: nextPolicy.id,
+        service_id: nextPolicy.service_id,
+        scaling_enabled: nextPolicy.scaling_enabled,
+      }),
+    );
   };
 
   const [advancedIsOpen, setOpen] = useState(false);
@@ -423,6 +434,17 @@ const VerticalAutoscalingSection = ({
                         )
                       }
                     />
+                  </FormGroup>
+                  <FormGroup
+                    splitWidthInputs
+                    label="Reset to Default Advanced Settings"
+                    htmlFor="reset-button"
+                  >
+                    <div id="reset-button">
+                      <ButtonIcon icon={<IconRefresh variant="sm" />} variant="white" onClick={resetAdvancedSettings}>
+                        Reset to Defaults
+                      </ButtonIcon>
+                    </div>
                   </FormGroup>
                 </div>
               </div>


### PR DESCRIPTION
Now Enable/Disable will pause and resume scaling with the same settings instead of deleting the service's scaling policy membership.

Requires https://github.com/aptible/deploy-api/pull/1337 to be deployed first.