### PR TITLE
fix: improve tooltips for multi-line commit messages

### DIFF
--- a/src/ui/shared/git.tsx
+++ b/src/ui/shared/git.tsx
@@ -57,7 +57,15 @@ export const GitCommitMessage = ({ message }: { message: string }) => {
   const firstLine = message.trim().split("\n")[0];
   return (
     <div className="inline-block">
-      <Tooltip text={message} fluid>
+      <Tooltip
+        text={
+          <pre className="overflow-hidden max-w-[150ch] text-ellipsis">
+            {message}
+          </pre>
+        }
+        fluid
+        placement="top"
+      >
         <p className="leading-8 text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block">
           {firstLine}
           {message.length > firstLine.length ? " ..." : ""}


### PR DESCRIPTION
This PR leverages the work in #799 to improve the display of multi-line commit message tooltips.

<img width="1657" alt="Screenshot 2024-04-19 at 4 00 53 PM" src="https://github.com/aptible/app-ui/assets/293571/2eb5ddf3-c792-472a-b215-4242effb3784">
