### PR TITLE
feat: deployments tab for sources

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -115,6 +115,7 @@ import {
   SettingsPage,
   SignupPage,
   SourceDetailAppsPage,
+  SourceDetailDeploymentsPage,
   SourceDetailLayout,
   SourceDetailPage,
   SourcesPage,
@@ -289,6 +290,10 @@ export const appRoutes: RouteObject[] = [
               {
                 path: routes.SOURCE_DETAIL_APPS_PATH,
                 element: <SourceDetailAppsPage />,
+              },
+              {
+                path: routes.SOURCE_DETAIL_DEPLOYMENTS_PATH,
+                element: <SourceDetailDeploymentsPage />,
               },
             ],
           },

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -22,6 +22,7 @@ export interface DeploymentResponse {
     operation: LinkResponse;
     configuration: LinkResponse;
     image: LinkResponse;
+    source: LinkResponse;
   };
   _type: "deployment";
 }
@@ -48,6 +49,7 @@ export const defaultDeploymentResponse = (
       operation: defaultHalHref(),
       configuration: defaultHalHref(),
       image: defaultHalHref(),
+      source: defaultHalHref(),
       ...p._links,
     },
     ...p,
@@ -77,6 +79,7 @@ export const deserializeDeployment = (
     operationId: extractIdFromLink(links.operation),
     imageId: extractIdFromLink(links.image),
     configurationId: extractIdFromLink(links.configuration),
+    sourceId: extractIdFromLink(links.source),
   };
 };
 

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -98,6 +98,13 @@ export const selectDeploymentsByAppId = createSelector(
     return deployments.filter((d) => d.appId === appId);
   },
 );
+export const selectDeploymentsBySourceId = createSelector(
+  selectDeploymentsAsList,
+  (_: WebState, p: { sourceId: string }) => p.sourceId,
+  (deployments, sourceId): Deployment[] => {
+    return deployments.filter((d) => d.sourceId === sourceId);
+  },
+);
 
 export function getRegistryParts(url: string): { name: string; tag: string } {
   const [name, tag] = url.split(":");

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -689,6 +689,7 @@ export const testDeploymentGit = defaultDeploymentResponse({
     ),
     configuration: defaultHalHref(),
     image: defaultHalHref(),
+    source: defaultHalHref(),
   },
 });
 
@@ -711,6 +712,7 @@ export const testDeploymentDocker = defaultDeploymentResponse({
     ),
     configuration: defaultHalHref(),
     image: defaultHalHref(),
+    source: defaultHalHref(),
   },
 });
 
@@ -731,5 +733,6 @@ export const testDeploymentEmpty = defaultDeploymentResponse({
     ),
     configuration: defaultHalHref(),
     image: defaultHalHref(),
+    source: defaultHalHref(),
   },
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -397,3 +397,6 @@ export const SOURCE_DETAIL_PATH = "/sources/:id";
 export const sourceDetailUrl = (id: string) => `/sources/${id}`;
 export const SOURCE_DETAIL_APPS_PATH = "/sources/:id/apps";
 export const sourceDetailAppsUrl = (id: string) => `/sources/${id}/apps`;
+export const SOURCE_DETAIL_DEPLOYMENTS_PATH = "/sources/:id/deployments";
+export const sourceDetailDeploymentsUrl = (id: string) =>
+  `/sources/${id}/deployments`;

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -822,6 +822,7 @@ export const defaultDeployment = (a: Partial<Deployment> = {}): Deployment => {
     operationId: "",
     imageId: "",
     configurationId: "",
+    sourceId: "",
     ...a,
   };
 };

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -46,6 +46,9 @@ export const selectSourcesAsList = schema.sources.selectTableAsList;
 
 export const fetchSources = api.get("/sources");
 export const fetchSourceById = api.get<{ id: string }>("/sources/:id");
