### PR TITLE
update database version + type to description

### DIFF
--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -1,5 +1,5 @@
 import { prettyDateTime } from "@app/date";
-import { fetchDatabaseImages, formatDatabaseType } from "@app/deploy";
+import { fetchDatabaseImages } from "@app/deploy";
 import {
   calcMetrics,
   cancelDatabaseOpsPoll,

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -84,7 +84,7 @@ export function DatabaseHeader({
           {metrics.totalMemoryLimit / 1024} GB
         </DetailInfoItem>
         <DetailInfoItem title="Type">
-          {formatDatabaseType(database.type, image.version)}
+          {image.description}
         </DetailInfoItem>
         <DetailInfoItem title="Disk Type">{disk.ebsVolumeType}</DetailInfoItem>
         <DetailInfoItem title="CPU Share">{metrics.totalCPU}</DetailInfoItem>

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -83,9 +83,7 @@ export function DatabaseHeader({
         <DetailInfoItem title="Memory Limit">
           {metrics.totalMemoryLimit / 1024} GB
         </DetailInfoItem>
-        <DetailInfoItem title="Type">
-          {image.description}
-        </DetailInfoItem>
+        <DetailInfoItem title="Type">{image.description}</DetailInfoItem>
         <DetailInfoItem title="Disk Type">{disk.ebsVolumeType}</DetailInfoItem>
         <DetailInfoItem title="CPU Share">{metrics.totalCPU}</DetailInfoItem>
         <DetailInfoItem title="Disk Size">{disk.size} GB</DetailInfoItem>

--- a/src/ui/pages/database-detail-cluster.tsx
+++ b/src/ui/pages/database-detail-cluster.tsx
@@ -13,7 +13,6 @@ import {
 } from "@app/deploy";
 import { useQuery, useSelector } from "@app/react";
 import { databaseEndpointsUrl } from "@app/routes";
-import { capitalize } from "@app/string-utils";
 import type { DeployDatabase } from "@app/types";
 import { useParams } from "react-router";
 import { Link } from "react-router-dom";

--- a/src/ui/pages/database-detail-cluster.tsx
+++ b/src/ui/pages/database-detail-cluster.tsx
@@ -56,10 +56,7 @@ const ClusterDatabaseRow = ({
       </Td>
 
       <Td className="flex-1">
-        <div className="text-gray-900">{capitalize(db.type)}</div>
-        <div className={tokens.type["normal lighter"]}>
-          Version {image.version}
-        </div>
+        <div className="text-gray-900">{image.description}</div>
       </Td>
 
       <Td className="flex-1">

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -71,7 +71,7 @@ export const DatabaseItemView = ({
         <p className="flex flex-col">
           <span className={tokens.type["table link"]}>{database.handle}</span>
           <span className={tokens.type["normal lighter"]}>
-            {formatDatabaseType(database.type, image.version)}
+            {image.description}
           </span>
         </p>
       </Link>

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -16,7 +16,6 @@ import {
   selectLatestOpByDatabaseId,
   selectServiceById,
 } from "@app/deploy";
-import { formatDatabaseType } from "@app/deploy";
 import { useQuery } from "@app/react";
 import { useSelector } from "@app/react";
 import {


### PR DESCRIPTION
Switches from Type + Version to the Description, which has more information available that is already intended to be human readable (the same string you use when you _choose_ a database image)
![Screenshot 2024-07-30 at 13 14 47](https://github.com/user-attachments/assets/319dc44b-6c31-4547-aac4-f33b8144fbc9)
![Screenshot 2024-07-30 at 13 15 24](https://github.com/user-attachments/assets/07cc51c7-8f91-4cf0-ad06-fa666e766003)
![Screenshot 2024-07-30 at 13 15 55](https://github.com/user-attachments/assets/43c6f32c-1734-4b9a-8ad1-bfed9daeef77)

