### PR TITLE
fix: change deployment details logo

### DIFF
--- a/src/ui/layouts/deployment-detail-layout.tsx
+++ b/src/ui/layouts/deployment-detail-layout.tsx
@@ -46,7 +46,7 @@ export function DeploymentHeader({
         title="Deployment Details"
         icon={
           <img
-            src={"/resource-types/logo-activity.png"}
+            src={"/resource-types/logo-deployments.png"}
             className="w-[32px] h-[32px] mr-3"
             aria-label="Deployment"
           />


### PR DESCRIPTION
Use the Deployments image on the Deployments Detail page

![Screenshot 2024-04-04 at 10 04 47 AM](https://github.com/aptible/app-ui/assets/4295811/476b6157-45d2-4724-8781-caf41d6f46a1)
