### PR TITLE
fix: don't redirect to source setup if search returns no results

### DIFF
--- a/src/ui/pages/sources.tsx
+++ b/src/ui/pages/sources.tsx
@@ -161,7 +161,7 @@ export function SourcesPage() {
 
   // If there are no sources to display, redirect the user to the setup page.
   const navigate = useNavigate();
-  if (!isLoading && sources.length === 0) {
+  if (!isLoading && search === "" && sources.length === 0) {
     navigate(sourcesSetupUrl());
   }
 


### PR DESCRIPTION
This PR fixes an issue where a search that returns no results would cause a redirect to the source setup page.