### PR TITLE
app/services autoscaling status column

### DIFF
--- a/src/deploy/entities.ts
+++ b/src/deploy/entities.ts
@@ -20,6 +20,7 @@ import { permissionEntities } from "./permission";
 import { activePlanEntities, planEntities } from "./plan";
 import { releaseEntities } from "./release";
 import { serviceEntities } from "./service";
+import { serviceSizingPolicyEntities } from "./service-sizing-policy";
 import { stackEntities } from "./stack";
 import { vpcPeerEntities } from "./vpc-peer";
 import { vpnTunnelEntities } from "./vpn-tunnel";
@@ -51,4 +52,5 @@ export const entities = {
   ...activityReportEntities,
   ...imageEntities,
   ...diskEntities,
+  ...serviceSizingPolicyEntities,
 };

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -4,6 +4,7 @@ export * from "./environment";
 export * from "./endpoint";
 export * from "./database";
 export * from "./service";
+export * from "./service-sizing-policy";
 export * from "./log-drain";
 export * from "./database-images";
 export * from "./metric-drain";

--- a/src/deploy/service-sizing-policy/index.ts
+++ b/src/deploy/service-sizing-policy/index.ts
@@ -1,0 +1,213 @@
+import { api, cacheShortTimer, thunks } from "@app/api";
+import { call, createSelector } from "@app/fx";
+import { defaultEntity, defaultHalHref, extractIdFromLink } from "@app/hal";
+import { schema } from "@app/schema";
+import { DeployServiceSizingPolicy, LinkResponse } from "@app/types";
+import { selectServiceById } from "../service";
+
+export interface DeployServiceSizingPolicyResponse {
+  id: number | undefined;
+  scaling_enabled: boolean;
+  default_policy: boolean;
+  metric_lookback_seconds: number;
+  percentile: number;
+  post_scale_up_cooldown_seconds: number;
+  post_scale_down_cooldown_seconds: number;
+  post_release_cooldown_seconds: number;
+  mem_cpu_ratio_r_threshold: number;
+  mem_cpu_ratio_c_threshold: number;
+  mem_scale_up_threshold: number;
+  mem_scale_down_threshold: number;
+  minimum_memory: number;
+  maximum_memory: number | null;
+  created_at: string;
+  updated_at: string;
+  _links: {
+    account: LinkResponse;
+  };
+  _type: "service_sizing_policy";
+}
+
+export const defaultServiceSizingPolicyResponse = (
+  s: Partial<DeployServiceSizingPolicyResponse> = {},
+): DeployServiceSizingPolicyResponse => {
+  const now = new Date().toISOString();
+  return {
+    id: undefined,
+    scaling_enabled: false,
+    default_policy: false,
+    metric_lookback_seconds: 300,
+    percentile: 99,
+    post_scale_up_cooldown_seconds: 60,
+    post_scale_down_cooldown_seconds: 300,
+    post_release_cooldown_seconds: 300,
+    mem_cpu_ratio_r_threshold: 4,
+    mem_cpu_ratio_c_threshold: 2,
+    mem_scale_up_threshold: 0.9,
+    mem_scale_down_threshold: 0.75,
+    minimum_memory: 2048,
+    maximum_memory: null,
+    created_at: now,
+    updated_at: now,
+    _type: "service_sizing_policy",
+    ...s,
+    _links: { account: defaultHalHref(), ...s._links },
+  };
+};
+
+export const deserializeDeployServiceSizingPolicy = (
+  payload: DeployServiceSizingPolicyResponse,
+): DeployServiceSizingPolicy => {
+  const links = payload._links;
+  const environmentId = extractIdFromLink(links.account);
+
+  return {
+    id: `${payload.id}`,
+    environmentId,
+    scalingEnabled: payload.scaling_enabled,
+    defaultPolicy: payload.default_policy,
+    metricLookbackSeconds: payload.metric_lookback_seconds,
+    percentile: payload.percentile,
+    postScaleUpCooldownSeconds: payload.post_scale_up_cooldown_seconds,
+    postScaleDownCooldownSeconds: payload.post_scale_down_cooldown_seconds,
+    postReleaseCooldownSeconds: payload.post_release_cooldown_seconds,
+    memCpuRatioRThreshold: payload.mem_cpu_ratio_r_threshold,
+    memCpuRatioCThreshold: payload.mem_cpu_ratio_c_threshold,
+    memScaleUpThreshold: payload.mem_scale_up_threshold,
+    memScaleDownThreshold: payload.mem_scale_down_threshold,
+    minimumMemory: payload.minimum_memory,
+    maximumMemory: payload.maximum_memory,
+    createdAt: payload.created_at,
+    updatedAt: payload.updated_at,
+  };
+};
+
+export const serviceSizingPolicyEntities = {
+  service_sizing_policy: defaultEntity({
+    id: "service_sizing_policy",
+    deserialize: deserializeDeployServiceSizingPolicy,
+    save: schema.serviceSizingPolicies.add,
+  }),
+};
+
+export const selectServiceSizingPolicyById =
+  schema.serviceSizingPolicies.selectById;
+export const selectServiceSizingPolicyByServiceId = createSelector(
+  selectServiceById,
+  schema.serviceSizingPolicies.selectTableAsList,
+  (service, policies) =>
+    policies.find((p) => p.id === service.serviceSizingPolicyId) ||
+    schema.serviceSizingPolicies.empty,
+);
+
+export const fetchServiceSizingPoliciesByEnvironmentId = api.get<{
+  id: string;
+}>("/accounts/:id/service_sizing_policies");
+export const fetchServiceSizingPoliciesByServiceId = api.get<{
+  serviceId: string;
+}>("/services/:serviceId/service_sizing_policies", {
+  supervisor: cacheShortTimer(),
+});
+
+export interface ServiceSizingPolicyEditProps {
+  scalingEnabled: boolean;
+  metricLookbackSeconds: number;
+  percentile: number;
+  postScaleUpCooldownSeconds: number;
+  postScaleDownCooldownSeconds: number;
+  postReleaseCooldownSeconds: number;
+  memCpuRatioRThreshold: number;
+  memCpuRatioCThreshold: number;
+  memScaleUpThreshold: number;
+  memScaleDownThreshold: number;
+  minimumMemory: number;
+  maximumMemory: number | null;
+}
+
+const serializeServiceSizingPolicyEditProps = (
+  payload: ServiceSizingPolicyEditProps,
+) => ({
+  scaling_enabled: payload.scalingEnabled,
+  metric_lookback_seconds: payload.metricLookbackSeconds,
+  percentile: payload.percentile,
+  post_scale_up_cooldown_seconds: payload.postScaleUpCooldownSeconds,
+  post_scale_down_cooldown_seconds: payload.postScaleDownCooldownSeconds,
+  post_release_cooldown_seconds: payload.postReleaseCooldownSeconds,
+  mem_cpu_ratio_r_threshold: payload.memCpuRatioRThreshold,
+  mem_cpu_ratio_c_threshold: payload.memCpuRatioCThreshold,
+  mem_scale_up_threshold: payload.memScaleUpThreshold,
+  mem_scale_down_threshold: payload.memScaleDownThreshold,
+  minimum_memory: payload.minimumMemory,
+  maximum_memory: payload.maximumMemory || null, // 0 => null
+});
+
+export interface ModifyServiceSizingPolicyProps
+  extends ServiceSizingPolicyEditProps {
+  id: string;
+  serviceId: string;
+}
+
+export const createServiceSizingPolicyByServiceId = api.post<
+  ModifyServiceSizingPolicyProps,
+  DeployServiceSizingPolicyResponse
+>(["/services/:serviceId/service_sizing_policies"], function* (ctx, next) {
+  ctx.request = ctx.req({
+    body: JSON.stringify(serializeServiceSizingPolicyEditProps(ctx.payload)),
+  });
+  yield* next();
+});
+
+export const updateServiceSizingPolicyByServiceId = api.put<
+  ModifyServiceSizingPolicyProps,
+  DeployServiceSizingPolicyResponse
+>(["/services/:serviceId/service_sizing_policies"], function* (ctx, next) {
+  ctx.request = ctx.req({
+    body: JSON.stringify(serializeServiceSizingPolicyEditProps(ctx.payload)),
+  });
+  yield* next();
+});
+
+export const deleteServiceSizingPolicyByServiceId = api.delete<{
+  serviceId: string;
+}>(["/services/:serviceId/service_sizing_policy"], function* (ctx, next) {
+  yield* next();
+  if (!ctx.json.ok) {
+    return;
+  }
+  ctx.loader = { message: "Policy changes saved" };
+});
+
+export const modifyServiceSizingPolicy =
+  thunks.create<ModifyServiceSizingPolicyProps>(
+    "modify-service-sizing-policy",
+    function* (ctx, next) {
+      yield* schema.update(schema.loaders.start({ id: ctx.name }));
+      const nextPolicy = ctx.payload;
+      let updateCtx;
+      if (nextPolicy.id) {
+        updateCtx = yield* call(() =>
+          updateServiceSizingPolicyByServiceId.run(nextPolicy),
+        );
+      } else {
+        updateCtx = yield* call(() =>
+          createServiceSizingPolicyByServiceId.run(nextPolicy),
+        );
+      }
+
+      yield* next();
+
+      if (updateCtx.json.ok) {
+        yield* schema.update(
+          schema.loaders.success({
+            id: ctx.name,
+            message: "Policy changes saved",
+          }),
+        );
+      } else {
+        const data = updateCtx.json.error as Error;
+        yield* schema.update(
+          schema.loaders.error({ id: ctx.name, message: data.message }),
+        );
+      }
+    },
+  );

