### PR TITLE
fix: set max height for git commit messages

### DIFF
--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -108,7 +108,9 @@ export function AppHeader({
           )}
         </DetailInfoItem>
         <DetailInfoItem title="Commit Message">
-          <GitCommitMessage message={deployment.gitCommitMessage} />
+          <div className="max-h-[21px]">
+            <GitCommitMessage message={deployment.gitCommitMessage} />
+          </div>
         </DetailInfoItem>
 
         <DetailInfoItem title="Created">

--- a/src/ui/layouts/deployment-detail-layout.tsx
+++ b/src/ui/layouts/deployment-detail-layout.tsx
@@ -71,7 +71,9 @@ export function DeploymentHeader({
         </DetailInfoItem>
         {deployment.gitCommitMessage ? (
           <DetailInfoItem title="Commit Message">
-            <GitMetadata deployment={deployment} />
+            <div className="max-h-[21px]">
+              <GitMetadata deployment={deployment} />
+            </div>
           </DetailInfoItem>
         ) : null}
         <DetailInfoItem title="Tag">


### PR DESCRIPTION
**Small Spacing Tweak**
Set max height for git commit messages only inside detailbox components on the App Detail and Deployment Detail headers to save vertical space.

This works because we truncate the commit messages to only 30 characters long, and they never wrap to 2 lines.

BEFORE
![Screenshot-2024-04-02-at-4 23 18 PM](https://github.com/aptible/app-ui/assets/4295811/39d66f5e-134e-495f-947c-51f0d49f3d83)


AFTER
![Screenshot 2024-04-02 at 4 23 38 PM](https://github.com/aptible/app-ui/assets/4295811/3960bae1-d9f4-41aa-8aff-5b262131f340)