+export const fetchDeploymentsBySourceId = api.get<{ id: string }>(
+  "/sources/:id/deployments",
+);
 
 export const entities = {
   source: defaultEntity({

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -82,4 +82,5 @@ export interface Deployment {
   appId: string;
   configurationId: string;
   imageId: string;
+  sourceId: string;
 }

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -3,14 +3,16 @@ import {
   cancelAppOpsPoll,
   fetchApp,
   fetchConfiguration,
+  fetchImageById,
   fetchServicesByAppId,
   pollAppOperations,
   selectAppById,
   selectEnvironmentById,
+  selectImageById,
   selectLatestDeployOp,
   selectUserHasPerms,
 } from "@app/deploy";
-import { fetchDeploymentById, getDockerImageName } from "@app/deployment";
+import { fetchDeploymentById, selectDeploymentById } from "@app/deployment";
 import { findLoaderComposite } from "@app/loaders";
 import { selectHasBetaFeatures } from "@app/organizations";
 import { useDispatch, useQuery, useSelector } from "@app/react";
@@ -25,23 +27,24 @@ import {
   appServicesUrl,
   appSettingsUrl,
   environmentAppsUrl,
+  sourceDetailUrl,
 } from "@app/routes";
-import { schema } from "@app/schema";
 import { setResourceStats } from "@app/search";
+import { fetchSourceById, selectSourceById } from "@app/source";
 import type { DeployApp } from "@app/types";
 import { useEffect, useMemo } from "react";
-import { Outlet, useParams } from "react-router-dom";
+import { Link, Outlet, useParams } from "react-router-dom";
 import { usePoller } from "../hooks";
 import {
   ActiveOperationNotice,
-  DeploymentGitSha,
-  DeploymentTagText,
   DetailHeader,
   DetailInfoGrid,
   DetailInfoItem,
   DetailPageHeaderView,
   DetailTitleBar,
-  GitMetadata,
+  DockerImage,
+  GitCommitMessage,
+  GitRef,
   SourceName,
   TabItem,
 } from "../shared";
@@ -54,11 +57,23 @@ export function AppHeader({
   const lastDeployOp = useSelector((s) =>
     selectLatestDeployOp(s, { appId: app.id }),
   );
+
+  const hasBetaFeatures = useSelector(selectHasBetaFeatures);
+
   useQuery(fetchDeploymentById({ id: app.currentDeploymentId }));
   const deployment = useSelector((s) =>
-    schema.deployments.selectById(s, { id: app.currentDeploymentId }),
+    selectDeploymentById(s, { id: app.currentDeploymentId }),
   );
-  const dockerImage = getDockerImageName(deployment);
+
+  useQuery(fetchImageById({ id: app.currentImageId }));
+  const image = useSelector((s) =>
+    selectImageById(s, { id: app.currentImageId }),
+  );
+
+  useQuery(fetchSourceById({ id: app.currentSourceId }));
+  const source = useSelector((s) =>
+    selectSourceById(s, { id: app.currentSourceId }),
+  );
 
   return (
     <DetailHeader>
@@ -78,25 +93,34 @@ export function AppHeader({
       <DetailInfoGrid>
         <DetailInfoItem title="ID">{app.id}</DetailInfoItem>
         <DetailInfoItem title="Git Ref">
-          <DeploymentGitSha deployment={deployment} />
+          <GitRef
+            gitRef={deployment.gitRef}
+            commitSha={deployment.gitCommitSha}
+            commitUrl={deployment.gitCommitUrl}
+          />
         </DetailInfoItem>
 
         <DetailInfoItem title="Source">
-          <SourceName app={app} deployment={deployment} />
+          {hasBetaFeatures && source.id ? (
+            <Link to={sourceDetailUrl(source.id)}>{source.displayName}</Link>
+          ) : (
+            <SourceName app={app} deployment={deployment} />
+          )}
         </DetailInfoItem>
-        {deployment.gitCommitMessage ? (
-          <DetailInfoItem title="Commit Message">
-            <GitMetadata deployment={deployment} />
-          </DetailInfoItem>
-        ) : null}
-        <DetailInfoItem title="Tag">
-          <DeploymentTagText deployment={deployment} />
+        <DetailInfoItem title="Commit Message">
+          <GitCommitMessage message={deployment.gitCommitMessage} />
         </DetailInfoItem>
 
         <DetailInfoItem title="Created">
           {prettyDateTime(app.createdAt)}
         </DetailInfoItem>
-        <DetailInfoItem title="Docker Image">{dockerImage}</DetailInfoItem>
+        <DetailInfoItem title="Docker Image">
+          <DockerImage
+            image={deployment.dockerImage}
+            digest={image.dockerRef}
+            repoUrl={deployment.dockerRepositoryUrl}
+          />
+        </DetailInfoItem>
         <DetailInfoItem title="Last Deployed">
           {lastDeployOp
             ? `${prettyDateTime(lastDeployOp.createdAt)}`

--- a/src/ui/layouts/source-detail-layout.tsx
+++ b/src/ui/layouts/source-detail-layout.tsx
@@ -1,6 +1,10 @@
 import { prettyDateTime } from "@app/date";
 import { useQuery, useSelector } from "@app/react";
-import { sourceDetailAppsUrl, sourcesUrl } from "@app/routes";
+import {
+  sourceDetailAppsUrl,
+  sourceDetailDeploymentsUrl,
+  sourcesUrl,
+} from "@app/routes";
 import { fetchSourceById, selectSourceById } from "@app/source";
 import { DeploySource } from "@app/types";
 import { Outlet, useParams } from "react-router";
@@ -57,7 +61,10 @@ function SourcePageHeader() {
 
   const crumbs = [{ name: "Sources", to: sourcesUrl() }];
 
-  const tabs: TabItem[] = [{ name: "Apps", href: sourceDetailAppsUrl(id) }];
+  const tabs: TabItem[] = [
+    { name: "Apps", href: sourceDetailAppsUrl(id) },
+    { name: "Deployments", href: sourceDetailDeploymentsUrl(id) },
+  ];
 
   return (
     <DetailPageHeaderView

--- a/src/ui/pages/__snapshots__/app-detail-deployments.test.tsx.snap
+++ b/src/ui/pages/__snapshots__/app-detail-deployments.test.tsx.snap
@@ -65,19 +65,19 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  Tag
+                  Git Ref
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  Commit
+                  Commit Message
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  Message
+                  Docker Image
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
@@ -124,21 +124,33 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  Aptible Git Deployment
+                  <em>
+                    Not Provided
+                  </em>
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
-                />
-                <td
-                  class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
-                  colspan="1"
-                />
+                >
+                  <em>
+                    Not Provided
+                  </em>
+                </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  <span />
+                  <em>
+                    Not Provided
+                  </em>
+                </td>
+                <td
+                  class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
+                  colspan="1"
+                >
+                  <em>
+                    Unknown
+                  </em>
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
@@ -186,49 +198,86 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  <a
-                    class=" "
-                    href="https://github.com/aptible/app-ui"
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    github.com/aptible/app-ui
-                  </a>
+                  <em>
+                    Not Provided
+                  </em>
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  <code
-                    class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
+                  <div
+                    class="inline-block"
                   >
-                    v3
-                  </code>
-                </td>
-                <td
-                  class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
-                  colspan="1"
-                >
-                  <code
-                    class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
-                  >
-                    <a
-                      class=" "
-                      href="https://github.com/aptible/app-ui/commit/a947a95a92e7a7a4db7fe01c28346281c128b859"
-                      rel="noreferrer"
-                      target="_blank"
+                    <code
+                      class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
                     >
-                      a947a95
-                    </a>
-                  </code>
+                      v3
+                    </code>
+                     
+                    @
+                     
+                    <code
+                      class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
+                    >
+                      <a
+                        class=" "
+                        href="https://github.com/aptible/app-ui/commit/a947a95a92e7a7a4db7fe01c28346281c128b859"
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        a947a95
+                      </a>
+                    </code>
+                  </div>
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  <span>
-                    fix(backup): pass page to fetch request (#754)
-                  </span>
+                  <div
+                    class="inline-block"
+                  >
+                    <div
+                      class="tooltip relative "
+                    >
+                      <div
+                        class="cursor-pointer"
+                      >
+                        <p
+                          class="leading-8 text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block"
+                        >
+                          fix(backup): pass page to fetch request (#754)
+                        </p>
+                      </div>
+                      <div
+                        class="tooltip-top z-50 left-0 top-0 shadow absolute rounded-md px-3 py-2 bg-black text-white w-[60vw] md:w-max"
+                      >
+                        fix(backup): pass page to fetch request (#754)
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
+                  colspan="1"
+                >
+                  <div
+                    class="inline-block"
+                  >
+                    <code
+                      class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
+                    >
+                      <a
+                        class=" "
+                        href="https://quay.io/repositories/aptible/cloud-ui"
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        quay.io/aptible/cloud-ui:v200
+                      </a>
+                    </code>
+                  </div>
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
@@ -276,49 +325,73 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  <a
-                    class=" "
-                    href="https://github.com/aptible/app-ui"
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    github.com/aptible/app-ui
-                  </a>
+                  <em>
+                    Not Provided
+                  </em>
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  <code
-                    class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
+                  <div
+                    class="inline-block"
                   >
-                    v3
-                  </code>
-                </td>
-                <td
-                  class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
-                  colspan="1"
-                >
-                  <code
-                    class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
-                  >
-                    <a
-                      class=" "
-                      href="https://github.com/aptible/app-ui/commit/a947a95a92e7a7a4db7fe01c28346281c128b859"
-                      rel="noreferrer"
-                      target="_blank"
+                    <code
+                      class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
                     >
-                      a947a95
-                    </a>
-                  </code>
+                      v3
+                    </code>
+                     
+                    @
+                     
+                    <code
+                      class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
+                    >
+                      <a
+                        class=" "
+                        href="https://github.com/aptible/app-ui/commit/a947a95a92e7a7a4db7fe01c28346281c128b859"
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        a947a95
+                      </a>
+                    </code>
+                  </div>
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
                   colspan="1"
                 >
-                  <span>
-                    fix(backup): pass page to fetch request (#754)
-                  </span>
+                  <div
+                    class="inline-block"
+                  >
+                    <div
+                      class="tooltip relative "
+                    >
+                      <div
+                        class="cursor-pointer"
+                      >
+                        <p
+                          class="leading-8 text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block"
+                        >
+                          fix(backup): pass page to fetch request (#754)
+                        </p>
+                      </div>
+                      <div
+                        class="tooltip-top z-50 left-0 top-0 shadow absolute rounded-md px-3 py-2 bg-black text-white w-[60vw] md:w-max"
+                      >
+                        fix(backup): pass page to fetch request (#754)
+                      </div>
+                    </div>
+                  </div>
+                </td>
+                <td
+                  class="text-sm text-gray-500 pl-4 py-3 break-words text-left"
+                  colspan="1"
+                >
+                  <em>
+                    Unknown
+                  </em>
                 </td>
                 <td
                   class="text-sm text-gray-500 pl-4 py-3 break-words text-left"

--- a/src/ui/pages/source-detail.tsx
+++ b/src/ui/pages/source-detail.tsx
@@ -1,6 +1,6 @@
 import { sourceDetailAppsUrl } from "@app/routes";
 import { Navigate, useParams } from "react-router";
-import { AppListBySource } from "../shared";
+import { AppListBySource, DeploymentsTableBySource } from "../shared";
 
 export function SourceDetailPage() {
   const { id = "" } = useParams();
@@ -10,4 +10,9 @@ export function SourceDetailPage() {
 export function SourceDetailAppsPage() {
   const { id = "" } = useParams();
   return <AppListBySource sourceId={id} />;
+}
+
+export function SourceDetailDeploymentsPage() {
+  const { id = "" } = useParams();
+  return <DeploymentsTableBySource sourceId={id} />;
 }

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -19,6 +19,7 @@ import { fetchDeploymentById, selectDeploymentById } from "@app/deployment";
 import { useQuery, useSelector } from "@app/react";
 import {
   appDetailUrl,
+  deploymentDetailUrl,
   environmentCreateAppUrl,
   operationDetailUrl,
 } from "@app/routes";
@@ -27,7 +28,7 @@ import type { DeployApp } from "@app/types";
 import { usePaginate } from "@app/ui/hooks";
 import { useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { ButtonCreate } from "../button";
+import { ButtonCreate, ButtonLink } from "../button";
 import { DockerImage } from "../docker";
 import { GitCommitMessage, GitRef } from "../git";
 import { Group } from "../group";
@@ -438,6 +439,16 @@ const AppListBySourceRow = ({ app }: { app: DeployApp }) => {
         />
       </Td>
       <Td>{prettyDateTime(deployment.createdAt)}</Td>
+      <Td variant="right">
+        <ButtonLink
+          to={deploymentDetailUrl(deployment.id)}
+          size="sm"
+          className="w-15"
+          variant="primary"
+        >
+          View
+        </ButtonLink>
+      </Td>
     </Tr>
   );
 };
@@ -487,6 +498,7 @@ export const AppListBySource = ({
           <Th>Commit Message</Th>
           <Th>Docker Image</Th>
           <Th>Last Deployed</Th>
+          <Th variant="right">Actions</Th>
         </THead>
 
         <TBody>

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -28,8 +28,8 @@ import { usePaginate } from "@app/ui/hooks";
 import { useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { ButtonCreate } from "../button";
-import { Code } from "../code";
-import { OptionalExternalLink } from "../external-link";
+import { DockerImage } from "../docker";
+import { GitCommitMessage, GitRef } from "../git";
 import { Group } from "../group";
 import { IconChevronDown, IconPlusCircle } from "../icons";
 import { InputSearch } from "../input";
@@ -45,7 +45,6 @@ import {
 import { EnvStackCell } from "../resource-table";
 import { EmptyTr, TBody, THead, Table, Td, Th, Tr } from "../table";
 import { tokens } from "../tokens";
-import { Tooltip } from "../tooltip";
 
 interface AppCellProps {
   app: DeployApp;
@@ -406,69 +405,6 @@ export const AppListByCertificate = ({
   );
 };
 
-const GitRefCell = ({
-  gitRef,
-  commitSha,
-  commitUrl,
-}: { gitRef: string | null; commitSha: string; commitUrl?: string }) => {
-  const ref = gitRef?.trim() || "";
-  const sha = commitSha.trim().slice(0, 7);
-  const url = commitUrl || "";
-
-  return (
-    <Td>
-      <Code>{ref || sha}</Code>
-      {ref && sha && ref !== sha ? (
-        <>
-          {" "}
-          @{" "}
-          <Code>
-            <OptionalExternalLink
-              href={url}
-              linkIf={!!url.match(/^https?:\/\//)}
-            >
-              {sha}
-            </OptionalExternalLink>
-          </Code>
-        </>
-      ) : null}
-    </Td>
-  );
-};
-const GitCommitMessageCell = ({ message }: { message: string }) => {
-  const firstLine = message.trim().split("\n")[0];
-  return (
-    <Td>
-      <Tooltip text={message} fluid>
-        <p className="leading-8 text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block">
-          {firstLine}
-          {message.length > firstLine.length ? " ..." : ""}
-        </p>
-      </Tooltip>
-    </Td>
-  );
-};
-
-const DockerImageCell = ({
-  image,
-  digest,
-  repoUrl,
-}: { image: string; digest: string; repoUrl?: string }) => {
-  const shortDigest = digest.replace("sha256:", "").slice(0, 11);
-  const url = repoUrl || "";
-
-  return (
-    <Td>
-      <Code>
-        <OptionalExternalLink href={url} linkIf={!!url.match(/^https?:\/\//)}>
-          {image}
-        </OptionalExternalLink>
-      </Code>{" "}
-      @ <Code>sha256:{shortDigest}</Code>
-    </Td>
-  );
-};
-
 const AppListBySourceRow = ({ app }: { app: DeployApp }) => {
   useQuery(fetchDeploymentById({ id: app.currentDeploymentId }));
   const deployment = useSelector((s) =>
@@ -484,17 +420,23 @@ const AppListBySourceRow = ({ app }: { app: DeployApp }) => {
     <Tr>
       <AppPrimaryCell app={app} />
       <AppIdCell app={app} />
-      <GitRefCell
-        gitRef={deployment.gitRef}
-        commitSha={deployment.gitCommitSha}
-        commitUrl={deployment.gitCommitUrl}
-      />
-      <GitCommitMessageCell message={deployment.gitCommitMessage} />
-      <DockerImageCell
-        image={deployment.dockerImage || currentImage.dockerRepo}
-        digest={currentImage.dockerRef}
-        repoUrl={deployment.dockerRepositoryUrl}
-      />
+      <Td>
+        <GitRef
+          gitRef={deployment.gitRef}
+          commitSha={deployment.gitCommitSha}
+          commitUrl={deployment.gitCommitUrl}
+        />
+      </Td>
+      <Td>
+        <GitCommitMessage message={deployment.gitCommitMessage} />
+      </Td>
+      <Td>
+        <DockerImage
+          image={deployment.dockerImage || currentImage.dockerRepo}
+          digest={currentImage.dockerRef}
+          repoUrl={deployment.dockerRepositoryUrl}
+        />
+      </Td>
       <Td>{prettyDateTime(deployment.createdAt)}</Td>
     </Tr>
   );

--- a/src/ui/shared/deployments-table.tsx
+++ b/src/ui/shared/deployments-table.tsx
@@ -1,14 +1,24 @@
 import { prettyDateTime } from "@app/date";
-import { getRegistryParts, getRepoNameFromUrl } from "@app/deployment";
-import { deploymentDetailUrl } from "@app/routes";
+import { fetchImageById, selectAppById, selectImageById } from "@app/deploy";
+import {
+  getRegistryParts,
+  getRepoNameFromUrl,
+  selectDeploymentsBySourceId,
+} from "@app/deployment";
+import { useQuery, useSelector } from "@app/react";
+import { appDetailUrl, deploymentDetailUrl } from "@app/routes";
+import { fetchDeploymentsBySourceId } from "@app/source";
 import { prettyGitSha } from "@app/string-utils";
 import { DeployApp, Deployment } from "@app/types";
+import { usePaginate } from "@app/ui/hooks";
+import { Group } from "@app/ui/shared/group";
+import { Tooltip } from "@app/ui/shared/tooltip";
 import { Link } from "react-router-dom";
 import { ButtonLink } from "./button";
 import { Code } from "./code";
-import { ExternalLink } from "./external-link";
+import { ExternalLink, OptionalExternalLink } from "./external-link";
 import { OpStatus } from "./operation-status";
-import { EmptyTr, TBody, THead, Table, Td, Tr } from "./table";
+import { EmptyTr, TBody, THead, Table, Td, Th, Tr } from "./table";
 import { tokens } from "./tokens";
 
 export function DeploymentTagText({ deployment }: { deployment: Deployment }) {
@@ -151,5 +161,183 @@ export function DeploymentsTable({
         })}
       </TBody>
     </Table>
+  );
+}
+
+const AppCell = ({ app }: { app: DeployApp }) => {
+  return (
+    <Td className="flex-1">
+      <Link to={appDetailUrl(app.id)} className="flex">
+        <p className={`${tokens.type["table link"]} leading-8`}>{app.handle}</p>
+      </Link>
+    </Td>
+  );
+};
+
+const GitRefCell = ({
+  gitRef,
+  commitSha,
+  commitUrl,
+}: { gitRef: string | null; commitSha: string; commitUrl?: string }) => {
+  const ref = gitRef?.trim() || "";
+  const sha = commitSha.trim().slice(0, 7);
+  const url = commitUrl || "";
+
+  if (!sha) {
+    return (
+      <Td>
+        <em>Not Provided</em>
+      </Td>
+    );
+  }
+
+  return (
+    <Td>
+      <Code>{ref || sha}</Code>
+      {ref && sha && ref !== sha ? (
+        <>
+          {" "}
+          @{" "}
+          <Code>
+            <OptionalExternalLink
+              href={url}
+              linkIf={!!url.match(/^https?:\/\//)}
+            >
+              {sha}
+            </OptionalExternalLink>
+          </Code>
+        </>
+      ) : null}
+    </Td>
+  );
+};
+
+const GitCommitMessageCell = ({ message }: { message: string }) => {
+  if (!message) {
+    return (
+      <Td>
+        <em>Not Provided</em>
+      </Td>
+    );
+  }
+
+  const firstLine = message.trim().split("\n")[0];
+
+  return (
+    <Td>
+      <Tooltip text={message} fluid>
+        <p className="leading-8 text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block">
+          {firstLine}
+          {message.length > firstLine.length ? " ..." : ""}
+        </p>
+      </Tooltip>
+    </Td>
+  );
+};
+
+const DockerImageCell = ({
+  image,
+  digest,
+  repoUrl,
+}: { image: string; digest: string; repoUrl?: string }) => {
+  const shortDigest = digest.replace("sha256:", "").slice(0, 11);
+  const url = repoUrl || "";
+
+  return (
+    <Td>
+      <Code>
+        <OptionalExternalLink href={url} linkIf={!!url.match(/^https?:\/\//)}>
+          {image}
+        </OptionalExternalLink>
+      </Code>{" "}
+      @ <Code>sha256:{shortDigest}</Code>
+    </Td>
+  );
+};
+
+export function DeploymentSourceRow({
+  deployment,
+}: { deployment: Deployment }) {
+  const app = useSelector((s) => selectAppById(s, { id: deployment.appId }));
+
+  useQuery(fetchImageById({ id: app.currentImageId }));
+  const currentImage = useSelector((s) =>
+    selectImageById(s, { id: app.currentImageId }),
+  );
+
+  return (
+    <Tr>
+      <Td>
+        <Link
+          to={deploymentDetailUrl(deployment.id)}
+          className={tokens.type["table link"]}
+        >
+          {deployment.id}
+        </Link>
+      </Td>
+      <Td>
+        <OpStatus status={deployment.status} />
+      </Td>
+      <AppCell app={app} />
+      <GitRefCell
+        gitRef={deployment.gitRef}
+        commitSha={deployment.gitCommitSha}
+        commitUrl={deployment.gitCommitUrl}
+      />
+      <GitCommitMessageCell message={deployment.gitCommitMessage} />
+      <DockerImageCell
+        image={deployment.dockerImage || currentImage.dockerRepo}
+        digest={currentImage.dockerRef}
+        repoUrl={deployment.dockerRepositoryUrl}
+      />
+      <Td>{prettyDateTime(deployment.createdAt)}</Td>
+      <Td variant="right">
+        <ButtonLink
+          to={deploymentDetailUrl(deployment.id)}
+          size="sm"
+          className="w-15"
+          variant="primary"
+        >
+          View
+        </ButtonLink>
+      </Td>
+    </Tr>
+  );
+}
+
+export function DeploymentsTableBySource({ sourceId }: { sourceId: string }) {
+  useQuery(fetchDeploymentsBySourceId({ id: sourceId }));
+  const deployments = useSelector((s) =>
+    selectDeploymentsBySourceId(s, { sourceId }),
+  );
+  const paginated = usePaginate(deployments);
+
+  return (
+    <Group>
+      <Table>
+        <THead>
+          <Th>ID</Th>
+          <Th>Status</Th>
+          <Th>App</Th>
+          <Th>Git Ref</Th>
+          <Th>Commit Message</Th>
+          <Th>Docker Image</Th>
+          <Th>Date</Th>
+          <Th variant="right">Actions</Th>
+        </THead>
+
+        <TBody>
+          {paginated.data.length === 0 ? <EmptyTr colSpan={8} /> : null}
+          {paginated.data.map((deployment) => {
+            return (
+              <DeploymentSourceRow
+                key={deployment.id}
+                deployment={deployment}
+              />
+            );
+          })}
+        </TBody>
+      </Table>
+    </Group>
   );
 }

--- a/src/ui/shared/docker.tsx
+++ b/src/ui/shared/docker.tsx
@@ -13,14 +13,23 @@ export const DockerImage = ({
   const shortDigest = digest.replace("sha256:", "").slice(0, 11);
   const url = repoUrl || "";
 
+  if (!image) {
+    return <em>Unknown</em>;
+  }
+
   return (
     <div className="inline-block">
       <Code>
         <OptionalExternalLink href={url} linkIf={!!url.match(/^https?:\/\//)}>
           {image}
         </OptionalExternalLink>
-      </Code>{" "}
-      @ <Code>sha256:{shortDigest}</Code>
+      </Code>
+      {shortDigest && (
+        <>
+          {" "}
+          @ <Code>sha256:{shortDigest}</Code>
+        </>
+      )}
     </div>
   );
 };

--- a/src/ui/shared/docker.tsx
+++ b/src/ui/shared/docker.tsx
@@ -1,0 +1,26 @@
+import { Code } from "./code";
+import { OptionalExternalLink } from "./external-link";
+
+export const DockerImage = ({
+  image,
+  digest,
+  repoUrl,
+}: {
+  image: string;
+  digest: string;
+  repoUrl?: string;
+}) => {
+  const shortDigest = digest.replace("sha256:", "").slice(0, 11);
+  const url = repoUrl || "";
+
+  return (
+    <div className="inline-block">
+      <Code>
+        <OptionalExternalLink href={url} linkIf={!!url.match(/^https?:\/\//)}>
+          {image}
+        </OptionalExternalLink>
+      </Code>{" "}
+      @ <Code>sha256:{shortDigest}</Code>
+    </div>
+  );
+};

--- a/src/ui/shared/git.tsx
+++ b/src/ui/shared/git.tsx
@@ -1,0 +1,59 @@
+import { Tooltip } from "@app/ui/shared/tooltip";
+import { Code } from "./code";
+import { OptionalExternalLink } from "./external-link";
+
+export const GitRef = ({
+  gitRef,
+  commitSha,
+  commitUrl,
+}: {
+  gitRef: string | null;
+  commitSha: string;
+  commitUrl?: string;
+}) => {
+  const ref = gitRef?.trim() || "";
+  const sha = commitSha.trim().slice(0, 7);
+  const url = commitUrl || "";
+
+  if (!sha) {
+    return <em>Not Provided</em>;
+  }
+
+  return (
+    <div className="inline-block">
+      <Code>{ref || sha}</Code>
+      {ref && sha && ref !== sha ? (
+        <>
+          {" "}
+          @{" "}
+          <Code>
+            <OptionalExternalLink
+              href={url}
+              linkIf={!!url.match(/^https?:\/\//)}
+            >
+              {sha}
+            </OptionalExternalLink>
+          </Code>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+export const GitCommitMessage = ({ message }: { message: string }) => {
+  if (!message) {
+    return <em>Not Provided</em>;
+  }
+
+  const firstLine = message.trim().split("\n")[0];
+  return (
+    <div className="inline-block">
+      <Tooltip text={message} fluid>
+        <p className="leading-8 text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block">
+          {firstLine}
+          {message.length > firstLine.length ? " ..." : ""}
+        </p>
+      </Tooltip>
+    </div>
+  );
+};

--- a/src/ui/shared/index.ts
+++ b/src/ui/shared/index.ts
@@ -67,3 +67,5 @@ export * from "./env-editor";
 export * from "./app-auto-deploy-guide";
 export * from "./deployments-table";
 export * from "./source";
+export * from "./git";
+export * from "./docker";


### PR DESCRIPTION
## Overview

This PR implements a Deployments tab on the Source detail page.

Additionally, this PR refactors the git- and docker-related display elements into their own reusable components, and updates existing interfaces (e.g. the app detail page, deployments table, etc) to use them for visual consistency.

## Source Detail Page

### Changes

* Create a new "Deployments" tab to list all deployments from the source
* Update the app list table to use the new `GitRef`, `GitCommitMessage`, and `DockerImage` components
* Add a "View" button to the app list table for consistency

<img width="1674" alt="Screenshot 2024-04-02 at 12 01 52 PM" src="https://github.com/aptible/app-ui/assets/293571/5e45fd2a-68a9-4874-a088-89b2383c4d24">

<img width="1674" alt="Screenshot 2024-04-02 at 12 04 07 PM" src="https://github.com/aptible/app-ui/assets/293571/93b7e072-9b33-438f-88f1-77c5bb1d39a1">


## App Detail Page

### Changes

* Use the new `GitRef`, `GitCommitMessage`, and `DockerImage` components in the detail header and deployments table
* Always show the git commit message in the detail header (to prevent jump/jank on first load)
* Link the source name to the source detail page if the user has beta features enabled (otherwise link to the external repository)

### Screenshots

**With all metadata**

<img width="1499" alt="Screenshot 2024-04-01 at 4 22 00 PM" src="https://github.com/aptible/app-ui/assets/293571/e2cb2797-e3c4-481c-9dc5-389980523df6" />

**With partial metadata**

<img width="1674" alt="Screenshot 2024-04-02 at 12 00 11 PM" src="https://github.com/aptible/app-ui/assets/293571/a6af426a-2623-43c6-ab00-fdc4bca60f34">

**With no metadata (new/empty app)**

<img width="1674" alt="Screenshot 2024-04-02 at 12 00 29 PM" src="https://github.com/aptible/app-ui/assets/293571/6c87758f-4219-4c3c-9368-d1cd88847c49">