--- a/src/deploy/service-sizing-policy/index.ts
+++ b/src/deploy/service-sizing-policy/index.ts
@@ -92,7 +92,6 @@ export const serviceSizingPolicyEntities = {
 
 export const selectServiceSizingPolicyById =
   schema.serviceSizingPolicies.selectById;
-
 export const selectServiceSizingPolicyByServiceId = createSelector(
   selectServiceById,
   schema.serviceSizingPolicies.selectTableAsList,
@@ -101,6 +100,10 @@ export const selectServiceSizingPolicyByServiceId = createSelector(
     schema.serviceSizingPolicies.empty,
 );
 
+export const selectAutoscalingEnabledById = createSelector(
+  selectServiceSizingPolicyById,
+  (policy) => policy.scalingEnabled,
+);
 export const selectAutoscalingEnabledByServiceId = createSelector(
   selectServiceSizingPolicyByServiceId,
   (policy) => policy.scalingEnabled,

--- a/src/deploy/service-sizing-policy/index.ts
+++ b/src/deploy/service-sizing-policy/index.ts
@@ -92,12 +92,18 @@ export const serviceSizingPolicyEntities = {
 
 export const selectServiceSizingPolicyById =
   schema.serviceSizingPolicies.selectById;
+
 export const selectServiceSizingPolicyByServiceId = createSelector(
   selectServiceById,
   schema.serviceSizingPolicies.selectTableAsList,
   (service, policies) =>
     policies.find((p) => p.id === service.serviceSizingPolicyId) ||
     schema.serviceSizingPolicies.empty,
+);
+
+export const selectAutoscalingEnabledByServiceId = createSelector(
+  selectServiceSizingPolicyByServiceId,
+  (policy) => policy.scalingEnabled,
 );
 
 export const fetchServiceSizingPoliciesByEnvironmentId = api.get<{

--- a/src/deploy/service-sizing-policy/index.ts
+++ b/src/deploy/service-sizing-policy/index.ts
@@ -111,7 +111,7 @@ export const selectAutoscalingEnabledByServiceId = createSelector(
 
 export const fetchServiceSizingPoliciesByEnvironmentId = api.get<{
   id: string;
-}>("/accounts/:id/service_sizing_policies");
+}>("/accounts/:id/service_sizing_policies", { supervisor: cacheShortTimer() });
 export const fetchServiceSizingPoliciesByServiceId = api.get<{
   serviceId: string;
 }>("/services/:serviceId/service_sizing_policies", {

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -24,6 +24,7 @@ import {
   DeployRelease,
   DeployService,
   DeployServiceDefinition,
+  DeployServiceSizingPolicy,
   DeployStack,
   DeployVpcPeer,
   DeployVpnTunnel,
@@ -325,6 +326,7 @@ export const defaultDeployService = (
     appId: "",
     databaseId: "",
     environmentId: "",
+    serviceSizingPolicyId: "",
     handle: "",
     dockerRef: "",
     dockerRepo: "",
@@ -636,6 +638,32 @@ export const defaultDeployImage = (
     createdAt: now,
     updatedAt: now,
     ...img,
+  };
+};
+
+export const defaultServiceSizingPolicy = (
+  m: Partial<DeployServiceSizingPolicy> = {},
+): DeployServiceSizingPolicy => {
+  const now = new Date().toISOString();
+  return {
+    id: "",
+    environmentId: "",
+    scalingEnabled: false,
+    defaultPolicy: false,
+    metricLookbackSeconds: 300,
+    percentile: 99,
+    postScaleUpCooldownSeconds: 60,
+    postScaleDownCooldownSeconds: 300,
+    postReleaseCooldownSeconds: 300,
+    memCpuRatioRThreshold: 4,
+    memCpuRatioCThreshold: 2,
+    memScaleUpThreshold: 0.9,
+    memScaleDownThreshold: 0.75,
+    minimumMemory: 2048,
+    maximumMemory: null,
+    createdAt: now,
+    updatedAt: now,
+    ...m,
   };
 };
 

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -76,5 +76,8 @@ export const [schema, initialState] = createSchema({
   }),
   images: slice.table({ empty: factory.defaultDeployImage() }),
   memberships: slice.table({ empty: factory.defaultMembership() }),
+  serviceSizingPolicies: slice.table({
+    empty: factory.defaultServiceSizingPolicy(),
+  }),
 });
 export type WebState = typeof initialState;

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -41,6 +41,7 @@ export interface DeployService extends Timestamps {
   appId: string;
   databaseId: string;
   environmentId: string;
+  serviceSizingPolicyId: string;
   handle: string;
   dockerRepo: string;
   dockerRef: string;
@@ -544,6 +545,7 @@ export interface DeployServiceResponse {
     app?: LinkResponse;
     database?: LinkResponse;
     account: LinkResponse;
+    service_sizing_policy?: LinkResponse;
   };
   _type: "service";
 }
@@ -556,4 +558,22 @@ export interface DeployAppConfig {
   id: string;
   env: DeployAppConfigEnv;
   appId: string;
+}
+
+export interface DeployServiceSizingPolicy extends Timestamps {
+  id: string;
+  environmentId: string;
+  scalingEnabled: boolean;
+  defaultPolicy: boolean;
+  metricLookbackSeconds: number;
+  percentile: number;
+  postScaleUpCooldownSeconds: number;
+  postScaleDownCooldownSeconds: number;
+  postReleaseCooldownSeconds: number;
+  memCpuRatioRThreshold: number;
+  memCpuRatioCThreshold: number;
+  memScaleUpThreshold: number;
+  memScaleDownThreshold: number;
+  minimumMemory: number;
+  maximumMemory: number | null;
 }

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -35,38 +35,38 @@ import {
   IconPlusCircle,
   PaginateBar,
   Pill,
+  PillVariant,
   TBody,
   THead,
   Table,
   Td,
   Th,
   Tr,
-  pillStyles,
   tokens,
 } from "../shared";
 
 const DrainStatusPill = ({
   drain,
 }: { drain: DeployLogDrain | DeployMetricDrain }) => {
-  let pillClass = pillStyles.progress;
+  let pillVariant: PillVariant = "progress";
   if (
     drain.status === "pending" ||
     drain.status === "provisioning" ||
     drain.status === "deprovisioning"
   ) {
-    pillClass = pillStyles.pending;
+    pillVariant = "pending";
   }
   if (drain.status === "provisioned") {
-    pillClass = pillStyles.success;
+    pillVariant = "success";
   }
   if (
     drain.status === "deprovision_failed" ||
     drain.status === "provision_failed"
   ) {
-    pillClass = pillStyles.error;
+    pillVariant = "error";
   }
 
-  return <Pill className={pillClass}>{capitalize(drain.status)}</Pill>;
+  return <Pill variant={pillVariant}>{capitalize(drain.status)}</Pill>;
 };
 
 const LogDrainPrimaryCell = ({ logDrain }: { logDrain: DeployLogDrain }) => {

--- a/src/ui/pages/stack-detail-vpc-peering.tsx
+++ b/src/ui/pages/stack-detail-vpc-peering.tsx
@@ -21,7 +21,6 @@ import {
   Td,
   Th,
   Tr,
-  pillStyles,
   tokens,
 } from "../shared";
 
@@ -30,11 +29,8 @@ const VPCPeerStatusPill = ({
 }: {
   vpcPeer: DeployVpcPeer;
 }) => {
-  const cls =
-    vpcPeer.connectionStatus === "active"
-      ? pillStyles.success
-      : pillStyles.error;
-  return <Pill className={cls}>{capitalize(vpcPeer.connectionStatus)}</Pill>;
+  const variant = vpcPeer.connectionStatus === "active" ? "success" : "error";
+  return <Pill variant={variant}>{capitalize(vpcPeer.connectionStatus)}</Pill>;
 };
 
 export const StackDetailVpcPeeringPage = () => {

--- a/src/ui/pages/styles.tsx
+++ b/src/ui/pages/styles.tsx
@@ -87,7 +87,6 @@ import {
   Tooltip,
   Tr,
   listToTextColor,
-  pillStyles,
   tokens,
 } from "../shared";
 
@@ -564,16 +563,16 @@ const Pills = () => (
         </Pill>
       </div>
       <div className="mt-4">
-        <Pill className={pillStyles.error}>Error Pill</Pill>
+        <Pill variant="error">Error Pill</Pill>
       </div>
       <div className="mt-4">
-        <Pill className={pillStyles.pending}>Pending Pill</Pill>
+        <Pill variant="pending">Pending Pill</Pill>
       </div>
       <div className="mt-4">
-        <Pill className={pillStyles.progress}>Progress Pill</Pill>
+        <Pill variant="progress">Progress Pill</Pill>
       </div>
       <div className="mt-4">
-        <Pill className={pillStyles.success}>Success Pill</Pill>
+        <Pill variant="success">Success Pill</Pill>
       </div>
     </div>
   </div>

--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -25,7 +25,7 @@ import { Code } from "../code";
 import { CopyTextButton } from "../copy";
 import { Group } from "../group";
 import { IconChevronDown, IconInfo } from "../icons";
-import { Pill, pillStyles } from "../pill";
+import { Pill } from "../pill";
 import {
   ActionBar,
   DescBar,
@@ -147,12 +147,12 @@ const AutoscaleCell = ({ service }: { service: DeployServiceRow }) => {
   const enabled = useSelector((s) =>
     selectAutoscalingEnabledById(s, { id: service.serviceSizingPolicyId }),
   );
-  const style = enabled ? pillStyles.success : "";
+  const variant = enabled ? "success" : "default";
   const text = enabled ? "Enabled" : "Disabled";
 
   return (
     <Td>
-      <Pill className={style}>{text}</Pill>
+      <Pill variant={variant}>{text}</Pill>
     </Td>
   );
 };

--- a/src/ui/shared/app/services-detail.tsx
+++ b/src/ui/shared/app/services-detail.tsx
@@ -1,8 +1,10 @@
 import {
   calcMetrics,
   calcServiceMetrics,
+  fetchServiceSizingPoliciesByEnvironmentId,
   fetchServicesByAppId,
   selectAppById,
+  selectAutoscalingEnabledByServiceId,
   selectServicesByAppId,
   serviceCommandText,
 } from "@app/deploy";
@@ -22,7 +24,8 @@ import { ButtonCreate, ButtonLink } from "../button";
 import { Code } from "../code";
 import { CopyTextButton } from "../copy";
 import { Group } from "../group";
-import { IconChevronDown } from "../icons";
+import { IconCheckCircle, IconChevronDown } from "../icons";
+import { Pill, pillStyles } from "../pill";
 import {
   ActionBar,
   DescBar,
@@ -116,6 +119,23 @@ const CostCell = ({ service }: { service: DeployServiceRow }) => {
   );
 };
 
+const AutoscaleCell = ({ service }: { service: DeployServiceRow }) => {
+  const enabled = useSelector((s) =>
+    selectAutoscalingEnabledByServiceId(s, { id: service.id }),
+  );
+  const style = enabled ? pillStyles.success : "";
+  const text = enabled ? "Enabled" : "Disabled";
+  const icon = enabled ? <IconCheckCircle variant="sm" /> : null;
+
+  return (
+    <Td>
+      <Pill className={style} icon={icon}>
+        {text}
+      </Pill>
+    </Td>
+  );
+};
+
 const AppServiceByAppRow = ({
   service,
 }: {
@@ -131,6 +151,7 @@ const AppServiceByAppRow = ({
         <CmdCell service={service} size="lg" />
         <DetailsCell service={service} />
         <CostCell service={service} />
+        <AutoscaleCell service={service} />
 
         <Td variant="right">
           <Group size="sm" variant="horizontal">
@@ -277,6 +298,9 @@ export function AppServicesByApp({
     navigate(appDeployResumeUrl(app.id));
   };
   useQuery(fetchServicesByAppId({ id: app.id }));
+  useQuery(
+    fetchServiceSizingPoliciesByEnvironmentId({ id: app.environmentId }),
+  );
   const paginated = usePaginate(services);
 
   return (
@@ -306,6 +330,7 @@ export function AppServicesByApp({
           <Th>Command</Th>
           <Th>Details</Th>
           <Th>Est. Monthly Cost</Th>
+          <Th>Autoscaling</Th>
           <Th variant="right">Actions</Th>
         </THead>
 

--- a/src/ui/shared/cert.tsx
+++ b/src/ui/shared/cert.tsx
@@ -1,7 +1,7 @@
 import { DeployCertificate } from "@app/types";
 
 import { prettyDate } from "@app/date";
-import { Pill, pillStyles } from "./pill";
+import { Pill } from "./pill";
 import { tokens } from "./tokens";
 
 interface CertProp {
@@ -10,7 +10,7 @@ interface CertProp {
 
 export const CertTrustedPill = ({ cert }: CertProp) => {
   return (
-    <Pill className={cert.trusted ? pillStyles.success : pillStyles.error}>
+    <Pill variant={cert.trusted ? "success" : "error"}>
       {cert.trusted ? "Trusted" : "Untrusted"}
     </Pill>
   );
@@ -18,7 +18,7 @@ export const CertTrustedPill = ({ cert }: CertProp) => {
 
 export const CertManagedHTTPSPill = ({ cert }: CertProp) => {
   if (!cert.acme) return null;
-  return <Pill className={pillStyles.success}>Managed HTTPS</Pill>;
+  return <Pill variant="success">Managed HTTPS</Pill>;
 };
 
 export const CertValidDateRange = ({ cert }: CertProp) => {

--- a/src/ui/shared/pill.tsx
+++ b/src/ui/shared/pill.tsx
@@ -3,19 +3,52 @@ import { OperationStatus } from "@app/types";
 import cn from "classnames";
 import { IconCheck, IconInfo, IconSettings, IconX } from "./icons";
 
+// TODO: Add support for StatusVariant | "pending"
+export type PillVariant =
+  | "default"
+  | "pending"
+  | "progress"
+  | "success"
+  | "error";
+
+const pillStyles = {
+  pending: "text-brown border-brown bg-orange-100",
+  error: "text-red border-red-300 bg-red-100",
+  progress: "text-indigo border-indigo-300 bg-indigo-100",
+  success: "text-forest border-lime-300 bg-lime-100",
+};
+
+const variantToClassName = (variant: PillVariant) => {
+  switch (variant) {
+    case "pending":
+      return pillStyles.pending;
+    case "progress":
+      return pillStyles.progress;
+    case "success":
+      return pillStyles.success;
+    case "error":
+      return pillStyles.error;
+    default:
+      return "";
+  }
+};
+
 export const Pill = ({
   children,
   className = "",
+  variant = "default",
   icon = null,
 }: {
   children: React.ReactNode;
   className?: string;
+  variant?: PillVariant;
   icon?: React.ReactNode;
 }) => {
   const defaultClassName = cn(
     "rounded-full border-2",
     "text-sm font-semibold text-black-500",
     "px-2 flex gap-2 justify-between items-center w-fit",
+    variantToClassName(variant),
   );
   return (
     <div className={`${defaultClassName} ${className}`}>
@@ -23,13 +56,6 @@ export const Pill = ({
       <div>{children}</div>
     </div>
   );
-};
-
-export const pillStyles = {
-  pending: "text-brown border-brown bg-orange-100",
-  error: "text-red border-red-300 bg-red-100",
-  progress: "text-indigo border-indigo-300 bg-indigo-100",
-  success: "text-forest border-lime-300 bg-lime-100",
 };
 
 export const StatusPill = ({


### PR DESCRIPTION
- Adds an autoscaling status column on the app/services page if autoscaling is enabled on the Stack. The global services page (services by org) is unaffected.
- Adds service sizing policies to the schema and updates existing pages to use it.
- Adds the `variant` option to `Pill` to conform to our other elements.

Disabled:
<img width="363" alt="Screenshot 2024-01-26 at 09 10 55" src="https://github.com/aptible/app-ui/assets/48493233/32a72d75-3293-43d3-b4a5-05c3a740a178">

Enabled:
<img width="388" alt="Screenshot 2024-01-26 at 09 13 18" src="https://github.com/aptible/app-ui/assets/48493233/f3bda5aa-7c8b-4758-a8c0-839694c05e72">

<img width="520" alt="Screenshot 2024-01-26 at 09 13 04" src="https://github.com/aptible/app-ui/assets/48493233/4d6b9f9a-f8a8-477a-a526-220d49b272af">

Open tasks:

- [x] Requires https://github.com/aptible/deploy-api/pull/1345 to be deployed
- [x] Hide the column unless the autoscaling UI is enabled