### PR TITLE
Don't say 'all' if it's qualified with 'other'.

### DIFF
--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -170,9 +170,9 @@ export const revokeAllTokens = authApi.post(
     ctx.loader = {
       message:
         "Successfully logged out of other sessions! You may wish to log out of this session, as well.",
-     };
-   },
-  );
+    };
+  },
+);
 
 export function* revokeTokensMdw(ctx: AuthApiCtx, next: Next) {
   yield* next();

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -170,8 +170,9 @@ export const revokeAllTokens = authApi.post(
     ctx.loader = {
       message:
         "Successfully logged out of other sessions! You may wish to log out of this session, as well.",
-    };  },
-);
+     };
+   },
+  );
 
 export function* revokeTokensMdw(ctx: AuthApiCtx, next: Next) {
   yield* next();

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -167,7 +167,7 @@ export const revokeAllTokens = authApi.post(
       return;
     }
     tunaEvent("revoked-all-tokens");
-    ctx.loader = { message: "Successfully logged out all other sessions!" };
+    ctx.loader = { message: "Successfully logged out other sessions! You may wish to log out of this session, as well." };
   },
 );
 

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -167,8 +167,10 @@ export const revokeAllTokens = authApi.post(
       return;
     }
     tunaEvent("revoked-all-tokens");
-    ctx.loader = { message: "Successfully logged out of other sessions! You may wish to log out of this session, as well." };
-  },
+    ctx.loader = {
+      message:
+        "Successfully logged out of other sessions! You may wish to log out of this session, as well.",
+    };  },
 );
 
 export function* revokeTokensMdw(ctx: AuthApiCtx, next: Next) {

--- a/src/auth/token.ts
+++ b/src/auth/token.ts
@@ -167,7 +167,7 @@ export const revokeAllTokens = authApi.post(
       return;
     }
     tunaEvent("revoked-all-tokens");
-    ctx.loader = { message: "Successfully logged out other sessions! You may wish to log out of this session, as well." };
+    ctx.loader = { message: "Successfully logged out of other sessions! You may wish to log out of this session, as well." };
   },
 );
 
@@ -180,5 +180,5 @@ export function* revokeTokensMdw(ctx: AuthApiCtx, next: Next) {
 
   yield* revokeAllTokens.run();
   const msg = ctx.loader?.message || "Success!";
-  ctx.loader = { message: `${msg} All other sessions have been logged out.` };
+  ctx.loader = { message: `${msg} Other sessions have been logged out.` };
 }

--- a/src/ui/pages/logout.tsx
+++ b/src/ui/pages/logout.tsx
@@ -23,7 +23,7 @@ export const LogoutPage = () => {
         <p className="my-6 text-gray-600">
           Click to log out now or visit{" "}
           <Link to={securitySettingsUrl()}>Security Settings</Link> to log out
-          of all active sessions.
+          of other active sessions, first.
         </p>
       </div>
       <Box>

--- a/src/ui/pages/settings-security.tsx
+++ b/src/ui/pages/settings-security.tsx
@@ -365,12 +365,12 @@ const LogOut = () => {
 
       <div>
         This action will log out all <strong>other</strong> sessions and cannot
-        be undone.
+        be undone. This session will remain logged in.
       </div>
 
       <div>
         <Button variant="delete" requireConfirm onClick={confirmLogout}>
-          Log out all sessions
+          Log out other sessions
         </Button>
       </div>
     </Group>
@@ -396,7 +396,7 @@ export const SecuritySettingsPage = () => {
       <Section title="Security Keys">
         <SecurityKeys />
       </Section>
-      <Section title="Log out all sessions">
+      <Section title="Log out other sessions">
         <LogOut />
       </Section>
     </BoxGroup>

--- a/src/ui/pages/settings-security.tsx
+++ b/src/ui/pages/settings-security.tsx
@@ -17,6 +17,7 @@ import {
 } from "@app/react";
 import {
   addSecurityKeyUrl,
+  logoutUrl,
   otpRecoveryCodesUrl,
   otpSetupUrl,
 } from "@app/routes";
@@ -24,6 +25,7 @@ import { schema } from "@app/schema";
 import { selectCurrentUserId, updateEmail } from "@app/users";
 import { emailValidator } from "@app/validator";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { useCurrentUser } from "../hooks";
 import {
   Banner,
@@ -361,7 +363,21 @@ const LogOut = () => {
 
   return (
     <Group>
-      <BannerMessages {...loader} />
+      {loader.isSuccess ? (
+        <BannerMessages
+          {...loader}
+          message={
+            <>
+              <span>{loader.message} </span>
+              <Link to={logoutUrl()} className={tokens.type["white link"]}>
+                Logout
+              </Link>
+            </>
+          }
+        />
+      ) : (
+        <BannerMessages {...loader} />
+      )}
 
       <div>
         This action will log out all <strong>other</strong> sessions and cannot

--- a/src/ui/shared/banner.tsx
+++ b/src/ui/shared/banner.tsx
@@ -117,7 +117,7 @@ export const BannerMessages = ({
   isSuccess: boolean;
   isError: boolean;
   isWarning?: boolean;
-  message: string;
+  message: React.ReactNode;
   className?: string;
 }) => {
   if (!message) return null;

--- a/src/ui/shared/tokens.ts
+++ b/src/ui/shared/tokens.ts
@@ -7,6 +7,7 @@ export const tokens = {
 
     link: "font-medium text-sm text-gray-500 hover:text-indigo",
     "table link": "text-black group-hover:text-indigo hover:text-indigo",
+    "white link": "text-white underline",
 
     "active link": "font-medium text-sm text-gray-700",
     "subdued active link": "font-medium text-sm text-amber-600",


### PR DESCRIPTION
Be as clear as possible that "other" is not inclusive of the current session, including avoiding the word "all" entirely.