### PR TITLE
Show stack default-domain on create endpoint page

### DIFF
--- a/src/deploy/stack/index.ts
+++ b/src/deploy/stack/index.ts
@@ -31,6 +31,8 @@ export interface DeployStackResponse {
   allow_r_instance_profile: boolean;
   allow_granular_container_sizes: boolean;
   vertical_autoscaling: boolean;
+  internal_domain: string;
+  default_domain: string;
   _links: {
     organization: LinkResponse;
   };
@@ -60,6 +62,8 @@ export const defaultStackResponse = (
     allow_t_instance_profile: true,
     allow_granular_container_sizes: true,
     vertical_autoscaling: false,
+    internal_domain: "aptible.in",
+    default_domain: "on-aptible.com",
     _links: { organization: { href: "" } },
     _type: "stack",
     ...s,
@@ -89,6 +93,8 @@ export const deserializeDeployStack = (
     allowGranularContainerSizes: payload.allow_granular_container_sizes,
     verticalAutoscaling: payload.vertical_autoscaling,
     organizationId: extractIdFromLink(payload._links.organization),
+    internalDomain: payload.internal_domain,
+    defaultDomain: payload.default_domain,
   };
 };
 

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -231,6 +231,8 @@ export const defaultDeployStack = (
     allowTInstanceProfile: false,
     allowGranularContainerSizes: false,
     verticalAutoscaling: false,
+    internalDomain: "aptible.in",
+    defaultDomain: "on-aptible.com",
     ...s,
   };
 };

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -146,6 +146,8 @@ export interface DeployStack extends Timestamps {
   allowGranularContainerSizes: boolean;
   verticalAutoscaling: boolean;
   organizationId: string;
+  internalDomain: string;
+  defaultDomain: string;
 }
 
 export type OperationStatus =

--- a/src/ui/pages/app-create-endpoint.tsx
+++ b/src/ui/pages/app-create-endpoint.tsx
@@ -2,12 +2,16 @@ import {
   CreateEndpointProps,
   EndpointManagedType,
   fetchApp,
+  fetchEnvironmentById,
   fetchImageById,
+  fetchStack,
   getContainerPort,
   parseIpStr,
   provisionEndpoint,
   selectAppById,
+  selectEnvironmentById,
   selectImageById,
+  selectStackById,
 } from "@app/deploy";
 import {
   useDispatch,
@@ -69,10 +73,16 @@ export const AppCreateEndpointPage = () => {
   const { id = "" } = useParams();
   useQuery(fetchApp({ id }));
   const app = useSelector((s) => selectAppById(s, { id }));
+  useQuery(fetchImageById({ id: app.currentImageId }));
   const image = useSelector((s) =>
     selectImageById(s, { id: app.currentImageId }),
   );
-  useQuery(fetchImageById({ id: app.currentImageId }));
+  useQuery(fetchEnvironmentById({ id: app.environmentId }));
+  const env = useSelector((s) =>
+    selectEnvironmentById(s, { id: app.environmentId }),
+  );
+  useQuery(fetchStack({ id: env.stackId }));
+  const stack = useSelector((s) => selectStackById(s, { id: env.stackId }));
 
   const [serviceId, setServiceId] = useState("");
   const [port, setPort] = useState("");
@@ -148,7 +158,7 @@ export const AppCreateEndpointPage = () => {
 
   const options: SelectOption[] = [
     {
-      label: `Use app-${app.id}.on-aptible.com default endpoint`,
+      label: `Use app-${app.id}.${stack.defaultDomain} default endpoint`,
       value: "default",
     },
     { label: "Use a custom domain with Managed HTTPS", value: "managed" },


### PR DESCRIPTION
Instead of hardcoding `on-aptible.com`.
