### PR TITLE
[DO NOT MERGE] Add Updated timeago styling to <Descbar> globally

### DIFF
--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -263,7 +263,7 @@ function ActivityTable({
           </Group>
 
           <Group variant="horizontal" size="lg" className="items-center mt-1">
-            <DescBar>{paginated.totalItems} Operations</DescBar>
+            <DescBar>{paginated.totalItems} Operations<span>, Updated Now <a className="text-gray-500 underline hover:text-indigo cursor-pointer">Refresh</a></span></DescBar>
             <PaginateBar {...paginated} />
           </Group>
         </FilterBar>

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -269,7 +269,7 @@ function ActivityTable({
               <span className="inline-block">
                 <Tooltip text="Refresh">
                   <IconRefresh
-                    className="inline-block -mt-1 opacity-50 hover:opacity-100"
+                    className="inline-block -mt-1 ml-1 opacity-50 hover:opacity-100"
                     variant="sm"
                   />
                 </Tooltip>

--- a/src/ui/shared/activity.tsx
+++ b/src/ui/shared/activity.tsx
@@ -37,6 +37,7 @@ import { useMemo } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { usePaginate } from "../hooks";
 import { usePoller } from "../hooks/use-poller";
+import { IconRefresh, Tooltip } from "../shared";
 import { Button } from "./button";
 import { Group } from "./group";
 import { InputSearch } from "./input";
@@ -263,7 +264,17 @@ function ActivityTable({
           </Group>
 
           <Group variant="horizontal" size="lg" className="items-center mt-1">
-            <DescBar>{paginated.totalItems} Operations<span>, Updated Now <a className="text-gray-500 underline hover:text-indigo cursor-pointer">Refresh</a></span></DescBar>
+            <DescBar>
+              {paginated.totalItems} Operations, Updated Now{" "}
+              <span className="inline-block">
+                <Tooltip text="Refresh">
+                  <IconRefresh
+                    className="inline-block -mt-1 opacity-50 hover:opacity-100"
+                    variant="sm"
+                  />
+                </Tooltip>
+              </span>
+            </DescBar>
             <PaginateBar {...paginated} />
           </Group>
         </FilterBar>


### PR DESCRIPTION
**Notes**
• We can have it update every second, but I think the constant second counting will be distracting. I think a better solution is to change the "Updated N" text every minute (ex. 1m ago, 2m ago, etc...), and after 59m ago, change to 1h ago (1h ago, 2h ago, etc...).
• After refreshing change the "Updated N" text to **Updated Now**
• I think we can hide the refresh icon until the page hits 1m ago OR whatever time we think justifies a refresh


Normal State
![Screenshot 2024-02-23 at 11 28 57 AM](https://github.com/aptible/app-ui/assets/4295811/f453b6a1-d4c1-474b-8855-0ec7375e7207)

Hover State
![Screenshot-2024-02-23-at-11 29 00 AM](https://github.com/aptible/app-ui/assets/4295811/b5bfdec8-eec4-47ad-a45d-371e015c9f55)
