### PR TITLE
Fix a mismatched colspan for the app list on the Source details page

### DIFF
--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -511,7 +511,7 @@ export const AppListBySource = ({
         </THead>
 
         <TBody>
-          {paginated.data.length === 0 ? <EmptyTr colSpan={5} /> : null}
+          {paginated.data.length === 0 ? <EmptyTr colSpan={7} /> : null}
           {paginated.data.map((app) => (
             <AppListBySourceRow app={app} key={app.id} />
           ))}


### PR DESCRIPTION
This PR fixes a mismatch between the "No resources found" colspan and the number of table columns.