### PR TITLE
fix: blank env editor

### DIFF
--- a/src/ui/hooks/use-env-editor.ts
+++ b/src/ui/hooks/use-env-editor.ts
@@ -23,13 +23,6 @@ export const validateEnvs = (items: TextVal[]): ValidatorError[] => {
         message: `${item.key} does not match regex: /[a-zA-Z_]+[a-zA-Z0-9_]*/`,
       });
     }
-
-    if (item.value === "") {
-      errors.push({
-        item,
-        message: `${item.key} is blank, either provide a value or remove the environment variable`,
-      });
-    }
   };
 
   items.forEach(validate);

--- a/src/ui/pages/app-deploy-configure.test.tsx
+++ b/src/ui/pages/app-deploy-configure.test.tsx
@@ -66,43 +66,6 @@ describe("AppDeployConfigurePage", () => {
     expect(btn).not.toBeInTheDocument();
   });
 
-  it("should display error when validating environment variables", async () => {
-    const handlers = stacksWithResources({
-      apps: [testApp],
-    });
-    server.use(...handlers);
-
-    const { TestProvider, store } = setupIntegrationTest({
-      path: APP_DEPLOY_CONFIGURE_PATH,
-      initEntries: [
-        appDeployConfigureUrl(
-          `${testApp.id}`,
-          "dbs=database_url:postgres:14&envs=DEBUG:1,APP",
-        ),
-      ],
-    });
-
-    await waitForBootup(store);
-
-    render(
-      <TestProvider>
-        <AppDeployConfigurePage />
-      </TestProvider>,
-    );
-
-    const envTxtArea = await screen.findByLabelText("Environment Variables");
-    expect(envTxtArea.textContent).toBe("DEBUG=1\nAPP=");
-    await screen.findByText("postgres v14");
-
-    const btn = await screen.findByRole("button", { name: "Save & Deploy" });
-    fireEvent.click(btn);
-
-    const text = await screen.findByText(
-      /APP is blank, either provide a value or remove the environment variable/,
-    );
-    expect(text).toBeInTheDocument();
-  });
-
   it("should display error when validating database environment variables", async () => {
     const handlers = stacksWithResources({
       apps: [testApp],

--- a/src/ui/pages/app-detail-config.tsx
+++ b/src/ui/pages/app-detail-config.tsx
@@ -86,17 +86,30 @@ const EnvEditor = ({ app }: { app: DeployApp }) => {
   }
 
   const desc = (
-    <p>
-      Add any additional required variables, such as API keys, KNOWN_HOSTS
-      setting, etc. We use{" "}
-      <ExternalLink variant="info" href="https://github.com/motdotla/dotenv">
-        dotenv
-      </ExternalLink>{" "}
-      to parse the textarea. Each line is a separate variable in format:{" "}
-      <Code>ENV_VAR="VALUE"</Code>. If you want to delete an environment
-      variable, set it to empty: <Code>ENV_VAR=""</Code>. If you have an
-      environment variable that spans multiple lines then wrap in double quotes.
-    </p>
+    <div>
+      <p>
+        Specify any ENV variables you wish to add or modify, one per line. We
+        use{" "}
+        <ExternalLink variant="info" href="https://github.com/motdotla/dotenv">
+          dotenv
+        </ExternalLink>{" "}
+        to parse these variables.
+      </p>
+      <ol>
+        <li>
+          Each line corresponds to a separate variable with the format{" "}
+          <Code>ENV_VAR=value</Code>.
+        </li>
+        <li>
+          If you want to delete an environment variable, set it to an empty
+          string, with or without double quotes: <Code>ENV_VAR=""</Code>.
+        </li>
+        <li>
+          Multi-line environment variables may be set by wrapping in double
+          quotes.
+        </li>
+      </ol>
+    </div>
   );
 
   return (

--- a/src/ui/pages/app-detail-config.tsx
+++ b/src/ui/pages/app-detail-config.tsx
@@ -99,7 +99,7 @@ const EnvEditor = ({ app }: { app: DeployApp }) => {
       <ol className="list-disc list-inside">
         <li>
           Each line corresponds to a separate variable with the format{" "}
-          <Code>ENV_VAR=value</Code>.
+          <Code>ENV_VAR="value"</Code> or <Code>ENV_VAR='value'</Code>.
         </li>
         <li>
           If you want to delete an environment variable, set it to an empty
@@ -143,6 +143,7 @@ const EnvEditor = ({ app }: { app: DeployApp }) => {
 
         <hr />
 
+        <div className={tokens.type.h4}>Preview</div>
         <PreText text={JSON.stringify(partialEnv, null, 2)} />
 
         <Group variant="horizontal">

--- a/src/ui/pages/app-detail-config.tsx
+++ b/src/ui/pages/app-detail-config.tsx
@@ -22,6 +22,7 @@ import { useNavigate, useParams } from "react-router";
 import { useEnvEditor, useLatestCodeResults } from "../hooks";
 import {
   AppConfigView,
+  Banner,
   BannerMessages,
   Box,
   Button,
@@ -95,7 +96,7 @@ const EnvEditor = ({ app }: { app: DeployApp }) => {
         </ExternalLink>{" "}
         to parse these variables.
       </p>
-      <ol>
+      <ol className="list-disc list-inside">
         <li>
           Each line corresponds to a separate variable with the format{" "}
           <Code>ENV_VAR=value</Code>.
@@ -115,6 +116,15 @@ const EnvEditor = ({ app }: { app: DeployApp }) => {
   return (
     <form onSubmit={onSubmit}>
       <Group>
+        <Banner variant="warning">
+          Warning: This UI uses dotenv to parse ENV variables. Dotenv parsing
+          differs slightly from shell, so if you're most familiar with setting
+          ENV variables in shell, e.g. via the <Code>aptible config:set</Code>{" "}
+          CLI command, note that this parser may behave differently with
+          multi-line variables or special characters. We recommend first setting
+          variables on a staging app or a different ENV key within a production
+          app if unsure how the variable will be parsed.
+        </Banner>
         <FormGroup
           label="Environment Variables"
           htmlFor="envs"
@@ -132,6 +142,8 @@ const EnvEditor = ({ app }: { app: DeployApp }) => {
         </FormGroup>
 
         <hr />
+
+        <PreText text={JSON.stringify(partialEnv, null, 2)} />
 
         <Group variant="horizontal">
           <ButtonSensitive


### PR DESCRIPTION
Previously we showed all the environment variables which could cause some unintended side-effects and doesn't really map with how environment variables are set in Apps.  This change aligns more closely with how the CLI functions: it's additive.

I also updated the explainer text to make it more clear how we parse our textarea.
<img width="711" alt="Screenshot 2024-02-08 at 7 52 25 PM" src="https://github.com/aptible/app-ui/assets/1940365/380d3b4e-0eba-43c5-91ad-90b77b30355b">

