### PR TITLE
fix: a bug preventing some users from viewing deployment configuration

### DIFF
--- a/src/ui/pages/app-detail-config.tsx
+++ b/src/ui/pages/app-detail-config.tsx
@@ -103,8 +103,8 @@ const CodeScanView = ({ codeScan }: { codeScan: DeployCodeScanResponse }) => {
 
 export const AppDetailConfigPage = () => {
   const { id = "" } = useParams();
-  const app = useSelector((s) => selectAppById(s, { id }));
   useQuery(fetchApp({ id }));
+  const app = useSelector((s) => selectAppById(s, { id }));
   useQuery(fetchConfiguration({ id: app.currentConfigurationId }));
 
   return (

--- a/src/ui/pages/deployment-detail-config.tsx
+++ b/src/ui/pages/deployment-detail-config.tsx
@@ -1,5 +1,6 @@
 import {
   configEnvToStr,
+  fetchApp,
   fetchConfiguration,
   selectAppById,
   selectAppConfigById,
@@ -58,7 +59,8 @@ const ConfigView = ({
 export function DeploymentDetailConfigPage() {
   const { id = "" } = useParams();
   const deployment = useSelector((s) => selectDeploymentById(s, { id }));
-  const app = useSelector((s) => selectAppById(s, { id }));
+  useQuery(fetchApp({ id: deployment.appId }));
+  const app = useSelector((s) => selectAppById(s, { id: deployment.appId }));
 
   return (
     <Box>


### PR DESCRIPTION
This PR fixes a [reported bug](https://aptible.slack.com/archives/C05CMUW3LHX/p1712611841145119) that was attempting to fetch an app using a deployment ID (instead of the deployment's app ID), manifesting as a permission issue.