### PR TITLE
chore: fix typo on scale page

### DIFF
--- a/src/app/test/app-detail-service-scale.test.tsx
+++ b/src/app/test/app-detail-service-scale.test.tsx
@@ -164,7 +164,7 @@ describe("AppDetailServiceScalePage", () => {
           });
 
           await screen.findByText(
-            /Automatically scale your services by regularly revieweing recent CPU and RAM/,
+            /Automatically scale your services by regularly reviewing recent CPU and RAM/,
           );
 
           const btns = screen.getAllByRole("button", {

--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -151,7 +151,7 @@ const VerticalAutoscalingSection = ({
           <BannerMessages {...modifyLoader} />
           <FormGroup
             splitWidthInputs
-            description="Automatically scale your services by regularly revieweing recent CPU and RAM utilization and scaling to the optimal configuration."
+            description="Automatically scale your services by regularly reviewing recent CPU and RAM utilization and scaling to the optimal configuration."
             label="Vertical Autoscaling"
             htmlFor="vertical-autoscaling"
           >


### PR DESCRIPTION
Fix typo on scale page: `revieweing` should be spelled `reviewing`