### PR TITLE
Check for existing invitation during signup

### DIFF
--- a/src/auth/loader.ts
+++ b/src/auth/loader.ts
@@ -12,7 +12,8 @@ export const isAuthenticationError = (error: AuthErrorType) => {
     error === "invalid_email" ||
     error === "unsupported_grant_type" ||
     error === "access_denied" ||
-    error === "invalid_scope"
+    error === "invalid_scope" ||
+    error === "use_invitation"
   );
 };
 

--- a/src/auth/signup.ts
+++ b/src/auth/signup.ts
@@ -15,7 +15,13 @@ const log = createLog("signup");
 export const signup = thunks.create<CreateUserForm>(
   "signup",
   function* onSignup(ctx, next) {
-    const { company: orgName, name, email, password, challenge_token } = ctx.payload;
+    const {
+      company: orgName,
+      name,
+      email,
+      password,
+      challenge_token
+    } = ctx.payload;
     const id = ctx.key;
     yield* schema.update(schema.loaders.start({ id }));
 

--- a/src/auth/signup.ts
+++ b/src/auth/signup.ts
@@ -20,13 +20,13 @@ export const signup = thunks.create<CreateUserForm>(
       name,
       email,
       password,
-      challenge_token,
+      challengeToken,
     } = ctx.payload;
     const id = ctx.key;
     yield* schema.update(schema.loaders.start({ id }));
 
     let claimCtx;
-    if (challenge_token === "") {
+    if (challengeToken === "") {
       claimCtx = yield* call(checkClaim.run(ctx.payload));
     }
 

--- a/src/auth/signup.ts
+++ b/src/auth/signup.ts
@@ -20,7 +20,7 @@ export const signup = thunks.create<CreateUserForm>(
     yield* schema.update(schema.loaders.start({ id }));
 
     let userCtx;
-    if (challenge_token == "") {
+    if (challenge_token === "") {
       userCtx = yield* call(createUserViaClaim.run(ctx.payload));
     } else {
       userCtx = yield* call(createUser.run(ctx.payload));

--- a/src/auth/signup.ts
+++ b/src/auth/signup.ts
@@ -20,7 +20,7 @@ export const signup = thunks.create<CreateUserForm>(
       name,
       email,
       password,
-      challenge_token
+      challenge_token,
     } = ctx.payload;
     const id = ctx.key;
     yield* schema.update(schema.loaders.start({ id }));

--- a/src/auth/signup.ts
+++ b/src/auth/signup.ts
@@ -5,7 +5,7 @@ import { call } from "@app/fx";
 import { submitHubspotForm } from "@app/hubspot";
 import { schema } from "@app/schema";
 import { tunaEvent } from "@app/tuna";
-import { CreateUserForm, createUser, checkClaim } from "@app/users";
+import { CreateUserForm, checkClaim, createUser } from "@app/users";
 import { AUTH_LOADER_ID, defaultAuthLoaderMeta } from "./loader";
 import { createOrganization } from "./organization";
 import { createToken, elevateToken } from "./token";
@@ -30,7 +30,7 @@ export const signup = thunks.create<CreateUserForm>(
       claimCtx = yield* call(checkClaim.run(ctx.payload));
     }
 
-    log(claimCtx)
+    log(claimCtx);
 
     if (claimCtx && !claimCtx.json.ok) {
       const { message, ...meta } = claimCtx.json.error;
@@ -43,7 +43,7 @@ export const signup = thunks.create<CreateUserForm>(
       );
       return;
     }
-    
+
     const userCtx = yield* call(createUser.run(ctx.payload));
 
     log(userCtx);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -72,15 +72,7 @@ const authHandlers = [
     return res(ctx.json(testUser));
   }),
   rest.post(`${testEnv.authUrl}/claims/user`, (_, res, ctx) => {
-    return res(
-      ctx.status(400),
-      ctx.json({
-        code: 400,
-        exception_context: {},
-        error: "use_invitation",
-        message: "mock error message",
-      }),
-    );
+    return res(ctx.json({}));
   }),
   rest.post(`${testEnv.authUrl}/users`, (_, res, ctx) => {
     return res(ctx.json(testUser));

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -79,7 +79,7 @@ const authHandlers = [
         exception_context: {},
         error: "use_invitation",
         message: "mock error message",
-      })
+      }),
     );
   }),
   rest.post(`${testEnv.authUrl}/users`, (_, res, ctx) => {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -71,6 +71,9 @@ const authHandlers = [
   rest.put(`${testEnv.authUrl}/users/:userId`, (_, res, ctx) => {
     return res(ctx.json(testUser));
   }),
+  rest.post(`${testEnv.authUrl}/claim/user`, (_, res, ctx) => {
+    return res(ctx.json(testUser));
+  }),
   rest.post(`${testEnv.authUrl}/users`, (_, res, ctx) => {
     return res(ctx.json(testUser));
   }),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -71,8 +71,16 @@ const authHandlers = [
   rest.put(`${testEnv.authUrl}/users/:userId`, (_, res, ctx) => {
     return res(ctx.json(testUser));
   }),
-  rest.post(`${testEnv.authUrl}/claim/user`, (_, res, ctx) => {
-    return res(ctx.json(testUser));
+  rest.post(`${testEnv.authUrl}/claims/user`, (_, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({
+        code: 400,
+        exception_context: {},
+        error: "use_invitation",
+        message: "mock error message",
+      })
+    );
   }),
   rest.post(`${testEnv.authUrl}/users`, (_, res, ctx) => {
     return res(ctx.json(testUser));

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -9,6 +9,7 @@ export type AuthErrorType =
   | "unsupported_grant_type"
   | "access_denied"
   | "invalid_scope"
+  | "use_invitation"
   | "";
 
 export interface AuthLoaderMeta {

--- a/src/ui/pages/signup.test.tsx
+++ b/src/ui/pages/signup.test.tsx
@@ -199,7 +199,7 @@ describe("Signup page", () => {
       rest.get(`${testEnv.authUrl}/current_token`, (_, res, ctx) => {
         return res(ctx.status(400));
       }),
-      rest.post(`${testEnv.authUrl}/claim/users`, (_, res, ctx) => {
+      rest.post(`${testEnv.authUrl}/claims/user`, (_, res, ctx) => {
         return res(
           ctx.status(400),
           ctx.json({

--- a/src/ui/pages/signup.test.tsx
+++ b/src/ui/pages/signup.test.tsx
@@ -211,13 +211,13 @@ describe("Signup page", () => {
         );
       }),
     );
-  
+
     const { App } = setupAppIntegrationTest({
       initEntries: [signupUrl()],
     });
-  
+
     render(<App />);
-  
+
     const name = await screen.findByRole("textbox", { name: "name" });
     await act(() => userEvent.type(name, "mock name"));
     const company = await screen.findByRole("textbox", { name: "company" });
@@ -226,10 +226,10 @@ describe("Signup page", () => {
     await act(async () => userEvent.type(email, testEmail));
     const pass = await screen.findByLabelText("password");
     await act(() => userEvent.type(pass, "Aptible!1234"));
-  
+
     const btn = await screen.findByRole("button", { name: /Create Account/ });
     fireEvent.click(btn);
-  
+
     expect(await screen.findByText("mock error message")).toBeInTheDocument();
   });
 

--- a/src/ui/pages/signup.test.tsx
+++ b/src/ui/pages/signup.test.tsx
@@ -197,15 +197,15 @@ describe("Signup page", () => {
   it("errors properly when claim fails (check claim)", async () => {
     server.use(
       rest.get(`${testEnv.authUrl}/current_token`, (_, res, ctx) => {
-        return res(ctx.status(401));
+        return res(ctx.status(400));
       }),
       rest.post(`${testEnv.authUrl}/claim/users`, (_, res, ctx) => {
         return res(
-          ctx.status(401),
+          ctx.status(400),
           ctx.json({
-            code: 401,
+            code: 400,
             exception_context: {},
-            error: "invalid_credentials",
+            error: "use_invitation",
             message: "mock error message",
           }),
         );

--- a/src/ui/pages/signup.test.tsx
+++ b/src/ui/pages/signup.test.tsx
@@ -194,6 +194,45 @@ describe("Signup page", () => {
     expect(await screen.findByText("Check your Email")).toBeInTheDocument();
   });
 
+  it("errors properly when claim fails (check claim)", async () => {
+    server.use(
+      rest.get(`${testEnv.authUrl}/current_token`, (_, res, ctx) => {
+        return res(ctx.status(401));
+      }),
+      rest.post(`${testEnv.authUrl}/claim/users`, (_, res, ctx) => {
+        return res(
+          ctx.status(401),
+          ctx.json({
+            code: 401,
+            exception_context: {},
+            error: "invalid_credentials",
+            message: "mock error message",
+          }),
+        );
+      }),
+    );
+  
+    const { App } = setupAppIntegrationTest({
+      initEntries: [signupUrl()],
+    });
+  
+    render(<App />);
+  
+    const name = await screen.findByRole("textbox", { name: "name" });
+    await act(() => userEvent.type(name, "mock name"));
+    const company = await screen.findByRole("textbox", { name: "company" });
+    await act(() => userEvent.type(company, "mock company"));
+    const email = await screen.findByRole("textbox", { name: "email" });
+    await act(async () => userEvent.type(email, testEmail));
+    const pass = await screen.findByLabelText("password");
+    await act(() => userEvent.type(pass, "Aptible!1234"));
+  
+    const btn = await screen.findByRole("button", { name: /Create Account/ });
+    fireEvent.click(btn);
+  
+    expect(await screen.findByText("mock error message")).toBeInTheDocument();
+  });
+
   it("errors properly when signup fails (create user)", async () => {
     server.use(
       rest.get(`${testEnv.authUrl}/current_token`, (_, res, ctx) => {

--- a/src/ui/pages/signup.tsx
+++ b/src/ui/pages/signup.tsx
@@ -42,7 +42,7 @@ const validators = {
   name: (props: CreateUserForm) =>
     existValidtor(props.name, "Name") || nameValidator(props.name),
   company: (props: CreateUserForm) => {
-    if (props.challenge_token !== "") {
+    if (props.challengeToken !== "") {
       return;
     }
     return (
@@ -167,7 +167,7 @@ export const SignupPage = () => {
     name,
     email,
     password,
-    challenge_token: code,
+    challengeToken: code,
   };
   const action = signup(data);
   const loader = useLoader(action);

--- a/src/users/effects.ts
+++ b/src/users/effects.ts
@@ -64,9 +64,9 @@ export const createUser = authApi.post<CreateUserForm, UserResponse>(
   },
 );
 
-export const createUserViaClaim = authApi.post<CreateUserForm, UserResponse>(
-  "/claims/:user",
-  function* onCreateUserViaClaim(ctx, next) {
+export const checkClaim = authApi.post<CreateUserForm, UserResponse>(
+  "/claims/user",
+  function* onCheckClaim(ctx, next) {
     const origin = yield* select(selectOrigin);
     ctx.request = ctx.req({
       body: JSON.stringify({ ...ctx.payload, origin }),

--- a/src/users/effects.ts
+++ b/src/users/effects.ts
@@ -64,6 +64,18 @@ export const createUser = authApi.post<CreateUserForm, UserResponse>(
   },
 );
 
+export const createUserViaClaim = authApi.post<CreateUserForm, UserResponse>(
+  "/claims/:user",
+  function* onCreateUserViaClaim(ctx, next) {
+    const origin = yield* select(selectOrigin);
+    ctx.request = ctx.req({
+      body: JSON.stringify({ ...ctx.payload, origin }),
+    });
+
+    yield* next();
+  },
+);
+
 export const updateUserName = authApi.patch<{ userId: string; name: string }>(
   ["/users/:userId", "name"],
   function* (ctx, next) {

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -32,5 +32,5 @@ export interface CreateUserForm {
   name: string;
   email: string;
   password: string;
-  challenge_token: string;
+  challengeToken: string;
 }


### PR DESCRIPTION
Prevent a new user from signing up and accidentally creating a duplicate org when they have an existing invitation. Instead, show an error message that points them to check their email for an invite. 