### PR TITLE
fix(security): call next mdw when revoking tokens

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -166,17 +166,18 @@ export const revokeAllTokens = authApi.post(
       return;
     }
     tunaEvent("revoked-all-tokens");
-    ctx.loader = { message: "Success!" };
+    ctx.loader = { message: "Successfully logged out all other sessions!" };
   },
 );
 
 export function* revokeTokensMdw(ctx: AuthApiCtx, next: Next) {
+  yield* next();
+
   if (!ctx.json.ok) {
     return;
   }
 
-  yield* put(revokeAllTokens());
+  yield* revokeAllTokens.run();
   const msg = ctx.loader?.message || "Success!";
   ctx.loader = { message: `${msg} All other sessions have been logged out.` };
-  yield* next();
 }


### PR DESCRIPTION
We were preventing any security related http requests from happening because of a regression when we decided to revoke all tokens after some security operations.  This commit refactors that work so it functions as expected.