### PR TITLE
fix(env): change default values for env backup retention policy

### DIFF
--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -605,13 +605,14 @@ export const defaultBackupRp = (
   bk: Partial<DeployBackupRetentionPolicy> = {},
 ): DeployBackupRetentionPolicy => {
   const now = new Date().toISOString();
+  // based on https://github.com/aptible/deploy-api/blob/b537960533f3cb6fb8f57f339de3a46207e70f4b/app/models/backup_retention_policy.rb#L8
   return {
     id: "",
-    daily: 0,
-    monthly: 0,
+    daily: 90,
+    monthly: 72,
     yearly: 0,
-    makeCopy: false,
-    keepFinal: false,
+    makeCopy: true,
+    keepFinal: true,
     environmentId: "",
     createdAt: now,
     ...bk,


### PR DESCRIPTION
https://app.shortcut.com/aptible/story/24238/display-of-backup-retention-policy-on-a-new-environment-is-wrongly-set-to-0?vc_group_by=day&ct_workflow=all&cf_workflow=500000186