### PR TITLE
chore: add CSP headers

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -45,6 +45,6 @@ http {
     add_header "X-Frame-Options" "DENY" always;
     add_header "X-Content-Type-Options" "nosniff";
     add_header "X-Permitted-Cross-Domain-Policies" "master-only";
+    add_header "Content-Security-Policy" "default-src 'self'; connect-src 'self' https://*.aptible.com https://*.aptible-sandbox.com https://*.aptible-staging.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self' https://*.aptible.com https://*.aptible-sandbox.com https://*.aptible-staging.com;";
   }
 }
-


### PR DESCRIPTION
## Summary
* chore: add CSP headers covering all Aptible sites

## Context
Adds CSP headers for all deployment stages.

## References
* https://app.shortcut.com/aptible/story/20750