### PR TITLE
feat: add live commits column to the source list page

### DIFF
--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -10,6 +10,7 @@ import type {
   DeployAppConfigEnv,
   DeployOperation,
   DeployServiceResponse,
+  Deployment,
   LinkResponse,
   ProvisionableStatus,
 } from "@app/types";
@@ -110,6 +111,7 @@ export const findAppById = schema.apps.findById;
 
 export interface DeployAppRow extends DeployApp {
   envHandle: string;
+  currentDeployment: Deployment;
   gitRef: string;
   gitCommitSha: string;
   dockerImageName: string;

--- a/src/deploy/search/index.ts
+++ b/src/deploy/search/index.ts
@@ -1,6 +1,7 @@
 import { selectDeploymentsAsList } from "@app/deployment";
 import { WebState, schema } from "@app/schema";
-import { DeployServiceRow } from "@app/types";
+import { selectSourcesAsList } from "@app/source";
+import { DeployServiceRow, DeploySource, Deployment } from "@app/types";
 import { createSelector } from "starfx";
 import {
   DeployAppRow,
@@ -157,8 +158,9 @@ export const selectAppsForTable = createSelector(
         const appOps = findOperationsByAppId(ops, app.id);
         const lastOperation = appOps?.[0] || schema.operations.empty;
         const currentDeployment =
-          deployments.find((d) => d.id === app.currentDeploymentId) ||
-          schema.deployments.empty;
+          deployments.find(
+            (d) => d.id.toString() === app.currentDeploymentId.toString(),
+          ) || schema.deployments.empty;
         const appServices = services.filter((s) => s.appId === app.id);
         const cost = appServices.reduce((acc, service) => {
           const mm = calcServiceMetrics(service);
@@ -171,6 +173,7 @@ export const selectAppsForTable = createSelector(
           ...metrics,
           envHandle: env.handle,
           lastOperation,
+          currentDeployment,
           gitRef: currentDeployment.gitRef,
           gitCommitSha: currentDeployment.gitCommitSha,
           dockerImageName: currentDeployment.dockerImage,
@@ -366,6 +369,102 @@ export const selectAppsForTableSearchBySourceId = createSelector(
       }
 
       return searchMatch;
+    });
+
+    return results.sort(sortFn);
+  },
+);
+
+export type GitCommit = {
+  sha: string;
+  ref: string;
+  message: string;
+  date: string | null;
+  url: string;
+};
+
+export type DeploySourceRow = DeploySource & {
+  apps: DeployAppRow[];
+  deployments: Deployment[];
+  liveCommits: GitCommit[];
+};
+
+export const selectSourcesForTable = createSelector(
+  selectSourcesAsList,
+  selectAppsForTable,
+  (sources, apps) =>
+    sources.map<DeploySourceRow>((source) => {
+      const sourceApps = apps.filter(
+        (app) => app.currentSourceId.toString() === source.id.toString(),
+      );
+      const sourceDeployments = sourceApps.map((app) => app.currentDeployment);
+      const distinctCommits = sourceDeployments.reduce<
+        Record<string, GitCommit>
+      >((commits, deployment) => {
+        const sha = deployment.gitCommitSha;
+
+        if (!sha || !!commits[sha]) {
+          return commits;
+        }
+
+        commits[sha] = {
+          sha,
+          ref: deployment.gitRef,
+          message: deployment.gitCommitMessage,
+          date: deployment.gitCommitTimestamp,
+          url: deployment.gitCommitUrl,
+        };
+
+        return commits;
+      }, {});
+      const liveCommits = Object.values(distinctCommits).sort((a, b) => {
+        if (!a.date || !b.date) {
+          return 0;
+        }
+
+        return new Date(b.date).getTime() - new Date(a.date).getTime();
+      });
+
+      return {
+        ...source,
+        apps: sourceApps,
+        deployments: sourceDeployments,
+        liveCommits,
+      };
+    }),
+);
+
+export const selectSourcesForTableSearch = createSelector(
+  selectSourcesForTable,
+  (_: WebState, props: { search: string }) => props.search.toLocaleLowerCase(),
+  (_: WebState, p: { sortBy: keyof DeploySourceRow }) => p.sortBy,
+  (_: WebState, p: { sortDir: "asc" | "desc" }) => p.sortDir,
+  (sources, search, sortBy, sortDir) => {
+    const sortFn = (a: DeploySourceRow, b: DeploySourceRow) => {
+      const left = (sortDir === "asc" ? a : b)[sortBy];
+      const right = (sortDir === "asc" ? b : a)[sortBy];
+
+      if (sortBy === "liveCommits") {
+        return left.length - right.length;
+      }
+
+      if (sortBy === "apps") {
+        return left.length - right.length;
+      }
+
+      if (sortBy === "displayName") {
+        return (<string>left).localeCompare(<string>right);
+      }
+
+      return 0;
+    };
+
+    if (search === "") {
+      return [...sources].sort(sortFn);
+    }
+
+    const results = sources.filter((source) => {
+      return source.displayName.includes(search);
     });
 
     return results.sort(sortFn);

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -14,7 +14,7 @@ export interface DeploymentResponse {
   git_commit_sha: string | null;
   git_commit_url: string | null;
   git_commit_message: string | null;
-  git_commit_date: string | null;
+  git_commit_timestamp: string | null;
   created_at: string;
   updated_at: string;
   _links: {
@@ -41,7 +41,7 @@ export const defaultDeploymentResponse = (
     git_commit_sha: "",
     git_commit_url: "",
     git_commit_message: "",
-    git_commit_date: "",
+    git_commit_timestamp: "",
     created_at: now,
     updated_at: now,
     _links: {
@@ -72,7 +72,7 @@ export const deserializeDeployment = (
     gitCommitSha: payload.git_commit_sha || "",
     gitCommitUrl: payload.git_commit_url || "",
     gitCommitMessage: payload.git_commit_message || "",
-    gitCommitDate: payload.git_commit_date,
+    gitCommitTimestamp: payload.git_commit_timestamp,
     createdAt: payload.created_at,
     updatedAt: payload.updated_at,
     appId: extractIdFromLink(links.app),
@@ -120,7 +120,7 @@ export function getDockerImageName(deployment: Deployment): string {
   return deployment.dockerImage || "Dockerfile Build";
 }
 
-export const fetchDeployments = api.get("/deployments");
+export const fetchDeployments = api.get("/deployments?per_page=5000");
 export const fetchDeploymentById = api.get<{ id: string }>("/deployments/:id");
 export const fetchDeploymentsByAppId = api.get<{ id: string }>(
   "/apps/:id/deployments",

--- a/src/deployment/index.ts
+++ b/src/deployment/index.ts
@@ -5,7 +5,7 @@ import { WebState, schema } from "@app/schema";
 import { Deployment, LinkResponse, OperationStatus } from "@app/types";
 
 export interface DeploymentResponse {
-  id: string;
+  id: number;
   status: string;
   docker_image: string | null;
   docker_repository_url: string | null;
@@ -32,7 +32,7 @@ export const defaultDeploymentResponse = (
 ): DeploymentResponse => {
   const now = new Date().toISOString();
   return {
-    id: "",
+    id: -1,
     status: "",
     docker_image: "",
     docker_repository_url: "",
@@ -84,6 +84,7 @@ export const deserializeDeployment = (
 };
 
 export const selectDeploymentById = schema.deployments.selectById;
+export const selectDeployments = schema.deployments.selectTable;
 export const selectDeploymentsAsList = createSelector(
   schema.deployments.selectTableAsList,
   (deployments) =>

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -672,7 +672,7 @@ export const testSaml = defaultSamlConfigurationResponse({
 const deployDate = new Date("2023-12-17T00:00:00Z").toISOString();
 
 export const testDeploymentGit = defaultDeploymentResponse({
-  id: "3",
+  id: 3,
   docker_image: "",
   git_repository_url: "https://github.com/aptible/app-ui",
   git_ref: "v3",
@@ -694,7 +694,7 @@ export const testDeploymentGit = defaultDeploymentResponse({
 });
 
 export const testDeploymentDocker = defaultDeploymentResponse({
-  id: "2",
+  id: 2,
   docker_image: "quay.io/aptible/cloud-ui:v200",
   docker_repository_url: "https://quay.io/repositories/aptible/cloud-ui",
   git_repository_url: "https://github.com/aptible/app-ui",
@@ -717,7 +717,7 @@ export const testDeploymentDocker = defaultDeploymentResponse({
 });
 
 export const testDeploymentEmpty = defaultDeploymentResponse({
-  id: "1",
+  id: 1,
   docker_image: "",
   git_repository_url: "",
   git_ref: "",

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -817,7 +817,7 @@ export const defaultDeployment = (a: Partial<Deployment> = {}): Deployment => {
     gitCommitSha: "",
     gitCommitUrl: "",
     gitCommitMessage: "",
-    gitCommitDate: "",
+    gitCommitTimestamp: "",
     createdAt: now,
     updatedAt: now,
     appId: "",

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -4,7 +4,7 @@ import { schema } from "@app/schema";
 import { DeploySource } from "@app/types";
 
 interface DeploySourceResponse {
-  id: string;
+  id: number;
   display_name: string;
   url: string;
   created_at: string;
@@ -17,7 +17,7 @@ export const defaultDeploySourceResponse = (
 ): DeploySourceResponse => {
   const now = new Date().toISOString();
   return {
-    id: "",
+    id: -1,
     display_name: "",
     url: "",
     created_at: now,
@@ -29,7 +29,7 @@ export const defaultDeploySourceResponse = (
 
 const deserializeDeploySource = (r: DeploySourceResponse): DeploySource => {
   return {
-    id: r.id,
+    id: `${r.id}`,
     displayName: r.display_name || "Unknown",
     url: r.url,
     createdAt: r.created_at,

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -75,7 +75,7 @@ export interface Deployment {
   gitCommitSha: string;
   gitCommitUrl: string;
   gitCommitMessage: string;
-  gitCommitDate: string | null;
+  gitCommitTimestamp: string | null;
   createdAt: string;
   updatedAt: string;
   operationId: string;

--- a/src/ui/pages/__snapshots__/app-detail-deployments.test.tsx.snap
+++ b/src/ui/pages/__snapshots__/app-detail-deployments.test.tsx.snap
@@ -207,18 +207,16 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                   colspan="1"
                 >
                   <div
-                    class="inline-block"
+                    class="inline-block whitespace-nowrap undefined"
                   >
                     <code
                       class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
                     >
                       v3
                     </code>
-                     
-                    @
-                     
+                     @ 
                     <code
-                      class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
+                      class="whitespace-nowrap bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
                     >
                       <a
                         class=" "
@@ -368,18 +366,16 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                   colspan="1"
                 >
                   <div
-                    class="inline-block"
+                    class="inline-block whitespace-nowrap undefined"
                   >
                     <code
                       class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
                     >
                       v3
                     </code>
-                     
-                    @
-                     
+                     @ 
                     <code
-                      class=" bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
+                      class="whitespace-nowrap bg-gray-200 font-mono text-black pt-0.5 pb-1 px-1.5 rounded-md text-[0.9rem]"
                     >
                       <a
                         class=" "

--- a/src/ui/pages/sources.tsx
+++ b/src/ui/pages/sources.tsx
@@ -52,31 +52,31 @@ function SourceListRow({ source }: { source: DeploySourceRow }) {
         </Link>
       </Td>
       <Td>
-        {(liveCommits.length && (
-          <div className="flex flex-row gap-1 items-center">
-            {liveCommits.map((liveCommit) => (
-              <Tooltip
-                key={liveCommit.sha}
-                fluid
-                theme="light"
-                className="py-1"
-                text={
-                  <GitRef
-                    gitRef={liveCommit.ref}
-                    commitSha={liveCommit.sha}
-                    commitUrl={liveCommit.url}
-                  />
-                }
-              >
-                <Link
-                  to="#"
-                  className="block bg-gray-300 h-[16px] w-[6px] hover:bg-indigo rounded-md"
+        {liveCommits.length === 0 ? <em>No commit information</em> : null}
+
+        <Group variant="horizontal" size="xs" className="items-center">
+          {liveCommits.map((liveCommit) => (
+            <Tooltip
+              key={liveCommit.sha}
+              fluid
+              theme="light"
+              className="py-1"
+              text={
+                <GitRef
+                  gitRef={liveCommit.ref}
+                  commitSha={liveCommit.sha}
+                  commitUrl={liveCommit.url}
                 />
-              </Tooltip>
-            ))}
-            {extraLiveCommits ? <p>+{extraLiveCommits}</p> : null}
-          </div>
-        )) || <em>No commit information</em>}
+              }
+            >
+              <Link
+                to="#"
+                className="block bg-gray-300 h-[16px] w-[6px] hover:bg-indigo rounded-md"
+              />
+            </Tooltip>
+          ))}
+          {extraLiveCommits ? <p>+{extraLiveCommits}</p> : null}
+        </Group>
       </Td>
       <Td variant="center" className="center items-center justify-center">
         <div className="text-center">{source.apps.length}</div>

--- a/src/ui/pages/sources.tsx
+++ b/src/ui/pages/sources.tsx
@@ -1,9 +1,14 @@
-import { selectAppsCountBySource } from "@app/deploy";
+import {
+  DeploySourceRow,
+  fetchApps,
+  selectSourcesForTableSearch,
+} from "@app/deploy";
+import { fetchDeployments } from "@app/deployment";
 import { useSelector } from "@app/react";
 import { sourceDetailUrl } from "@app/routes";
-import { fetchSources, selectSourcesAsList } from "@app/source";
-import { DeploySource } from "@app/types";
-import { Link } from "react-router-dom";
+import { fetchSources } from "@app/source";
+import { useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { useQuery } from "starfx/react";
 import { usePaginate } from "../hooks";
 import { AppSidebarLayout } from "../layouts";
@@ -11,7 +16,10 @@ import {
   DescBar,
   EmptyTr,
   FilterBar,
+  GitRef,
   Group,
+  IconChevronDown,
+  InputSearch,
   LoadingBar,
   PaginateBar,
   SourceLogo,
@@ -21,14 +29,14 @@ import {
   Td,
   Th,
   TitleBar,
+  Tooltip,
   Tr,
   tokens,
 } from "../shared";
 
-function SourceListRow({ source }: { source: DeploySource }) {
-  const appCount = useSelector((s) =>
-    selectAppsCountBySource(s, { sourceId: source.id }),
-  );
+function SourceListRow({ source }: { source: DeploySourceRow }) {
+  const liveCommits = source.liveCommits.slice(0, 7);
+  const extraLiveCommits = source.liveCommits.length - liveCommits.length;
 
   return (
     <Tr key={source.id}>
@@ -43,16 +51,100 @@ function SourceListRow({ source }: { source: DeploySource }) {
           </p>
         </Link>
       </Td>
+      <Td>
+        {(liveCommits.length && (
+          <div className="flex flex-row gap-1 items-center">
+            {liveCommits.map((liveCommit) => (
+              <Tooltip
+                key={liveCommit.sha}
+                fluid
+                theme="light"
+                className="py-1"
+                text={
+                  <GitRef
+                    gitRef={liveCommit.ref}
+                    commitSha={liveCommit.sha}
+                    commitUrl={liveCommit.url}
+                  />
+                }
+              >
+                <Link
+                  to="#"
+                  className="block bg-gray-300 h-[16px] w-[6px] hover:bg-indigo rounded-md"
+                />
+              </Tooltip>
+            ))}
+            {extraLiveCommits ? <p>+{extraLiveCommits}</p> : null}
+          </div>
+        )) || <em>No commit information</em>}
+      </Td>
       <Td variant="center" className="center items-center justify-center">
-        <div className="text-center">{appCount}</div>
+        <div className="text-center">{source.apps.length}</div>
       </Td>
     </Tr>
   );
 }
 
+const SortIcon = () => (
+  <div className="inline-block">
+    <IconChevronDown
+      variant="sm"
+      className="top-1 -ml-1 relative group-hover:opacity-100 opacity-50"
+    />
+  </div>
+);
+
 export function SourcesPage() {
-  const { isLoading } = useQuery(fetchSources());
-  const sources = useSelector(selectSourcesAsList);
+  const { isLoading: appsLoading } = useQuery(fetchApps());
+  const { isLoading: deploymentsLoading } = useQuery(fetchDeployments());
+  const { isLoading: sourcesLoading } = useQuery(fetchSources());
+  const isLoading = appsLoading || deploymentsLoading || sourcesLoading;
+
+  const [params, setParams] = useSearchParams();
+  const search = params.get("search") || "";
+  const defaultSortBy =
+    (params.get("sortBy") as keyof DeploySourceRow) || "handle";
+  const defaultSortDir = (params.get("asc") as "asc" | "desc") || "asc";
+  const [sortBy, setSortBy] = useState<typeof defaultSortBy>(defaultSortBy);
+  const [sortDir, setSortDir] = useState<typeof defaultSortDir>(defaultSortDir);
+
+  const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    setParams(
+      (prev) => {
+        prev.set("search", ev.currentTarget.value);
+        return prev;
+      },
+      { replace: true },
+    );
+  };
+  const onSort = (key: keyof DeploySourceRow) => {
+    const newSortBy = key;
+    const newSortDir = sortDir === "asc" ? "desc" : "asc";
+
+    if (newSortBy === sortBy) {
+      setSortDir(newSortDir);
+    } else {
+      setSortBy(newSortBy);
+      setSortDir(defaultSortDir);
+    }
+
+    setParams(
+      (prev) => {
+        prev.set("sortBy", newSortBy);
+        prev.set("sortDir", newSortDir);
+        return prev;
+      },
+      { replace: true },
+    );
+  };
+
+  const sources = useSelector((s) =>
+    selectSourcesForTableSearch(s, {
+      search,
+      sortBy,
+      sortDir,
+    }),
+  );
   const paginated = usePaginate(sources);
 
   return (
@@ -64,12 +156,19 @@ export function SourcesPage() {
           </TitleBar>
 
           <FilterBar>
+            <div className="flex justify-between">
+              <InputSearch
+                placeholder="Search..."
+                search={search}
+                onChange={onChange}
+              />
+            </div>
             <Group variant="horizontal" size="sm" className="items-center">
               <LoadingBar isLoading={isLoading} />
             </Group>
 
             <Group variant="horizontal" size="lg" className="items-center mt-1">
-              <DescBar>{paginated.totalItems} Sources</DescBar>
+              <DescBar>{paginated.totalItems} Apps</DescBar>
               <PaginateBar {...paginated} />
             </Group>
           </FilterBar>
@@ -77,8 +176,25 @@ export function SourcesPage() {
 
         <Table>
           <THead>
-            <Th>Name</Th>
-            <Th variant="center">Apps</Th>
+            <Th
+              className="cursor-pointer hover:text-black group"
+              onClick={() => onSort("displayName")}
+            >
+              Name <SortIcon />
+            </Th>
+            <Th
+              className="cursor-pointer hover:text-black group"
+              onClick={() => onSort("liveCommits")}
+            >
+              Live Commits <SortIcon />
+            </Th>
+            <Th
+              variant="center"
+              className="cursor-pointer hover:text-black group"
+              onClick={() => onSort("apps")}
+            >
+              Apps <SortIcon />
+            </Th>
           </THead>
 
           <TBody>

--- a/src/ui/shared/git.tsx
+++ b/src/ui/shared/git.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@app/ui/shared/tooltip";
+import { useMemo } from "react";
 import { Code } from "./code";
 import { OptionalExternalLink } from "./external-link";
 import { IconCommit } from "./icons";
@@ -7,41 +8,43 @@ export const GitRef = ({
   gitRef,
   commitSha,
   commitUrl,
+  className,
 }: {
   gitRef: string | null;
   commitSha: string;
   commitUrl?: string;
+  className?: string;
 }) => {
+  const sha = commitSha.trim();
+  const shortSha = sha.slice(0, 7);
   const ref = gitRef?.trim() || "";
-  const sha = commitSha.trim().slice(0, 7);
   const url = commitUrl || "";
 
   if (!sha) {
     return <em>Not Provided</em>;
   }
 
+  const commitWidget = useMemo(
+    () => (
+      <Code className="whitespace-nowrap">
+        <OptionalExternalLink href={url} linkIf={!!url.match(/^https?:\/\//)}>
+          <IconCommit color="#595E63" variant="sm" className="inline mr-1" />
+          {shortSha}
+        </OptionalExternalLink>
+      </Code>
+    ),
+    [url, shortSha],
+  );
+
   return (
-    <div className="inline-block">
-      <Code>{ref || sha}</Code>
+    <div className={`inline-block whitespace-nowrap ${className}`}>
       {ref && sha && ref !== sha ? (
         <>
-          {" "}
-          @{" "}
-          <Code>
-            <OptionalExternalLink
-              href={url}
-              linkIf={!!url.match(/^https?:\/\//)}
-            >
-              <IconCommit
-                color="#595E63"
-                variant="sm"
-                className="inline mr-1"
-              />
-              {sha}
-            </OptionalExternalLink>
-          </Code>
+          <Code>{ref || shortSha}</Code> @ {commitWidget}
         </>
-      ) : null}
+      ) : (
+        commitWidget
+      )}
     </div>
   );
 };

--- a/src/ui/shared/tooltip.tsx
+++ b/src/ui/shared/tooltip.tsx
@@ -1,7 +1,7 @@
 import cn from "classnames";
 
 export interface TooltipProps {
-  text: string;
+  text: string | React.ReactNode;
   children: React.ReactNode;
   autoSizeWidth?: boolean;
   fluid?: boolean;
@@ -9,6 +9,7 @@ export interface TooltipProps {
   className?: string;
   relative?: boolean;
   variant?: "top" | "left" | "bottom" | "right";
+  theme?: "light" | "dark";
 }
 
 export const Tooltip = ({
@@ -20,6 +21,7 @@ export const Tooltip = ({
   className = "",
   relative = true,
   variant = "top",
+  theme = "dark",
 }: TooltipProps) => {
   return (
     <div className={`tooltip ${relative ? "relative" : ""} ${className}`}>
@@ -33,7 +35,7 @@ export const Tooltip = ({
           "absolute",
           "rounded-md",
           "px-3 py-2",
-          "bg-black text-white",
+          theme === "dark" ? "bg-black text-white" : "bg-white text-black",
           autoSizeWidth ? "w-96" : "",
           fluid ? "w-[60vw] md:w-max" : "",
         ])}


### PR DESCRIPTION
This PR adds a sortable "live commits" column to the source list page. This will enable a user to gauge relative activity between sources.

<img width="1431" alt="Screenshot 2024-04-15 at 5 07 37 PM" src="https://github.com/aptible/app-ui/assets/293571/0e411d51-211f-4bbd-a017-2682eafcc05b">
