### PR TITLE
fix(app.config): make view and edit env consistent

### DIFF
--- a/src/deploy/configuration/index.ts
+++ b/src/deploy/configuration/index.ts
@@ -44,7 +44,7 @@ export const configEnvToStr = (env: DeployAppConfigEnv): string => {
     .reduce((acc, key) => {
       let value = String.raw`${env[key]}`;
       const prev = acc ? `${acc}\n` : "";
-      if (typeof value === "string" && value.includes("\n")) {
+      if (value.includes("\n")) {
         value = `"${value}"`;
       }
       return `${prev}${key}=${value}`;
@@ -52,7 +52,6 @@ export const configEnvToStr = (env: DeployAppConfigEnv): string => {
 };
 
 export const configStrToEnvList = (text: string): TextVal[] => {
-  // return parseText(text, () => ({}));
   const items: TextVal[] = [];
   const output = parse(text);
   Object.keys(output).forEach((key) => {

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -78,7 +78,3 @@ export const [schema, initialState] = createSchema({
   memberships: slice.table({ empty: factory.defaultMembership() }),
 });
 export type WebState = typeof initialState;
-/**
- * @deprecated Use {@link schema} instead
- */
-// export const db = schema;

--- a/src/ui/shared/app/config.tsx
+++ b/src/ui/shared/app/config.tsx
@@ -1,9 +1,9 @@
-import { selectAppConfigById } from "@app/deploy";
+import { configEnvToStr, selectAppConfigById } from "@app/deploy";
 import { useSelector } from "@app/react";
 import { useState } from "react";
 import { ButtonFullVisibility } from "../button";
 import { Group } from "../group";
-import { PreBox, TextSegment } from "../pre-code";
+import { PreBox } from "../pre-code";
 
 export const AppConfigView = ({
   configId,
@@ -11,14 +11,7 @@ export const AppConfigView = ({
 }: { configId: string; envId: string }) => {
   const [isVisible, setVisible] = useState(false);
   const config = useSelector((s) => selectAppConfigById(s, { id: configId }));
-  const envs: TextSegment[] = [];
-  Object.keys(config.env).forEach((key) => {
-    envs.push(
-      { text: `${key}=`, className: "text-lime" },
-      { text: `${config.env[key]}`, className: "text-white" },
-      { text: "\n", className: "" },
-    );
-  });
+  const envStr = configEnvToStr(config.env);
 
   return (
     <>
@@ -33,7 +26,10 @@ export const AppConfigView = ({
               Hide
             </ButtonFullVisibility>
           </div>
-          <PreBox allowCopy segments={envs} />
+          <PreBox
+            allowCopy
+            segments={[{ text: envStr, className: "text-white" }]}
+          />
         </Group>
       ) : (
         <div>


### PR DESCRIPTION
When you view the read-only version of an App's configuration it looks different from the edit-view.