### PR TITLE
fix(env): show correct backup label on backups tab

### DIFF
--- a/src/ui/shared/db/backup-list.tsx
+++ b/src/ui/shared/db/backup-list.tsx
@@ -28,10 +28,10 @@ const BackupTypePill = ({
     "px-2 flex justify-between items-center w-fit",
   );
   let type = "";
-  if (final) {
-    type = "Final";
-  } else if (manual) {
+  if (manual) {
     type = "Manual";
+  } else if (final) {
+    type = "Final";
   } else {
     type = "Auto";
   }


### PR DESCRIPTION
https://github.com/aptible/deploy-ui/blob/7c738cfb80f8ffd3a7d70b27770e5181c552964c/app/components/backup-item/template.hbs#L8