### PR TITLE
feat: sort and filter apps by their deployment metadata on the source detail page

### DIFF
--- a/src/bootup/index.ts
+++ b/src/bootup/index.ts
@@ -13,6 +13,7 @@ import {
   fetchServices,
   fetchStacks,
 } from "@app/deploy";
+import { fetchDeployments } from "@app/deployment";
 import { call, parallel, select, takeEvery } from "@app/fx";
 import { createAction } from "@app/fx";
 import { selectOrganizationSelected } from "@app/organizations";
@@ -81,6 +82,7 @@ function* onFetchResourceData() {
     fetchOrgOperations.run({ orgId: org.id }),
     fetchSystemStatus.run(),
     fetchSources.run(),
+    fetchDeployments.run(),
   ]);
   yield* group;
 }

--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -114,7 +114,11 @@ export const findAppById = schema.apps.findById;
 
 export interface DeployAppRow extends DeployApp {
   envHandle: string;
+  gitRef: string;
+  gitCommitSha: string;
+  dockerImageName: string;
   lastOperation: DeployOperation;
+  lastDeployed: string;
   cost: number;
   totalCPU: number;
   totalMemoryLimit: number;

--- a/src/deploy/search/index.ts
+++ b/src/deploy/search/index.ts
@@ -344,12 +344,16 @@ export const selectAppsForTableSearchBySourceId = createSelector(
   selectAppsForTable,
   (_: WebState, props: { search: string }) => props.search.toLocaleLowerCase(),
   (_: WebState, props: { sourceId: string }) => props.sourceId,
-  (apps, search, sourceId): DeployAppRow[] => {
+  (_: WebState, p: { sortBy: keyof DeployAppRow }) => p.sortBy,
+  (_: WebState, p: { sortDir: "asc" | "desc" }) => p.sortDir,
+  (apps, search, sourceId, sortBy, sortDir): DeployAppRow[] => {
+    const sortFn = createAppSortFn(sortBy, sortDir);
+
     if (search === "" && sourceId === "") {
-      return apps;
+      return [...apps].sort(sortFn);
     }
 
-    return apps.filter((app) => {
+    const results = apps.filter((app) => {
       const searchMatch = computeSearchMatch(app, search);
       const sourceIdMatch = sourceId !== "" && app.currentSourceId === sourceId;
 
@@ -363,6 +367,8 @@ export const selectAppsForTableSearchBySourceId = createSelector(
 
       return searchMatch;
     });
+
+    return results.sort(sortFn);
   },
 );
 

--- a/src/deploy/search/index.ts
+++ b/src/deploy/search/index.ts
@@ -156,9 +156,9 @@ export const selectAppsForTable = createSelector(
         const env = findEnvById(envs, { id: app.environmentId });
         const appOps = findOperationsByAppId(ops, app.id);
         const lastOperation = appOps?.[0] || schema.operations.empty;
-        const currentDeployment = deployments.find(
-          (d) => d.id === app.currentDeploymentId,
-        );
+        const currentDeployment =
+          deployments.find((d) => d.id === app.currentDeploymentId) ||
+          schema.deployments.empty;
         const appServices = services.filter((s) => s.appId === app.id);
         const cost = appServices.reduce((acc, service) => {
           const mm = calcServiceMetrics(service);
@@ -171,10 +171,10 @@ export const selectAppsForTable = createSelector(
           ...metrics,
           envHandle: env.handle,
           lastOperation,
-          gitRef: currentDeployment?.gitRef || "",
-          gitCommitSha: currentDeployment?.gitCommitSha || "",
-          dockerImageName: currentDeployment?.dockerImage || "",
-          lastDeployed: currentDeployment?.createdAt || "",
+          gitRef: currentDeployment.gitRef,
+          gitCommitSha: currentDeployment.gitCommitSha,
+          dockerImageName: currentDeployment.dockerImage,
+          lastDeployed: currentDeployment.createdAt,
           cost,
           totalServices: appServices.length,
         };

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -84,7 +84,7 @@ export const deserializeDeployment = (
 };
 
 export const selectDeploymentById = schema.deployments.selectById;
-const selectDeploymentsAsList = createSelector(
+export const selectDeploymentsAsList = createSelector(
   schema.deployments.selectTableAsList,
   (deployments) =>
     deployments.sort((a, b) => {

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -120,6 +120,7 @@ export function getDockerImageName(deployment: Deployment): string {
   return deployment.dockerImage || "Dockerfile Build";
 }
 
+export const fetchDeployments = api.get("/deployments");
 export const fetchDeploymentById = api.get<{ id: string }>("/deployments/:id");
 export const fetchDeploymentsByAppId = api.get<{ id: string }>(
   "/apps/:id/deployments",

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -473,13 +473,45 @@ export const AppListBySource = ({
 }) => {
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
+  const defaultSortBy =
+    (params.get("sortBy") as keyof DeployAppRow) || "handle";
+  const defaultSortDir = (params.get("asc") as "asc" | "desc") || "asc";
+  const [sortBy, setSortBy] = useState<typeof defaultSortBy>(defaultSortBy);
+  const [sortDir, setSortDir] = useState<typeof defaultSortDir>(defaultSortDir);
+
   const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    setParams({ search: ev.currentTarget.value }, { replace: true });
+    setParams(
+      (prev) => {
+        prev.set("search", ev.currentTarget.value);
+        return prev;
+      },
+      { replace: true },
+    );
   };
+  const onSort = (key: keyof DeployAppRow) => {
+    if (key === sortBy) {
+      setSortDir(sortDir === "asc" ? "desc" : "asc");
+    } else {
+      setSortBy(key);
+      setSortDir("desc");
+    }
+
+    setParams(
+      (prev) => {
+        prev.set("sortBy", sortBy);
+        prev.set("sortDir", sortDir);
+        return prev;
+      },
+      { replace: true },
+    );
+  };
+
   const apps = useSelector((s) =>
     selectAppsForTableSearchBySourceId(s, {
       sourceId,
       search,
+      sortBy,
+      sortDir,
     }),
   );
   const paginated = usePaginate(apps);
@@ -505,12 +537,32 @@ export const AppListBySource = ({
 
       <Table>
         <THead>
-          <Th>Handle</Th>
+          <Th
+            className="cursor-pointer hover:text-black group"
+            onClick={() => onSort("handle")}
+          >
+            Handle <SortIcon />
+          </Th>
           <Th>ID</Th>
-          <Th>Git Ref</Th>
+          <Th
+            className="cursor-pointer hover:text-black group"
+            onClick={() => onSort("gitRef")}
+          >
+            Git Ref <SortIcon />
+          </Th>
           <Th>Commit Message</Th>
-          <Th>Docker Image</Th>
-          <Th>Last Deployed</Th>
+          <Th
+            className="cursor-pointer hover:text-black group"
+            onClick={() => onSort("dockerImageName")}
+          >
+            Docker Image <SortIcon />
+          </Th>
+          <Th
+            className="cursor-pointer hover:text-black group"
+            onClick={() => onSort("lastDeployed")}
+          >
+            Last Deployed <SortIcon />
+          </Th>
           <Th variant="right">Actions</Th>
         </THead>
 


### PR DESCRIPTION
This PR implements support for searching and sorting apps on the Sources page based on their current git ref/commit, docker image, and deploy time.