### PR TITLE
Fix the width of the Live Commits column to prevent jumping when sorting

### DIFF
--- a/src/ui/pages/sources.tsx
+++ b/src/ui/pages/sources.tsx
@@ -54,7 +54,11 @@ function SourceListRow({ source }: { source: DeploySourceRow }) {
       <Td>
         {liveCommits.length === 0 ? <em>No commit information</em> : null}
 
-        <Group variant="horizontal" size="xs" className="items-center">
+        <Group
+          variant="horizontal"
+          size="xs"
+          className="items-center min-w-[150px]"
+        >
           {liveCommits.map((liveCommit) => (
             <Tooltip
               key={liveCommit.sha}


### PR DESCRIPTION
This PR fixes an annoying issue where sorting by Live Commits may cause the column header to jump left or right depending on the width of the data in the column.

This change makes the width of those cells fixed to prevent that issue.