### PR TITLE
Security validation fixes

### DIFF
--- a/src/auth/pass.ts
+++ b/src/auth/pass.ts
@@ -21,16 +21,8 @@ export const forgotPass = authApi.post<{ email: string }>(
 
     yield* next();
 
-    if (!ctx.json.ok) {
-      ctx.loader = {
-        message: `Error! Unable to submit request to reset your password: ${ctx.json.error.message}
-        `,
-      };
-      return;
-    }
-
     ctx.loader = {
-      message: "Success! Check your email to change your password.",
+      message: "If this is a valid email, you will recieve an email with instructions.",
     };
   },
 );

--- a/src/auth/pass.ts
+++ b/src/auth/pass.ts
@@ -25,7 +25,7 @@ export const forgotPass = authApi.post<{ email: string }>(
         ctx.loader = {
           message:
             "If an Aptible account exists for that email address, we will email you instructions for resetting your password.",
-          meta: { fakeTrue: true },
+          meta: { fakeSuccess: true },
         };
       } else {
         ctx.loader = {

--- a/src/auth/pass.ts
+++ b/src/auth/pass.ts
@@ -11,7 +11,6 @@ export const forgotPass = authApi.post<{ email: string }>(
     if (!origin || !email) {
       return;
     }
-
     ctx.request = ctx.req({
       body: JSON.stringify({
         email,
@@ -20,6 +19,21 @@ export const forgotPass = authApi.post<{ email: string }>(
     });
 
     yield* next();
+
+    if (!ctx.json.ok) {
+      if (ctx.json.error.error === 'invalid_email') {
+        ctx.loader = {
+          message: "If an Aptible account exists for that email address, we will email you instructions for resetting your password.",
+          meta: { fakeTrue: true },
+        }
+      } else {
+        ctx.loader = {
+          message: `Error! Unable to submit request to reset your password: ${ctx.json.error.message}
+          `,
+        };
+      }
+      return;
+    }
 
     ctx.loader = {
       message: "If an Aptible account exists for that email address, we will email you instructions for resetting your password.",

--- a/src/auth/pass.ts
+++ b/src/auth/pass.ts
@@ -22,7 +22,7 @@ export const forgotPass = authApi.post<{ email: string }>(
     yield* next();
 
     ctx.loader = {
-      message: "If this is a valid email, you will recieve an email with instructions.",
+      message: "If an Aptible account exists for that email address, we will email you instructions for resetting your password.",
     };
   },
 );

--- a/src/auth/pass.ts
+++ b/src/auth/pass.ts
@@ -21,11 +21,12 @@ export const forgotPass = authApi.post<{ email: string }>(
     yield* next();
 
     if (!ctx.json.ok) {
-      if (ctx.json.error.error === 'invalid_email') {
+      if (ctx.json.error.error === "invalid_email") {
         ctx.loader = {
-          message: "If an Aptible account exists for that email address, we will email you instructions for resetting your password.",
+          message:
+            "If an Aptible account exists for that email address, we will email you instructions for resetting your password.",
           meta: { fakeTrue: true },
-        }
+        };
       } else {
         ctx.loader = {
           message: `Error! Unable to submit request to reset your password: ${ctx.json.error.message}
@@ -36,7 +37,8 @@ export const forgotPass = authApi.post<{ email: string }>(
     }
 
     ctx.loader = {
-      message: "If an Aptible account exists for that email address, we will email you instructions for resetting your password.",
+      message:
+        "If an Aptible account exists for that email address, we will email you instructions for resetting your password.",
     };
   },
 );

--- a/src/ui/pages/forgot-pass.test.tsx
+++ b/src/ui/pages/forgot-pass.test.tsx
@@ -28,12 +28,32 @@ describe("ForgotPassPage", () => {
 
     const alert = await screen.findByRole("status");
     expect(alert.textContent).toMatch(
-      /Success! Check your email to change your password./,
+      /If an Aptible account exists for that email address, we will email you instructions for resetting your password./,
     );
     expect(
       btn,
       "when already reset password the btn should be disabled",
     ).toBeDisabled();
+  });
+
+  it("should hide a User not found email", async () => {
+    const { TestProvider } = setupIntegrationTest();
+    render(
+      <TestProvider>
+        <ForgotPassPage />
+      </TestProvider>,
+    );
+
+    const btn = await screen.findByRole("button");
+    const email = await screen.findByRole("textbox", { name: "email" });
+    await act(() => userEvent.type(email, "abc@abc.com"));
+
+    fireEvent.click(btn);
+
+    const alert = await screen.findByRole("status");
+    expect(alert.textContent).toMatch(
+      /If an Aptible account exists for that email address, we will email you instructions for resetting your password./,
+    );
   });
 });
 

--- a/src/ui/pages/forgot-pass.test.tsx
+++ b/src/ui/pages/forgot-pass.test.tsx
@@ -1,10 +1,11 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { testEmail } from "@app/mocks";
+import { testEmail, server, testEnv } from "@app/mocks";
 import { RESET_PASSWORD_PATH, resetPassVerifyUrl } from "@app/routes";
 import { setupIntegrationTest } from "@app/test";
 import { ForgotPassPage, ForgotPassVerifyPage } from "./forgot-pass";
+import { rest } from "msw";
 
 describe("ForgotPassPage", () => {
   it("should allow user to request a password reset", async () => {
@@ -37,6 +38,11 @@ describe("ForgotPassPage", () => {
   });
 
   it("should hide a User not found email", async () => {
+    server.use(
+      rest.post(`${testEnv.authUrl}/password/resets/new`, (_, res, ctx) => {
+        return res(ctx.status(400), ctx.json({ error: 'invalid_email', ok: false })); 
+      }),
+    );
     const { TestProvider } = setupIntegrationTest();
     render(
       <TestProvider>

--- a/src/ui/pages/forgot-pass.test.tsx
+++ b/src/ui/pages/forgot-pass.test.tsx
@@ -1,11 +1,11 @@
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { testEmail, server, testEnv } from "@app/mocks";
+import { server, testEmail, testEnv } from "@app/mocks";
 import { RESET_PASSWORD_PATH, resetPassVerifyUrl } from "@app/routes";
 import { setupIntegrationTest } from "@app/test";
-import { ForgotPassPage, ForgotPassVerifyPage } from "./forgot-pass";
 import { rest } from "msw";
+import { ForgotPassPage, ForgotPassVerifyPage } from "./forgot-pass";
 
 describe("ForgotPassPage", () => {
   it("should allow user to request a password reset", async () => {
@@ -40,7 +40,10 @@ describe("ForgotPassPage", () => {
   it("should hide a User not found email", async () => {
     server.use(
       rest.post(`${testEnv.authUrl}/password/resets/new`, (_, res, ctx) => {
-        return res(ctx.status(400), ctx.json({ error: 'invalid_email', ok: false })); 
+        return res(
+          ctx.status(400),
+          ctx.json({ error: "invalid_email", ok: false }),
+        );
       }),
     );
     const { TestProvider } = setupIntegrationTest();

--- a/src/ui/pages/forgot-pass.tsx
+++ b/src/ui/pages/forgot-pass.tsx
@@ -1,6 +1,7 @@
 import { forgotPass, resetPass } from "@app/auth/pass";
 import { useDispatch, useLoader } from "@app/react";
 import { loginUrl } from "@app/routes";
+import { sanitizeInput } from "@app/validator";
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { HeroBgLayout } from "../layouts";
@@ -14,7 +15,6 @@ import {
   Input,
   tokens,
 } from "../shared";
-import { sanitizeInput } from "@app/validator";
 
 export const ForgotPassPage = () => {
   const dispatch = useDispatch();

--- a/src/ui/pages/forgot-pass.tsx
+++ b/src/ui/pages/forgot-pass.tsx
@@ -37,7 +37,7 @@ export const ForgotPassPage = () => {
 
       <Box>
         <Group>
-          <BannerMessages {...loader} isSuccess={true} />
+          <BannerMessages {...loader} />
 
           <form onSubmit={onSubmit}>
             <FormGroup label="Email" htmlFor="email">

--- a/src/ui/pages/forgot-pass.tsx
+++ b/src/ui/pages/forgot-pass.tsx
@@ -38,7 +38,10 @@ export const ForgotPassPage = () => {
 
       <Box>
         <Group>
-          <BannerMessages {...loader} />
+          <BannerMessages
+            {...loader}
+            isSuccess={loader.meta.fakeSuccess || loader.isSuccess}
+          />
 
           <form onSubmit={onSubmit}>
             <FormGroup label="Email" htmlFor="email">

--- a/src/ui/pages/forgot-pass.tsx
+++ b/src/ui/pages/forgot-pass.tsx
@@ -37,7 +37,7 @@ export const ForgotPassPage = () => {
 
       <Box>
         <Group>
-          <BannerMessages {...loader} />
+          <BannerMessages {...loader} isSuccess={true} />
 
           <form onSubmit={onSubmit}>
             <FormGroup label="Email" htmlFor="email">

--- a/src/ui/pages/forgot-pass.tsx
+++ b/src/ui/pages/forgot-pass.tsx
@@ -14,6 +14,7 @@ import {
   Input,
   tokens,
 } from "../shared";
+import { sanitizeInput } from "@app/validator";
 
 export const ForgotPassPage = () => {
   const dispatch = useDispatch();
@@ -45,7 +46,7 @@ export const ForgotPassPage = () => {
                 type="email"
                 name="email"
                 value={email}
-                onChange={(e) => setEmail(e.currentTarget.value)}
+                onChange={(e) => setEmail(sanitizeInput(e.currentTarget.value))}
                 placeholder="Enter your email"
                 className="w-full"
               />

--- a/src/ui/pages/settings-profile.test.tsx
+++ b/src/ui/pages/settings-profile.test.tsx
@@ -1,0 +1,39 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { setupIntegrationTest } from "@app/test";
+import { SettingsProfilePage } from "./settings-profile";
+
+describe("ForgotPassPage", () => {
+  it("should hide sanitize name input", async () => {
+    const { TestProvider } = setupIntegrationTest();
+    render(
+      <TestProvider>
+        <SettingsProfilePage />
+      </TestProvider>,
+    );
+
+    const name = await screen.findByRole("textbox", { name: "name" });
+    await act(() => userEvent.type(name, "<test>!#@"));
+
+    expect(name).toHaveValue("not-verified&lt;test&gt;!#@");
+  });
+  it("should *not* allow symbols in name", async () => {
+    const { TestProvider } = setupIntegrationTest();
+    render(
+      <TestProvider>
+        <SettingsProfilePage />
+      </TestProvider>,
+    );
+
+    const name = await screen.findByRole("textbox", { name: "name" });
+    await act(() => userEvent.type(name, "<test>!#@"));
+
+    const el = await screen.findByRole("button", { name: "Save Changes" });
+    fireEvent.click(el);
+
+    expect(
+      await screen.findByText("Cannot have symbols in name"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/ui/pages/settings-profile.test.tsx
+++ b/src/ui/pages/settings-profile.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { setupIntegrationTest } from "@app/test";
 import { SettingsProfilePage } from "./settings-profile";
 
-describe("ForgotPassPage", () => {
+describe("SettingsProfilePage", () => {
   it("should hide sanitize name input", async () => {
     const { TestProvider } = setupIntegrationTest();
     render(

--- a/src/ui/pages/settings-profile.tsx
+++ b/src/ui/pages/settings-profile.tsx
@@ -1,6 +1,6 @@
 import { useDispatch, useLoader, useSelector } from "@app/react";
 import { selectCurrentUser, updateUserName } from "@app/users";
-import { nameValidator, existValidtor } from "@app/validator";
+import { nameValidator, existValidtor, sanitizeInput } from "@app/validator";
 import { useEffect, useState } from "react";
 import {
   BannerMessages,
@@ -83,9 +83,9 @@ export function SettingsProfilePage() {
                 name="name"
                 value={name}
                 onChange={(e) => {
-                  setName(e.currentTarget.value)
+                  setName(sanitizeInput(e.currentTarget.value))
                   validate({
-                    name: e.currentTarget.value
+                    name: sanitizeInput(e.currentTarget.value)
                   })
                 }}
               />

--- a/src/ui/pages/settings-profile.tsx
+++ b/src/ui/pages/settings-profile.tsx
@@ -1,7 +1,8 @@
 import { useDispatch, useLoader, useSelector } from "@app/react";
 import { selectCurrentUser, updateUserName } from "@app/users";
-import { nameValidator, existValidtor, sanitizeInput } from "@app/validator";
+import { existValidtor, nameValidator, sanitizeInput } from "@app/validator";
 import { useEffect, useState } from "react";
+import { useValidator } from "../hooks";
 import {
   BannerMessages,
   Box,
@@ -12,7 +13,6 @@ import {
   Input,
   tokens,
 } from "../shared";
-import { useValidator } from "../hooks";
 
 export function SettingsProfilePage() {
   const dispatch = useDispatch();
@@ -25,7 +25,8 @@ export function SettingsProfilePage() {
   };
   const action = updateUserName(data);
   const validators = {
-    name: (props: UpdateNameForm) => existValidtor(props.name, "Name") || nameValidator(props.name),
+    name: (props: UpdateNameForm) =>
+      existValidtor(props.name, "Name") || nameValidator(props.name),
   };
   const [errors, validate] = useValidator<UpdateNameForm, typeof validators>(
     validators,
@@ -74,19 +75,22 @@ export function SettingsProfilePage() {
           <Group>
             <BannerMessages {...loader} />
 
-            <FormGroup label="Name" htmlFor="name"
+            <FormGroup
+              label="Name"
+              htmlFor="name"
               feedbackMessage={errors.name}
-              feedbackVariant={errors.name ? "danger" : "info"}>
+              feedbackVariant={errors.name ? "danger" : "info"}
+            >
               <Input
                 type="text"
                 id="name"
                 name="name"
                 value={name}
                 onChange={(e) => {
-                  setName(sanitizeInput(e.currentTarget.value))
+                  setName(sanitizeInput(e.currentTarget.value));
                   validate({
-                    name: sanitizeInput(e.currentTarget.value)
-                  })
+                    name: sanitizeInput(e.currentTarget.value),
+                  });
                 }}
               />
             </FormGroup>

--- a/src/ui/pages/signup.tsx
+++ b/src/ui/pages/signup.tsx
@@ -14,7 +14,7 @@ import {
 } from "@app/routes";
 import { selectIsUserAuthenticated } from "@app/token";
 import { CreateUserForm } from "@app/users";
-import { emailValidator, existValidtor, passValidator } from "@app/validator";
+import { emailValidator, existValidtor, passValidator, nameValidator } from "@app/validator";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
@@ -33,12 +33,12 @@ import {
 } from "../shared";
 
 const validators = {
-  name: (props: CreateUserForm) => existValidtor(props.name, "Name"),
+  name: (props: CreateUserForm) => existValidtor(props.name, "Name") || nameValidator(props.name),
   company: (props: CreateUserForm) => {
     if (props.challenge_token !== "") {
       return;
     }
-    return existValidtor(props.company, "Company");
+    return existValidtor(props.company, "Company") || nameValidator(props.company);
   },
   email: (props: CreateUserForm) => emailValidator(props.email),
   pass: (props: CreateUserForm) => passValidator(props.password),

--- a/src/ui/pages/signup.tsx
+++ b/src/ui/pages/signup.tsx
@@ -14,7 +14,7 @@ import {
 } from "@app/routes";
 import { selectIsUserAuthenticated } from "@app/token";
 import { CreateUserForm } from "@app/users";
-import { emailValidator, existValidtor, passValidator, nameValidator } from "@app/validator";
+import { emailValidator, existValidtor, passValidator, nameValidator, sanitizeInput } from "@app/validator";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
@@ -220,7 +220,7 @@ export const SignupPage = () => {
                   required={true}
                   value={name}
                   className="w-full"
-                  onChange={(e) => setName(e.target.value)}
+                  onChange={(e) => setName(sanitizeInput(e.target.value))}
                 />
               </FormGroup>
 
@@ -239,7 +239,7 @@ export const SignupPage = () => {
                     required={true}
                     value={company}
                     className="w-full"
-                    onChange={(e) => setCompany(e.target.value)}
+                    onChange={(e) => setCompany(sanitizeInput(e.target.value))}
                   />
                 </FormGroup>
               )}
@@ -257,7 +257,7 @@ export const SignupPage = () => {
                   autoComplete="email"
                   required={true}
                   value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  onChange={(e) => setEmail(sanitizeInput(e.target.value))}
                   className="w-full"
                 />
               </FormGroup>

--- a/src/ui/pages/signup.tsx
+++ b/src/ui/pages/signup.tsx
@@ -14,7 +14,13 @@ import {
 } from "@app/routes";
 import { selectIsUserAuthenticated } from "@app/token";
 import { CreateUserForm } from "@app/users";
-import { emailValidator, existValidtor, passValidator, nameValidator, sanitizeInput } from "@app/validator";
+import {
+  emailValidator,
+  existValidtor,
+  nameValidator,
+  passValidator,
+  sanitizeInput,
+} from "@app/validator";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import { Link, useSearchParams } from "react-router-dom";
@@ -33,12 +39,15 @@ import {
 } from "../shared";
 
 const validators = {
-  name: (props: CreateUserForm) => existValidtor(props.name, "Name") || nameValidator(props.name),
+  name: (props: CreateUserForm) =>
+    existValidtor(props.name, "Name") || nameValidator(props.name),
   company: (props: CreateUserForm) => {
     if (props.challenge_token !== "") {
       return;
     }
-    return existValidtor(props.company, "Company") || nameValidator(props.company);
+    return (
+      existValidtor(props.company, "Company") || nameValidator(props.company)
+    );
   },
   email: (props: CreateUserForm) => emailValidator(props.email),
   pass: (props: CreateUserForm) => passValidator(props.password),

--- a/src/ui/shared/banner.tsx
+++ b/src/ui/shared/banner.tsx
@@ -110,11 +110,11 @@ export const BannerMessages = ({
   isWarning?: boolean;
   message: string;
   className?: string;
-  meta?: any
+  meta?: any;
 }) => {
   if (!message) return null;
 
-  if (isSuccess || meta.fakeTrue) {
+  if (isSuccess || meta?.fakeTrue) {
     return (
       <Banner className={className} variant="success">
         {message}

--- a/src/ui/shared/banner.tsx
+++ b/src/ui/shared/banner.tsx
@@ -103,16 +103,18 @@ export const BannerMessages = ({
   isWarning,
   message,
   className,
+  meta
 }: {
   isSuccess: boolean;
   isError: boolean;
   isWarning?: boolean;
   message: string;
   className?: string;
+  meta?: any
 }) => {
   if (!message) return null;
 
-  if (isSuccess) {
+  if (isSuccess || meta.fakeTrue) {
     return (
       <Banner className={className} variant="success">
         {message}

--- a/src/ui/shared/banner.tsx
+++ b/src/ui/shared/banner.tsx
@@ -103,18 +103,16 @@ export const BannerMessages = ({
   isWarning,
   message,
   className,
-  meta,
 }: {
   isSuccess: boolean;
   isError: boolean;
   isWarning?: boolean;
   message: string;
   className?: string;
-  meta?: any;
 }) => {
   if (!message) return null;
 
-  if (isSuccess || meta?.fakeTrue) {
+  if (isSuccess) {
     return (
       <Banner className={className} variant="success">
         {message}

--- a/src/ui/shared/banner.tsx
+++ b/src/ui/shared/banner.tsx
@@ -103,7 +103,7 @@ export const BannerMessages = ({
   isWarning,
   message,
   className,
-  meta
+  meta,
 }: {
   isSuccess: boolean;
   isError: boolean;

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -117,9 +117,9 @@ export function existValidtor(val: string, name: string) {
 
 export function nameValidator(name: string) {
   const regex = /^[a-zA-Z0-9\s]+$/;
-  
+
   if (!regex.test(name)) {
-    return 'Cannot have symbols in name';
+    return "Cannot have symbols in name";
   }
 }
 

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -122,3 +122,8 @@ export function nameValidator(name: string) {
     return 'Cannot have symbols in name';
   }
 }
+
+// Sanitizes inputs and removes harmful characters as they are inputs. Example <
+export function sanitizeInput(input: any) {
+  return input.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -114,3 +114,11 @@ export function emailValidator(email: string) {
 export function existValidtor(val: string, name: string) {
   if (val === "") return `${name} must not be empty`;
 }
+
+export function nameValidator(name: string) {
+  const regex = /^[a-zA-Z0-9\s]+$/;
+  
+  if (!regex.test(name)) {
+    return 'Cannot have symbols in name';
+  }
+}


### PR DESCRIPTION
- https://aptible.zendesk.com/agent/tickets/50991
- https://aptible.zendesk.com/agent/tickets/50992

- Added validation to forgot-pass, signup, and edit name
- Added sanitize function to remove harmful characters
- Modified invalid_email response from forgot-pass to show a `fakeTrue` so a potentially harmful user cannot know whether an email is a user.
    - they can still check the network tab but a change in `auth-api` will still be needed
