### PR TITLE
Db settings page typo

### DIFF
--- a/src/ui/pages/database-detail-settings.tsx
+++ b/src/ui/pages/database-detail-settings.tsx
@@ -115,7 +115,7 @@ const DatabaseDeprovision = ({ database }: DbProps) => {
         ) : null}
         <p>
           This will permanently deprovision <strong>{database.handle}</strong>{" "}
-          database. This action cannot be undone. If you want to proceed, type
+          database. This action cannot be undone. If you want to proceed, type 
           <strong>{database.handle}</strong> below to continue.
         </p>
 

--- a/src/ui/pages/database-detail-settings.tsx
+++ b/src/ui/pages/database-detail-settings.tsx
@@ -115,8 +115,8 @@ const DatabaseDeprovision = ({ database }: DbProps) => {
         ) : null}
         <p>
           This will permanently deprovision <strong>{database.handle}</strong>{" "}
-          database. This action cannot be undone. If you want to proceed, type 
-          <strong>{database.handle}</strong> below to continue.
+          database. This action cannot be undone. If you want to proceed, type
+           <strong>{database.handle}</strong> below to continue.
         </p>
 
         <BannerMessages {...loader} />

--- a/src/ui/pages/database-detail-settings.tsx
+++ b/src/ui/pages/database-detail-settings.tsx
@@ -115,8 +115,8 @@ const DatabaseDeprovision = ({ database }: DbProps) => {
         ) : null}
         <p>
           This will permanently deprovision <strong>{database.handle}</strong>{" "}
-          database. This action cannot be undone. If you want to proceed, type
-           <strong>{database.handle}</strong> below to continue.
+          database. This action cannot be undone. If you want to proceed, type{" "}
+          <strong>{database.handle}</strong> below to continue.
         </p>
 
         <BannerMessages {...loader} />


### PR DESCRIPTION
<img width="1238" alt="Screenshot 2024-05-17 at 10 38 46 AM" src="https://github.com/aptible/app-ui/assets/83726760/ec67db29-c516-4019-9676-dad3d4a1b6e2">

added space between "type" and the db name