### PR TITLE
fix: endpoint settings creating new cert

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -58,6 +58,7 @@ function* sentryErrorHandler(ctx: ApiCtx | ThunkCtx, next: Next) {
   try {
     yield* next();
   } catch (err) {
+    console.error(err);
     if (err instanceof Error) {
       for (const matcher of ignoreErrs) {
         if (matcher.test(err.message)) {

--- a/src/deploy/certificate/index.ts
+++ b/src/deploy/certificate/index.ts
@@ -171,9 +171,7 @@ export interface CreateCertProps {
 
 export const createCertificate = api.post<
   CreateCertProps,
-  DeployCertificateResponse,
-  // TODO: shouldn't need to provide this
-  { message: string }
+  DeployCertificateResponse
 >("/accounts/:envId/certificates", function* (ctx, next) {
   const body = JSON.stringify({
     certificate_body: ctx.payload.cert,

--- a/src/ui/pages/endpoint-detail-settings.tsx
+++ b/src/ui/pages/endpoint-detail-settings.tsx
@@ -133,7 +133,11 @@ const EndpointSettings = ({ endpointId }: { endpointId: string }) => {
         label="Create a New Certificate"
         name="new-cert"
         checked={usingNewCert}
-        onChange={(e) => setUsingNewCert(e.currentTarget.checked)}
+        onChange={(e) => {
+          // must remove certId for `updateEndpoint`
+          setCertId("");
+          setUsingNewCert(e.currentTarget.checked);
+        }}
       />
     </FormGroup>
   );


### PR DESCRIPTION
https://aptible.slack.com/archives/C05CMUW3LHX/p1723657960421089

When running `updateEndpoint` we were previously providing *both* the
previously attached `certId` as well as the newly added cert.
This made it so we never actually create the new cert and instead just
use the previous one.