### PR TITLE
Change dependency list key

### DIFF
--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -602,7 +602,7 @@ export const AppDependencyList = ({
           const app = dep.resource;
 
           return (
-            <Tr key={app.id}>
+            <Tr key={dep.why}>
               <AppPrimaryCell app={app} />
               <AppIdCell app={app} />
               <EnvStackCell environmentId={app.environmentId} />

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -393,7 +393,7 @@ export const DatabaseDependencyList = ({
           const db = dep.resource;
 
           return (
-            <Tr key={db.id}>
+            <Tr key={dep.why}>
               <DatabasePrimaryCell database={db} />
               <DatabaseIdCell database={db} />
               <EnvStackCell environmentId={db.environmentId} />


### PR DESCRIPTION
Currently, an App or Database can appear in the list multiple times so the resource ID is not suitable as the React key. The matching config key is better as it is unique.