### PR TITLE
fix: database backup pill color styling

### DIFF
--- a/src/ui/shared/db/backup-list.tsx
+++ b/src/ui/shared/db/backup-list.tsx
@@ -43,7 +43,7 @@ const BackupTypePill = ({
         manual
           ? "bg-indigo-100 text-indigo-400 border-indigo-300"
           : "bg-lime-100 text-green-400 border-lime-300",
-          final
+        final
           ? "!bg-indigo-100 !text-indigo-400 !border-indigo-300"
           : "bg-indigo-100 text-green-400 border-indigo-300",
       )}

--- a/src/ui/shared/db/backup-list.tsx
+++ b/src/ui/shared/db/backup-list.tsx
@@ -44,7 +44,7 @@ const BackupTypePill = ({
           ? "bg-indigo-100 text-indigo-400 border-indigo-300"
           : "bg-lime-100 text-green-400 border-lime-300",
         final
-          ? "!bg-indigo-100 !text-indigo-400 !border-indigo-300"
+          ? "!bg-orange-100 !text-brown !border-brown"
           : "bg-indigo-100 text-green-400 border-indigo-300",
       )}
     >

--- a/src/ui/shared/db/backup-list.tsx
+++ b/src/ui/shared/db/backup-list.tsx
@@ -43,6 +43,9 @@ const BackupTypePill = ({
         manual
           ? "bg-indigo-100 text-indigo-400 border-indigo-300"
           : "bg-lime-100 text-green-400 border-lime-300",
+          final
+          ? "!bg-indigo-100 !text-indigo-400 !border-indigo-300"
+          : "bg-indigo-100 text-green-400 border-indigo-300",
       )}
     >
       <div>{type}</div>


### PR DESCRIPTION
Update final backup pill color styling

**BEFORE** - (Final pills appear as green & blue)

Environment Detail / Backups Tab
![Screenshot 2024-02-05 at 11 26 15 AM](https://github.com/aptible/app-ui/assets/4295811/f0a4eab4-1433-404c-b8a8-0949f04037f6)

---

**AFTER** - (Final pills match the same color)

Environment Detail / Backups Tab
![Screenshot 2024-02-05 at 11 39 26 AM](https://github.com/aptible/app-ui/assets/4295811/b7836ff9-22ce-4859-a432-7a86777bb7ac)

Database / Backups Tab
![Screenshot 2024-02-05 at 11 26 30 AM](https://github.com/aptible/app-ui/assets/4295811/104c6354-5ffd-46ab-a2c3-afa4f5671bbb)
