### PR TITLE
feat: source setup page

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -148,6 +148,7 @@ import {
 import { DeploymentDetailLayout } from "@app/ui/layouts/deployment-detail-layout";
 import { EnvironmentEndpointsPage } from "@app/ui/pages/environment-detail-endpoints";
 import { SettingsProfilePage } from "@app/ui/pages/settings-profile";
+import { SourcesSetupPage } from "@app/ui/pages/sources-setup";
 import { RouteObject, createBrowserRouter } from "react-router-dom";
 import { Tuna } from "./tuna";
 
@@ -278,6 +279,10 @@ export const appRoutes: RouteObject[] = [
           {
             index: true,
             element: <SourcesPage />,
+          },
+          {
+            path: routes.SOURCES_SETUP_PATH,
+            element: <SourcesSetupPage />,
           },
           {
             path: routes.SOURCE_DETAIL_PATH,

--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -106,7 +106,7 @@ export const deserializeDeployApp = (payload: DeployAppResponse): DeployApp => {
 export const hasDeployApp = (a: DeployApp) => a.id !== "";
 export const selectAppById = schema.apps.selectById;
 export const selectApps = schema.apps.selectTable;
-const selectAppsAsList = schema.apps.selectTableAsList;
+export const selectAppsAsList = schema.apps.selectTableAsList;
 export const findAppById = schema.apps.findById;
 
 export interface DeployAppRow extends DeployApp {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -394,6 +394,8 @@ export const supportUrl = () => SUPPORT_URL;
 
 export const SOURCES_PATH = "/sources";
 export const sourcesUrl = () => SOURCES_PATH;
+export const SOURCES_SETUP_PATH = "/sources/setup";
+export const sourcesSetupUrl = () => SOURCES_SETUP_PATH;
 export const SOURCE_DETAIL_PATH = "/sources/:id";
 export const sourceDetailUrl = (id: string) => `/sources/${id}`;
 export const SOURCE_DETAIL_APPS_PATH = "/sources/:id/apps";

--- a/src/ui/pages/sources-setup.tsx
+++ b/src/ui/pages/sources-setup.tsx
@@ -1,0 +1,88 @@
+import { selectAppsAsList } from "@app/deploy";
+import { useSelector } from "@app/react";
+import { appCiCdUrl } from "@app/routes";
+import { AppSidebarLayout } from "@app/ui";
+import {
+  Banner,
+  Box,
+  Button,
+  FormGroup,
+  Group,
+  Select,
+  SelectOption,
+  TitleBar,
+  tokens,
+} from "@app/ui/shared";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
+export function SourcesSetupPage() {
+  const apps = useSelector(selectAppsAsList);
+  const options: SelectOption[] = [
+    { label: "Select an app", value: "" },
+    ...(apps || []).map((a) => ({ label: a.handle, value: a.id })),
+  ];
+  const [selectedAppId, setSelectedAppId] = useState<string>("");
+  const onAppSelect = (option: SelectOption) => setSelectedAppId(option.value);
+
+  return (
+    <AppSidebarLayout>
+      <Group>
+        <Group size="sm">
+          <TitleBar description="Sources connect apps with code repositories to show you what's deployed where.">
+            Sources
+          </TitleBar>
+        </Group>
+      </Group>
+      <Box>
+        <Banner variant="info" className="mb-6">
+          Sources connect apps with code repositories to show you what's
+          deployed where.{" "}
+          <Link
+            target="_blank"
+            to="https://www.loom.com/share/cb781fd9aa2e41198684e99f25d4ea2a"
+          >
+            Watch the demo video.
+          </Link>
+        </Banner>
+        <Group className="mb-4">
+          <h3 className={tokens.type.h3}>How to Setup a Source</h3>
+
+          <h4 className="font-semibold">
+            Step 1. View an app’s CI/CD tab and follow the setup instructions.
+          </h4>
+          <p>
+            Aptible automatically creates a source and links all releases to
+            that source when you use the Aptible GitHub Action (v4 or greater).
+          </p>
+
+          <h4 className="font-semibold">
+            Step 2. Commit your changes and wait for the release to finish.
+          </h4>
+          <p>
+            That’s it! Now you can view all apps, release history, release logs,
+            and release ENV variables (if you have permissions) tied to this
+            source.
+          </p>
+        </Group>
+        <Group>
+          <FormGroup
+            label="Choose App to configure Source"
+            htmlFor="Choose App to configure Source"
+          >
+            <Select
+              onSelect={onAppSelect}
+              value={selectedAppId || undefined}
+              options={options}
+            />
+          </FormGroup>
+          <Link to={selectedAppId ? appCiCdUrl(selectedAppId) : "#"}>
+            <Button className="w-fit" type="button" disabled={!selectedAppId}>
+              Continue to CI/CD Setup
+            </Button>
+          </Link>
+        </Group>
+      </Box>
+    </AppSidebarLayout>
+  );
+}

--- a/src/ui/pages/sources-setup.tsx
+++ b/src/ui/pages/sources-setup.tsx
@@ -1,5 +1,5 @@
-import { selectAppsAsList } from "@app/deploy";
-import { useSelector } from "@app/react";
+import { fetchApps, selectAppsAsList } from "@app/deploy";
+import { useQuery, useSelector } from "@app/react";
 import { appCiCdUrl } from "@app/routes";
 import { AppSidebarLayout } from "@app/ui";
 import {
@@ -17,10 +17,21 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 
 export function SourcesSetupPage() {
+  const { isLoading } = useQuery(fetchApps());
   const apps = useSelector(selectAppsAsList);
   const options: SelectOption[] = [
-    { label: "Select an app", value: "" },
-    ...(apps || []).map((a) => ({ label: a.handle, value: a.id })),
+    {
+      label: isLoading ? "Please wait..." : "Select an app",
+      value: "",
+      disabled: isLoading,
+    },
+    ...(apps || [])
+      .map((a) => ({
+        label: a.handle,
+        value: a.id,
+        disabled: !!a.currentSourceId,
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
   ];
   const [selectedAppId, setSelectedAppId] = useState<string>("");
   const onAppSelect = (option: SelectOption) => setSelectedAppId(option.value);
@@ -71,6 +82,7 @@ export function SourcesSetupPage() {
             htmlFor="Choose App to configure Source"
           >
             <Select
+              disabled={isLoading}
               onSelect={onAppSelect}
               value={selectedAppId || undefined}
               options={options}

--- a/src/ui/pages/sources-setup.tsx
+++ b/src/ui/pages/sources-setup.tsx
@@ -60,22 +60,27 @@ export function SourcesSetupPage() {
         <Group className="mb-4">
           <h3 className={tokens.type.h3}>How to Setup a Source</h3>
 
-          <h4 className="font-semibold">
-            Step 1. View an app’s CI/CD tab and follow the setup instructions.
-          </h4>
-          <p>
-            Aptible automatically creates a source and links all releases to
-            that source when you use the Aptible GitHub Action (v4 or greater).
-          </p>
+          <div>
+            <h4 className="font-semibold">
+              Step 1. View an app’s CI/CD tab and follow the setup instructions.
+            </h4>
+            <p>
+              Aptible automatically creates a source and links all releases to
+              that source when you use the Aptible GitHub Action (v4 or
+              greater).
+            </p>
+          </div>
 
-          <h4 className="font-semibold">
-            Step 2. Commit your changes and wait for the release to finish.
-          </h4>
-          <p>
-            That’s it! Now you can view all apps, release history, release logs,
-            and release ENV variables (if you have permissions) tied to this
-            source.
-          </p>
+          <div>
+            <h4 className="font-semibold">
+              Step 2. Commit your changes and wait for the release to finish.
+            </h4>
+            <p>
+              That’s it! Now you can view all apps, release history, release
+              logs, and release ENV variables (if you have permissions) tied to
+              this source.
+            </p>
+          </div>
         </Group>
         <Group>
           <FormGroup

--- a/src/ui/pages/sources-setup.tsx
+++ b/src/ui/pages/sources-setup.tsx
@@ -25,7 +25,7 @@ export function SourcesSetupPage() {
       value: "",
       disabled: isLoading,
     },
-    ...(apps || [])
+    ...apps
       .map((a) => ({
         label: a.handle,
         value: a.id,

--- a/src/ui/pages/sources-setup.tsx
+++ b/src/ui/pages/sources-setup.tsx
@@ -14,7 +14,7 @@ import {
   tokens,
 } from "@app/ui/shared";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 export function SourcesSetupPage() {
   const { isLoading } = useQuery(fetchApps());
@@ -35,6 +35,7 @@ export function SourcesSetupPage() {
   ];
   const [selectedAppId, setSelectedAppId] = useState<string>("");
   const onAppSelect = (option: SelectOption) => setSelectedAppId(option.value);
+  const navigate = useNavigate();
 
   return (
     <AppSidebarLayout>
@@ -88,11 +89,14 @@ export function SourcesSetupPage() {
               options={options}
             />
           </FormGroup>
-          <Link to={selectedAppId ? appCiCdUrl(selectedAppId) : "#"}>
-            <Button className="w-fit" type="button" disabled={!selectedAppId}>
-              Continue to CI/CD Setup
-            </Button>
-          </Link>
+          <Button
+            className="w-fit"
+            type="button"
+            disabled={!selectedAppId}
+            onClick={() => navigate(appCiCdUrl(selectedAppId))}
+          >
+            Continue to CI/CD Setup
+          </Button>
         </Group>
       </Box>
     </AppSidebarLayout>

--- a/src/ui/pages/sources.tsx
+++ b/src/ui/pages/sources.tsx
@@ -13,6 +13,8 @@ import { useQuery } from "starfx/react";
 import { usePaginate } from "../hooks";
 import { AppSidebarLayout } from "../layouts";
 import {
+  ActionBar,
+  ButtonAnyOwner,
   DescBar,
   EmptyTr,
   FilterBar,
@@ -20,6 +22,7 @@ import {
   Group,
   IconChevronDown,
   IconInfo,
+  IconPlusCircle,
   InputSearch,
   LoadingBar,
   PaginateBar,
@@ -173,7 +176,17 @@ export function SourcesPage() {
                 search={search}
                 onChange={onChange}
               />
+              <ActionBar>
+                <ButtonAnyOwner
+                  onClick={() => navigate(sourcesSetupUrl())}
+                  tooltipProps={{ placement: "left" }}
+                >
+                  <IconPlusCircle variant="sm" className="mr-2" />
+                  New Source
+                </ButtonAnyOwner>
+              </ActionBar>
             </div>
+
             <Group variant="horizontal" size="sm" className="items-center">
               <LoadingBar isLoading={isLoading} />
             </Group>

--- a/src/ui/pages/sources.tsx
+++ b/src/ui/pages/sources.tsx
@@ -5,10 +5,10 @@ import {
 } from "@app/deploy";
 import { fetchDeployments } from "@app/deployment";
 import { useSelector } from "@app/react";
-import { sourceDetailUrl } from "@app/routes";
+import { sourceDetailUrl, sourcesSetupUrl } from "@app/routes";
 import { fetchSources } from "@app/source";
 import { useState } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useQuery } from "starfx/react";
 import { usePaginate } from "../hooks";
 import { AppSidebarLayout } from "../layouts";
@@ -151,6 +151,12 @@ export function SourcesPage() {
     }),
   );
   const paginated = usePaginate(sources);
+
+  // If there are no sources to display, redirect the user to the setup page.
+  const navigate = useNavigate();
+  if (!isLoading && sources.length === 0) {
+    navigate(sourcesSetupUrl());
+  }
 
   return (
     <AppSidebarLayout>

--- a/src/ui/pages/sources.tsx
+++ b/src/ui/pages/sources.tsx
@@ -15,6 +15,7 @@ import { AppSidebarLayout } from "../layouts";
 import {
   ActionBar,
   ButtonAnyOwner,
+  CopyText,
   DescBar,
   EmptyTr,
   FilterBar,
@@ -54,6 +55,9 @@ function SourceListRow({ source }: { source: DeploySourceRow }) {
             {source.displayName}
           </p>
         </Link>
+      </Td>
+      <Td>
+        <CopyText text={source.url}>{source.url}</CopyText>
       </Td>
       <Td>
         {liveCommits.length === 0 ? <em>No commit information</em> : null}
@@ -206,6 +210,7 @@ export function SourcesPage() {
             >
               Name <SortIcon />
             </Th>
+            <Th>Source URL</Th>
             <Th
               className="cursor-pointer hover:text-black group"
               onClick={() => onSort("liveCommits")}

--- a/src/ui/shared/select.tsx
+++ b/src/ui/shared/select.tsx
@@ -4,6 +4,8 @@ import { Children, cloneElement } from "react";
 export interface SelectOption<V = string> {
   label: string;
   value: V;
+  disabled?: boolean;
+  key?: string;
 }
 
 export interface SelectProps<V = string> {
@@ -56,7 +58,11 @@ export function Select<V = string>({
     >
       {options.map((option) => {
         return (
-          <option key={option.value} value={option.value}>
+          <option
+            key={option.key || option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
             {option.label}
           </option>
         );


### PR DESCRIPTION
This PR introduces a "Source Setup" page. It also adds the Source URL to the source list table.

If a user has no sources, they will be automatically redirected to the Source Setup page, and given instructions on how to set up a source for a selected app.

<img width="1558" alt="Screenshot 2024-04-19 at 5 15 06 PM" src="https://github.com/aptible/app-ui/assets/293571/ac76a6aa-a014-4e67-a0af-3d153290d042">

A user that already has at least one source configured can visit the Source Setup page by clicking the New Source button.

<img width="1657" alt="Screenshot 2024-04-22 at 11 51 23 AM" src="https://github.com/aptible/app-ui/assets/293571/4476c900-fb2e-4acf-bd7d-cb5589b5b3fe">
