### PR TITLE
Improve backup load performance and show spinner until estimate is calculated

### DIFF
--- a/src/deploy/backup/index.ts
+++ b/src/deploy/backup/index.ts
@@ -65,6 +65,10 @@ export const selectBackupsAsList = schema.backups.selectTableAsList;
 export const selectBackups = schema.backups.selectTable;
 export const findBackupsByEnvId = (backups: DeployBackup[], envId: string) =>
   backups.filter((backup) => backup.environmentId === envId);
+export const findBackupsByDatabaseId = (
+  backups: DeployBackup[],
+  dbId: string,
+) => backups.filter((backup) => backup.databaseId === dbId);
 
 export const selectBackupsByEnvId = createSelector(
   selectBackupsAsList,
@@ -88,8 +92,7 @@ export const selectOrphanedBackupsByEnvId = createSelector(
 export const selectBackupsByDatabaseId = createSelector(
   selectBackupsAsList,
   (_: WebState, p: { dbId: string }) => p.dbId,
-  (backups, envId) =>
-    backups.filter((bk) => bk.databaseId === envId).sort(dateDescSort),
+  findBackupsByDatabaseId,
 );
 
 export const backupEntities = {
@@ -140,14 +143,14 @@ export const fetchBackup = api.get<{ id: string }>("/backups/:id");
 
 interface FetchByResourceIdProps {
   id: string;
-  orphaned: boolean;
+  onlyOrphaned?: boolean;
   perPage?: number;
 }
 export const fetchBackupsByEnvIdPage = api.get<
   FetchByResourceIdProps & PaginateProps,
   HalEmbedded<{ backups: BackupResponse[] }>
 >("/accounts/:id/backups?page=:page", function* (ctx, next) {
-  if (ctx.payload.orphaned) {
+  if (ctx.payload.onlyOrphaned === true) {
     ctx.request = ctx.req({
       url: `${ctx.req().url}&orphaned=true`,
     });

--- a/src/deploy/search/index.ts
+++ b/src/deploy/search/index.ts
@@ -9,6 +9,7 @@ import {
   selectApps,
   selectAppsByOrgAsList,
 } from "../app";
+import { findBackupsByDatabaseId, selectBackupsAsList } from "../backup";
 import { estimateMonthlyCost } from "../cost";
 import {
   type DeployDatabaseRow,
@@ -578,8 +579,9 @@ export const selectDatabasesForTable = createSelector(
   selectDisks,
   selectServices,
   selectEndpointsAsList,
+  selectBackupsAsList,
   selectDatabaseImages,
-  (dbs, envs, ops, disks, services, endpoints, images) =>
+  (dbs, envs, ops, disks, services, endpoints, backups, images) =>
     dbs
       .map((dbb): DeployDatabaseRow => {
         const env = findEnvById(envs, { id: dbb.environmentId });
@@ -594,6 +596,7 @@ export const selectDatabasesForTable = createSelector(
           services: [service],
           disks: [disk],
           endpoints: findEndpointsByServiceId(endpoints, service.id),
+          backups: findBackupsByDatabaseId(backups, dbb.id),
         });
         const metrics = calcMetrics([service]);
         const img = findDatabaseImageById(images, { id: dbb.databaseImageId });

--- a/src/ui/hooks/use-paginate-backups.ts
+++ b/src/ui/hooks/use-paginate-backups.ts
@@ -14,9 +14,12 @@ export function usePaginatedBackupsByDatabaseId(dbId: string) {
   return usePaginatedBackups(action, page, setPage);
 }
 
-export function usePaginatedBackupsByEnvId(envId: string, orphaned: boolean) {
+export function usePaginatedBackupsByEnvId(
+  envId: string,
+  onlyOrphaned: boolean,
+) {
   const [page, setPage] = useState(1);
-  const action = fetchBackupsByEnvIdPage({ id: envId, orphaned, page });
+  const action = fetchBackupsByEnvIdPage({ id: envId, onlyOrphaned, page });
   return usePaginatedBackups(action, page, setPage);
 }
 

--- a/src/ui/pages/__snapshots__/app-detail-deployments.test.tsx.snap
+++ b/src/ui/pages/__snapshots__/app-detail-deployments.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`App Detail Deployments page > should render deployments with proper fal
       class="flex gap-4 flex-col "
     >
       <div>
-        <span
+        <div
           class=""
         >
-          <span
-            class="cursor-pointer"
+          <div
+            class="cursor-pointer w-fit"
           >
             <button
               class="w-fit flex items-center justify-center px-4 py-2 text-base font-medium border border-transparent shadow-sm font-bold text-black bg-gradient-to-r from-yellow-400 to-yellow-500 hover:no-underline hover:from-yellow hover:to-yellow focus:from-orange-400 focus:to-orange-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500 disabled:from-orange-200 disabled:to-orange-200 disabled:text-black-300 disabled:cursor-not-allowed rounded-md opacity-50"
@@ -22,8 +22,8 @@ exports[`App Detail Deployments page > should render deployments with proper fal
             >
               Deployment Monitor
             </button>
-          </span>
-        </span>
+          </div>
+        </div>
       </div>
       <div
         class="overflow-x-scroll w-full shadow ring-1 ring-black ring-opacity-5 rounded-lg"
@@ -125,11 +125,11 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                     <em>
                       Not Provided
                     </em>
-                    <span
+                    <div
                       class=""
                     >
-                      <span
-                        class="cursor-pointer"
+                      <div
+                        class="cursor-pointer w-fit"
                       >
                         <svg
                           class="opacity-50 hover:opacity-100"
@@ -164,8 +164,8 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                             y2="8"
                           />
                         </svg>
-                      </span>
-                    </span>
+                      </div>
+                    </div>
                   </div>
                 </td>
                 <td
@@ -244,11 +244,11 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                     <em>
                       Not Provided
                     </em>
-                    <span
+                    <div
                       class=""
                     >
-                      <span
-                        class="cursor-pointer"
+                      <div
+                        class="cursor-pointer w-fit"
                       >
                         <svg
                           class="opacity-50 hover:opacity-100"
@@ -283,8 +283,8 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                             y2="8"
                           />
                         </svg>
-                      </span>
-                    </span>
+                      </div>
+                    </div>
                   </div>
                 </td>
                 <td
@@ -355,19 +355,19 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                   <div
                     class="inline-block"
                   >
-                    <span
+                    <div
                       class=""
                     >
-                      <span
-                        class="cursor-pointer"
+                      <div
+                        class="cursor-pointer w-fit"
                       >
                         <p
                           class="leading-8 text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block"
                         >
                           fix(backup): pass page to fetch request (#754)
                         </p>
-                      </span>
-                    </span>
+                      </div>
+                    </div>
                   </div>
                 </td>
                 <td
@@ -443,11 +443,11 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                     <em>
                       Not Provided
                     </em>
-                    <span
+                    <div
                       class=""
                     >
-                      <span
-                        class="cursor-pointer"
+                      <div
+                        class="cursor-pointer w-fit"
                       >
                         <svg
                           class="opacity-50 hover:opacity-100"
@@ -482,8 +482,8 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                             y2="8"
                           />
                         </svg>
-                      </span>
-                    </span>
+                      </div>
+                    </div>
                   </div>
                 </td>
                 <td
@@ -554,19 +554,19 @@ exports[`App Detail Deployments page > should render deployments with proper fal
                   <div
                     class="inline-block"
                   >
-                    <span
+                    <div
                       class=""
                     >
-                      <span
-                        class="cursor-pointer"
+                      <div
+                        class="cursor-pointer w-fit"
                       >
                         <p
                           class="leading-8 text-ellipsis whitespace-nowrap max-w-[30ch] overflow-hidden inline-block"
                         >
                           fix(backup): pass page to fetch request (#754)
                         </p>
-                      </span>
-                    </span>
+                      </div>
+                    </div>
                   </div>
                 </td>
                 <td

--- a/src/ui/pages/environment-detail-settings.tsx
+++ b/src/ui/pages/environment-detail-settings.tsx
@@ -128,7 +128,6 @@ const EnvDestroy = ({ envId }: { envId: string }) => {
   useQuery(
     fetchBackupsByEnvIdPage({
       id: envId,
-      orphaned: false,
       page: 1,
       perPage: 1,
     }),

--- a/src/ui/pages/services.tsx
+++ b/src/ui/pages/services.tsx
@@ -1,5 +1,9 @@
-import { fetchServices, selectServicesForTableSearch } from "@app/deploy";
-import { useQuery, useSelector } from "@app/react";
+import {
+  fetchEndpoints,
+  fetchServices,
+  selectServicesForTableSearch,
+} from "@app/deploy";
+import { useCompositeLoader, useQuery, useSelector } from "@app/react";
 import type { DeployServiceRow } from "@app/types";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
@@ -17,6 +21,9 @@ import {
 } from "../shared";
 
 export function ServicesPage() {
+  const costQueries = [fetchServices(), fetchEndpoints()];
+  costQueries.forEach((q) => useQuery(q));
+  const { isLoading: isCostLoading } = useCompositeLoader(costQueries);
   const { isLoading } = useQuery(fetchServices());
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
@@ -58,6 +65,7 @@ export function ServicesPage() {
 
         <AppServicesByOrg
           paginated={paginated}
+          costLoading={isCostLoading}
           onSort={(key) => {
             if (key === sortBy) {
               setSortDir(sortDir === "asc" ? "desc" : "asc");

--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -54,7 +54,10 @@ export function StacksPage() {
   );
 }
 
-function StackListRow({ stack }: { stack: DeployStackRow }) {
+function StackListRow({
+  stack,
+  costLoading,
+}: { stack: DeployStackRow; costLoading: boolean }) {
   const envCount = useSelector((s) =>
     selectEnvironmentsCountByStack(s, { stackId: stack.id }),
   );
@@ -78,7 +81,7 @@ function StackListRow({ stack }: { stack: DeployStackRow }) {
       <Td variant="center">{appCount}</Td>
       <Td variant="center">{dbCount}</Td>
       <Td>
-        <CostEstimateTooltip cost={stack.cost} />
+        <CostEstimateTooltip cost={costLoading ? null : stack.cost} />
       </Td>
     </Tr>
   );
@@ -153,14 +156,17 @@ function StackList() {
           <Th variant="center">Databases</Th>
           <Th className="flex space-x-2">
             <div>Est. Monthly Cost</div>
-            <LoadingBar isLoading={isCostLoading} />
           </Th>
         </THead>
 
         <TBody>
           {paginated.data.length === 0 ? <EmptyTr colSpan={8} /> : null}
           {paginated.data.map((stack) => (
-            <StackListRow stack={stack} key={stack.id} />
+            <StackListRow
+              key={stack.id}
+              stack={stack}
+              costLoading={isCostLoading}
+            />
           ))}
         </TBody>
       </Table>

--- a/src/ui/shared/cost-estimate-tooltip.tsx
+++ b/src/ui/shared/cost-estimate-tooltip.tsx
@@ -1,12 +1,13 @@
 import { formatCurrency } from "@app/deploy";
 import type { ComponentProps } from "react";
 import { IconInfo } from "./icons";
+import { LoadingSpinner } from "./loading";
 import { Tooltip, type TooltipProps } from "./tooltip";
 
 export interface CostEstimateTooltipProps
   extends ComponentProps<"div">,
     Omit<TooltipProps, "text" | "children"> {
-  cost: number;
+  cost: number | null;
   text?: string;
 }
 
@@ -16,10 +17,12 @@ export const CostEstimateTooltip = ({
   ...tooltipProps
 }: CostEstimateTooltipProps) => (
   <Tooltip text={text} {...tooltipProps}>
-    <span className="mr-1">{formatCurrency(cost)}</span>
-    <IconInfo
-      className="inline-block mb-1 opacity-50 hover:opacity-100"
-      variant="sm"
-    />
+    <span className="flex space-x-1 items-center w-fit">
+      {cost == null ? <LoadingSpinner /> : <span>{formatCurrency(cost)}</span>}
+      <IconInfo
+        className="inline-block opacity-50 hover:opacity-100"
+        variant="sm"
+      />
+    </span>
   </Tooltip>
 );

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -101,8 +101,7 @@ const DatabaseIdCell = ({ database }: DatabaseCellProps) => {
 const DatabaseCostCell = ({
   database,
   costLoading,
-  fetchBackups = false,
-}: DatabaseCellProps & { costLoading: boolean; fetchBackups?: boolean }) => {
+}: DatabaseCellProps & { costLoading: boolean }) => {
   const loading =
     costLoading ||
     useQuery(fetchBackupsByDatabaseId({ id: database.id })).isLoading;
@@ -314,11 +313,7 @@ export const DatabaseListByOrg = () => {
               <EnvStackCell environmentId={db.environmentId} />
               <DatabaseDiskSizeCell database={db} />
               <DatabaseContainerSizeCell database={db} />
-              <DatabaseCostCell
-                database={db}
-                costLoading={isCostLoading}
-                fetchBackups={true}
-              />
+              <DatabaseCostCell database={db} costLoading={isCostLoading} />
               <DatabaseActionsCell database={db} />
             </Tr>
           ))}
@@ -451,11 +446,7 @@ export const DatabaseDependencyList = ({
               <EnvStackCell environmentId={db.environmentId} />
               <DatabaseDiskSizeCell database={db} />
               <DatabaseContainerSizeCell database={db} />
-              <DatabaseCostCell
-                database={db}
-                costLoading={isCostLoading}
-                fetchBackups={true}
-              />
+              <DatabaseCostCell database={db} costLoading={isCostLoading} />
               <Td>
                 <Tooltip placement="left" text={dep.why} fluid>
                   <Code>{dep.why}</Code>

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -103,13 +103,9 @@ const DatabaseCostCell = ({
   costLoading,
   fetchBackups = false,
 }: DatabaseCellProps & { costLoading: boolean; fetchBackups?: boolean }) => {
-  let loading = costLoading;
-  if (fetchBackups) {
-    const { isLoading } = useQuery(
-      fetchBackupsByDatabaseId({ id: database.id }),
-    );
-    loading ||= isLoading;
-  }
+  const loading =
+    costLoading ||
+    useQuery(fetchBackupsByDatabaseId({ id: database.id })).isLoading;
 
   const service = useSelector((s) =>
     selectServiceById(s, { id: database.serviceId }),

--- a/src/ui/shared/tooltip.tsx
+++ b/src/ui/shared/tooltip.tsx
@@ -51,14 +51,14 @@ export const Tooltip = ({
   ]);
 
   return (
-    <span className={className}>
-      <span
+    <div className={className}>
+      <div
         ref={refs.setReference}
         {...getReferenceProps()}
-        className="cursor-pointer"
+        className="cursor-pointer w-fit"
       >
         {children}
-      </span>
+      </div>
       {isOpen && (
         <div
           ref={refs.setFloating}
@@ -82,6 +82,6 @@ export const Tooltip = ({
           </div>
         </div>
       )}
-    </span>
+    </div>
   );
 };


### PR DESCRIPTION
- I ran through all the places we show a cost estimate to ensure all of the necessary data is being pulled especially backups since they're not loaded on bootup.
- Moved fetching backups to per-database and per-environment in their lists so that we don't have to wait on all backups to get estimates. Stack estimates still require waiting for all backups to be fetched.
- Moved the cost loading spinner from headers to the cost themselves to make it extra clear when the cost has finished calculating (see screenshot below).

<img width="198" alt="Screenshot 2024-08-23 at 16 37 48" src="https://github.com/user-attachments/assets/7a7bb148-6859-4c31-9521-91fa776daeb2">
