### PR TITLE
chore(log-drain): add papertrail to syslog classification

### DIFF
--- a/src/deploy/log-drain/index.ts
+++ b/src/deploy/log-drain/index.ts
@@ -184,6 +184,10 @@ export const isLogDrainHttps = (drain: DeployLogDrain): boolean => {
   ];
   return isHttps.includes(drain.drainType);
 };
+export const isLogDrainSyslog = (drain: DeployLogDrain): boolean => {
+  const isHttps: LogDrainType[] = ["syslog_tls_tcp", "papertrail"];
+  return isHttps.includes(drain.drainType);
+};
 
 export const fetchLogDrains = api.get(
   "/log_drains?per_page=5000",

--- a/src/ui/pages/environment-detail-integrations.tsx
+++ b/src/ui/pages/environment-detail-integrations.tsx
@@ -5,6 +5,7 @@ import {
   fetchEnvLogDrains,
   fetchEnvMetricDrains,
   isLogDrainHttps,
+  isLogDrainSyslog,
   restartLogDrain,
   selectDatabaseById,
   selectLogDrainsByEnvId,
@@ -210,7 +211,7 @@ const LogDrainDestinationCell = ({
       <Tooltip
         relative={false}
         autoSizeWidth
-        className="absolute"
+        className="absolute mt-4"
         text="This log drain was automatically provisioned to support `aptible logs` in this environment. Access these logs via the Aptible CLI."
       >
         <Code>Destination</Code>
@@ -243,7 +244,7 @@ const LogDrainDestinationCell = ({
     );
   }
 
-  if (logDrain.drainType === "syslog_tls_tcp") {
+  if (isLogDrainSyslog(logDrain)) {
     return (
       <Group variant="horizontal" size="sm" className="items-center">
         <Code>


### PR DESCRIPTION
papertrail is syslog based: https://github.com/aptible/deploy-ui/blob/d00649b77a9beebc3f1a434106e5f817d4024f46/app/models/log-drain.js#L53