### PR TITLE
security: always use app 404

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,7 +8,6 @@ http {
   server {
     listen 80;
     server_name localhost;
-    server_tokens off;
     charset utf-8;
 
     root /app;

--- a/nginx.conf
+++ b/nginx.conf
@@ -8,13 +8,14 @@ http {
   server {
     listen 80;
     server_name localhost;
+    server_tokens off;
     charset utf-8;
 
     root /app;
     index index.html;
 
     location ~* \.(?:css|js)$ {
-        try_files $uri =404;
+        try_files $uri /index.html;
         expires 1y;
         access_log off;
         add_header Cache-Control "public";
@@ -22,7 +23,7 @@ http {
 
     # Any route containing a file extension (e.g. /devicesfile.js)
     location ~ ^.+\..+$ {
-        try_files $uri =404;
+        try_files $uri /index.html;
     }
 
     # Any route that doesn't have a file extension (e.g. /devices)


### PR DESCRIPTION
## Summary
* security: route 404s to app

## Context
PCI compliance scanning also flagged that some 404 URLs returned the default nginx 404 pages. The behavior found was as follows:

https://app.aptible.com/foo returns an app-based 404, e.g.
<img width="623" alt="image" src="https://github.com/aptible/app-ui/assets/8235320/d15afdb2-5601-4bd0-bc56-6874d7f74d19">

https://app.aptible.com/foo.js returns an nginx 404, e.g.
<img width="240" alt="image" src="https://github.com/aptible/app-ui/assets/8235320/b0d581c5-42cd-4a58-9d04-137bd2c38913">

We either need a custom nginx 404 page, or allow the app to handle 404s. This PR opts for the latter.

## Testing
Available on https://app-sbx-jherman.aptible-sandbox.com/

## References
* https://app.shortcut.com/aptible/story/23324