### PR TITLE
sort by hids start_date by default

### DIFF
--- a/src/ui/pages/stack-detail-hids.tsx
+++ b/src/ui/pages/stack-detail-hids.tsx
@@ -124,7 +124,10 @@ const ReportTable = ({ stack }: { stack: DeployStack }) => {
     );
   }
   const lastPage = Math.ceil((data.total_count || 0) / (data.per_page || 0));
-  const reports = data._embedded.intrusion_detection_reports;
+  const reports = [...data._embedded.intrusion_detection_reports].sort(
+    (a, b) =>
+      new Date(b.starts_at).getTime() - new Date(a.starts_at).getTime(),
+  );
 
   return (
     <>

--- a/src/ui/pages/stack-detail-hids.tsx
+++ b/src/ui/pages/stack-detail-hids.tsx
@@ -76,9 +76,9 @@ const ReportView = ({
   const fdate = fileDate(report.created_at);
   return (
     <Tr>
-      <Td>{date}</Td>
       <Td>{prettyDate(report.starts_at)}</Td>
       <Td>{prettyDate(report.ends_at)}</Td>
+      <Td>{date}</Td>
       <Td variant="right">
         <Group variant="horizontal" size="sm">
           <DownloadReport
@@ -147,9 +147,9 @@ const ReportTable = ({ stack }: { stack: DeployStack }) => {
 
       <Table>
         <THead>
-          <Th>Posted Date</Th>
           <Th>From Date</Th>
           <Th>To Date</Th>
+          <Th>Posted Date</Th>
           <Th>Download</Th>
         </THead>
 

--- a/src/ui/pages/stack-detail-hids.tsx
+++ b/src/ui/pages/stack-detail-hids.tsx
@@ -125,8 +125,7 @@ const ReportTable = ({ stack }: { stack: DeployStack }) => {
   }
   const lastPage = Math.ceil((data.total_count || 0) / (data.per_page || 0));
   const reports = [...data._embedded.intrusion_detection_reports].sort(
-    (a, b) =>
-      new Date(b.starts_at).getTime() - new Date(a.starts_at).getTime(),
+    (a, b) => new Date(b.starts_at).getTime() - new Date(a.starts_at).getTime(),
   );
 
   return (


### PR DESCRIPTION
https://aptible.zendesk.com/agent/tickets/54088

Customer reported that they use our HIDS reports for SOC2, and it's sometimes difficult to track because they're out of order. Updating logic to sort_by `From Date` instead of `Posted Date` by default. 

Before:
<img width="874" alt="Screenshot 2024-08-02 at 6 32 37 PM" src="https://github.com/user-attachments/assets/a9ec46c2-77ea-471d-8129-169934b8019c">


After: 

<img width="839" alt="Screenshot 2024-08-02 at 6 33 25 PM" src="https://github.com/user-attachments/assets/8d9516f7-12f9-4994-bf1e-d36ba972f034">

