### PR TITLE
chore: add autoscaling doc

### DIFF
--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -487,7 +487,7 @@ const LastScaleBanner = ({ serviceId }: { serviceId: string }) => {
   }
 
   return (
-    <Banner variant={currentComplete || neverScaled ? "default" : "progress"}>
+    <Banner variant={currentComplete || neverScaled ? "info" : "progress"}>
       {neverScaled ? (
         "Never Scaled"
       ) : (

--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -37,6 +37,7 @@ import { usePoller, useValidator } from "../hooks";
 import {
   Banner,
   ButtonIcon,
+  ButtonLinkDocs,
   IconChevronDown,
   IconChevronRight,
   IconRefresh,
@@ -131,7 +132,10 @@ const VerticalAutoscalingSection = ({
     <Box>
       <form onSubmit={onSubmitForm}>
         <div className="flex flex-col gap-4">
-          <h1 className="text-lg text-gray-500">Autoscale</h1>
+          <div className="flex justify-between items-start">
+            <h1 className="text-lg text-gray-500">Autoscale</h1>
+            <ButtonLinkDocs href="https://aptible.notion.site/Vertical-Autoscaler-d33817b4e1584e2e8a8a86edc507756a" />
+          </div>
           <BannerMessages {...modifyLoader} />
           <FormGroup
             splitWidthInputs
@@ -628,7 +632,7 @@ export const AppDetailServiceScalePage = () => {
         <form onSubmit={onSubmitForm}>
           <div className="flex flex-col gap-2">
             {stack.verticalAutoscaling ? (
-              <h1 className="text-lg text-gray-500">Manual Scale</h1>
+              <h1 className="text-lg text-gray-500 mb-4">Manual Scale</h1>
             ) : null}
             <FormGroup
               splitWidthInputs

--- a/src/ui/pages/styles.tsx
+++ b/src/ui/pages/styles.tsx
@@ -145,9 +145,6 @@ const Banners = () => (
     <h1 id="banners" className={tokens.type.h1}>
       Banners
     </h1>
-    <Banner className="mt-2" variant="default">
-      Default banner
-    </Banner>
     <Banner className="mt-2" variant="success">
       Success banner
     </Banner>


### PR DESCRIPTION
**Changes**
• Add view docs link for autoscale
• Change default banner styling to info variant & remove default from styles page (we never use default)

BEFORE
![Screenshot 2024-02-07 at 9 39 47 AM](https://github.com/aptible/app-ui/assets/4295811/65850d55-2b09-4e72-ad47-3a2a74b3840f)

AFTER
![Screenshot 2024-02-07 at 9 39 27 AM](https://github.com/aptible/app-ui/assets/4295811/6c78ee90-9a54-4db3-bf3a-f5211a63365c)
