### PR TITLE
fix: an issue where users with only `basic_read` permission would receive an access denied error message when viewing app details

### DIFF
--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -2,7 +2,6 @@ import { prettyDateTime } from "@app/date";
 import {
   cancelAppOpsPoll,
   fetchApp,
-  fetchConfiguration,
   fetchImageById,
   fetchServicesByAppId,
   pollAppOperations,
@@ -155,13 +154,10 @@ function AppPageHeader() {
   const loaderApp = useQuery(fetchApp({ id }));
   const loaderServices = useQuery(fetchServicesByAppId({ id: id }));
   const app = useSelector((s) => selectAppById(s, { id }));
-  const loaderConfig = useQuery(
-    fetchConfiguration({ id: app.currentConfigurationId }),
-  );
   const environment = useSelector((s) =>
     selectEnvironmentById(s, { id: app.environmentId }),
   );
-  const loader = findLoaderComposite([loaderApp, loaderServices, loaderConfig]);
+  const loader = findLoaderComposite([loaderApp, loaderServices]);
 
   const crumbs = [
     { name: environment.handle, to: environmentAppsUrl(environment.id) },


### PR DESCRIPTION
This PR removes a query for an app's current configuration on its detail page, which was causing "Access Denied" issues for users that only had basic read permissions.

The query is no longer needed: it was only used to retrieve the name of the app's Docker image, which is now retrieved from the current Deployment instead.