### PR TITLE
add primary db link in header for replicas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@
 .DS_Store
 .envrc
 .env
+.env.*
 node_modules
 dist
-.env.local
 tmp
 
 .pnp.*

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -35,6 +35,7 @@ import {
 import { setResourceStats } from "@app/search";
 import type { DeployDatabase, DeployService } from "@app/types";
 import { useEffect, useMemo } from "react";
+import { Link } from "react-router-dom";
 import { Outlet, useParams } from "react-router-dom";
 import { usePoller } from "../hooks";
 import {
@@ -51,10 +52,12 @@ import { AppSidebarLayout } from "./app-sidebar-layout";
 
 export function DatabaseHeader({
   database,
+  databasePrimary,
   service,
   isLoading,
 }: {
   database: DeployDatabase;
+  databasePrimary: DeployDatabase;
   service: DeployService;
   isLoading: boolean;
 }) {
@@ -105,6 +108,13 @@ export function DatabaseHeader({
         <DetailInfoItem title="Created">
           {prettyDateTime(database.createdAt)}
         </DetailInfoItem>
+        {databasePrimary?.id && (
+          <DetailInfoItem title="Replicates">
+            <Link to={databaseDetailUrl(databasePrimary.id)} className="flex">
+              {databasePrimary.handle}
+            </Link>
+          </DetailInfoItem>
+        )}
       </DetailInfoGrid>
     </DetailHeader>
   );
@@ -129,6 +139,9 @@ function DatabasePageHeader() {
   }, []);
 
   const database = useSelector((s) => selectDatabaseById(s, { id }));
+  const databasePrimary = useSelector((s) =>
+    selectDatabaseById(s, { id: database.initializeFrom }),
+  );
   const service = useSelector((s) =>
     selectServiceById(s, { id: database.serviceId }),
   );
@@ -165,6 +178,7 @@ function DatabasePageHeader() {
         detailsBox={
           <DatabaseHeader
             database={database}
+            databasePrimary={databasePrimary}
             service={service}
             isLoading={loader.isLoading}
           />

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -108,7 +108,7 @@ export function DatabaseHeader({
         <DetailInfoItem title="Created">
           {prettyDateTime(database.createdAt)}
         </DetailInfoItem>
-        {databasePrimary?.id && (
+        {databasePrimary.id && (
           <DetailInfoItem title="Replicates">
             <Link to={databaseDetailUrl(databasePrimary.id)} className="flex">
               {databasePrimary.handle}

--- a/src/ui/pages/styles.tsx
+++ b/src/ui/pages/styles.tsx
@@ -609,6 +609,10 @@ const DetailBoxes = () => {
     id: "222",
     type: "postgresql",
   });
+  const dbPrimary = defaultDeployDatabase({
+    id: "223",
+    type: "postgresql",
+  });
   const service = defaultDeployService({
     containerMemoryLimitMb: 4096,
   });
@@ -654,7 +658,12 @@ const DetailBoxes = () => {
         cost={99.99}
       />
       <AppHeader app={app} isLoading={false} />
-      <DatabaseHeader database={db} service={service} isLoading={false} />
+      <DatabaseHeader
+        database={db}
+        databasePrimary={dbPrimary}
+        service={service}
+        isLoading={false}
+      />
       <OpHeader op={op} resourceHandle={app.handle} isLoading={false} />
     </div>
   );


### PR DESCRIPTION
https://app.shortcut.com/aptible/story/26534/the-cluster-tab-only-shows-replicas

show link in the db detail page header if the replica has a linked primary

<img width="586" alt="image" src="https://github.com/user-attachments/assets/3cfe6472-3959-46c6-b05d-437fe8d480d7">

<img width="610" alt="image" src="https://github.com/user-attachments/assets/6048d874-5da3-49f5-92bb-05006ab373cc">
