### PR TITLE
Update plans to Development/Production/Enterprise without deploy-api code changes

### DIFF
--- a/src/app/test/no-payment-found.test.tsx
+++ b/src/app/test/no-payment-found.test.tsx
@@ -71,7 +71,7 @@ describe("Payment page takeover", () => {
                   {
                     ...testPlan,
                     id: fixedIdForTests,
-                    name: "growth",
+                    name: "production",
                   },
                   testEnterprisePlan,
                 ],
@@ -90,13 +90,13 @@ describe("Payment page takeover", () => {
       render(<App />);
 
       await screen.findByText(/Choose a Plan/);
-      await screen.findByText(/Growth/);
+      await screen.findByText(/Development/);
       const el = await screen.findAllByRole("button", {
         name: /Select Plan/,
       });
 
       fireEvent.click(el[0]);
-      await screen.findByText(/Successfully updated plan to Growth/);
+      await screen.findByText(/Successfully updated plan to Development/);
     });
   });
 
@@ -162,7 +162,7 @@ describe("Payment page takeover", () => {
                   {
                     ...testPlan,
                     id: fixedIdForTests,
-                    name: "growth",
+                    name: "production",
                   },
                   testEnterprisePlan,
                 ],

--- a/src/app/test/no-payment-found.test.tsx
+++ b/src/app/test/no-payment-found.test.tsx
@@ -71,7 +71,7 @@ describe("Payment page takeover", () => {
                   {
                     ...testPlan,
                     id: fixedIdForTests,
-                    name: "production",
+                    name: "development",
                   },
                   testEnterprisePlan,
                 ],
@@ -162,7 +162,7 @@ describe("Payment page takeover", () => {
                   {
                     ...testPlan,
                     id: fixedIdForTests,
-                    name: "production",
+                    name: "development",
                   },
                   testEnterprisePlan,
                 ],

--- a/src/deploy/plan/index.ts
+++ b/src/deploy/plan/index.ts
@@ -198,8 +198,10 @@ export const selectPlansForView = createSelector(
     const init: Record<PlanName, DeployPlan> = {
       none: defaultPlan({ name: "none" }),
       starter: defaultPlan({ name: "starter" }),
+      development: defaultPlan({ name: "development" }),
       growth: defaultPlan({ name: "growth" }),
       scale: defaultPlan({ name: "scale" }),
+      production: defaultPlan({ name: "production" }),
       enterprise: defaultPlan({ name: "enterprise" }),
     };
     return plans.reduce((acc, plan) => {

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -502,7 +502,7 @@ export const testEnterprisePlan = defaultPlanResponse({
 
 export const testActivePlan = defaultActivePlanResponse({
   id: createId(),
-  available_plans: ["growth", "scale"],
+  available_plans: ["development", "production"],
   organization_id: testOrg.id,
   _links: {
     organization: defaultHalHref(

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -488,7 +488,7 @@ export const defaultActivePlan = (
   return {
     id: "",
     automatedBackupLimitPerDb: 0,
-    availablePlans: ["starter", "growth", "scale"],
+    availablePlans: ["starter", "development", "growth", "scale", "production"],
     complianceDashboardAccess: false,
     containerMemoryLimit: 0,
     costCents: 0,

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -406,7 +406,14 @@ export interface DeployPrereleaseCommand extends Timestamps {
   index: number;
 }
 
-export type PlanName = "starter" | "growth" | "scale" | "enterprise" | "none";
+export type PlanName =
+  | "starter"
+  | "development"
+  | "growth"
+  | "scale"
+  | "production"
+  | "enterprise"
+  | "none";
 export interface DeployPlan extends Timestamps {
   id: string;
   automatedBackupLimitPerDb: number;

--- a/src/ui/pages/create-stack.tsx
+++ b/src/ui/pages/create-stack.tsx
@@ -87,9 +87,12 @@ export const CreateStackPage = () => {
   );
   // must have a non-starter active plan or,
   // an empty active plan (empty active plan means legacy enterprise)
-  const canRequestStack = ["growth", "scale", "enterprise"].includes(
-    selectedPlan.name,
-  );
+  const canRequestStack = [
+    "growth",
+    "scale",
+    "production",
+    "enterprise",
+  ].includes(selectedPlan.name);
 
   const [stackName, setStackName] = useState("");
   const [region, setRegion] = useState("none");
@@ -193,7 +196,7 @@ export const CreateStackPage = () => {
             {selectedPlan.id === "" || canRequestStack ? null : (
               <Banner variant="info">
                 Dedicated stacks are only available for{" "}
-                <strong>Growth, Scale, and Enterprise</strong> plans &mdash;{" "}
+                <strong>Production and Enterprise</strong> plans &mdash;{" "}
                 <Link to={plansUrl()}>Upgrade your plan for access.</Link>
               </Banner>
             )}

--- a/src/ui/pages/plans.test.tsx
+++ b/src/ui/pages/plans.test.tsx
@@ -62,7 +62,7 @@ const setupActionablePlanResponses = (extra: RestHandler[] = []) => {
               {
                 ...testPlan,
                 id: fixedIdForTests,
-                name: "growth",
+                name: "development",
               },
               testEnterprisePlan,
             ],
@@ -100,7 +100,7 @@ describe("Plans page", () => {
     );
     setupActionablePlanResponses();
     await screen.findByText("Choose a Plan");
-    await screen.findByText("Growth");
+    await screen.findByText("Development");
 
     const errText = screen.queryByText(
       "Unable to load plan data to allow for selection.",
@@ -112,7 +112,7 @@ describe("Plans page", () => {
     });
 
     fireEvent.click(el[0]);
-    await screen.findByText(/Successfully updated plan to Growth/);
+    await screen.findByText(/Successfully updated plan to Development/);
   });
 
   it("the plans page is visible, renders with plans found, but errors when user selects", async () => {
@@ -127,7 +127,7 @@ describe("Plans page", () => {
     );
 
     await screen.findByText("Choose a Plan");
-    await screen.findByText("Growth");
+    await screen.findByText("Development");
 
     const el = await screen.findAllByRole("button", {
       name: /Select Plan/,

--- a/src/ui/shared/plan.tsx
+++ b/src/ui/shared/plan.tsx
@@ -9,11 +9,17 @@ import { tokens } from "./tokens";
 const descriptionTextForPlan = (planName: PlanName): string =>
   ({
     none: "",
-    starter: "Deploy your app and get to market fast",
+    // Legacy
+    starter: "Get started in a limited trial environment",
     growth: "Gain user traction and deliver more functionality",
     scale: "Run mission-critical apps at scale without worry",
+
+    // Current
+    development: "Develop your prototype with a seamless path to production",
+    production:
+      "Go to production in your own private network with everything you need to meet compliance requirements",
     enterprise:
-      "Meet any requirement across performance, reliability, and security",
+      "Leverage Aptible at scale with enterprise features and support for additional compliance frameworks",
   })[planName];
 
 const Section = ({
@@ -79,20 +85,14 @@ const PlanButton = ({
 
 const PlanCostBlock = ({
   price,
-  max,
 }: {
   price: string;
-  max: string;
 }) => {
   return (
     <div className="flex justify-between mb-2">
       <div>
         <p>Starts at</p>
         <h3 className={tokens.type.h4}>{price}</h3>
-      </div>
-      <div>
-        <p>Approx. Max Invoice</p>
-        <h3 className={tokens.type.h4}>{max}</h3>
       </div>
     </div>
   );
@@ -123,7 +123,7 @@ const BulletListForPlan = ({
   if (plan.name === "starter") {
     return (
       <>
-        <PlanCostBlock price="0" max="$220.56" />
+        <PlanCostBlock price="$0/month" />
 
         <Section>
           <SectionItem className="font-semibold">Includes</SectionItem>
@@ -159,7 +159,7 @@ const BulletListForPlan = ({
   if (plan.name === "growth") {
     return (
       <>
-        <PlanCostBlock price="$185" max="$1,256.56" />
+        <PlanCostBlock price="$185/month" />
 
         <Section>
           <SectionItem className="font-semibold">Includes</SectionItem>
@@ -198,7 +198,7 @@ const BulletListForPlan = ({
   if (plan.name === "scale") {
     return (
       <>
-        <PlanCostBlock price="$599" max="$3,698.80" />
+        <PlanCostBlock price="$599/month" />
 
         <Section>
           <SectionItem className="font-semibold">Includes</SectionItem>
@@ -226,8 +226,39 @@ const BulletListForPlan = ({
             Up to 3 concurrent SSH Sessions for temporary container access
           </IconLi>
           <IconLi>Support: Choose from Standard or Premium</IconLi>
-          <IconLi>Dedicated Stacks (Isolated Tenancy) Available</IconLi>
+          <IconLi>Dedicated Stacks (Isolated Tenancy) available</IconLi>
           <IconLi>Available HIPAA BAA</IconLi>
+        </ul>
+      </>
+    );
+  }
+
+  if (plan.name === "development") {
+    return (
+      <>
+        <PlanCostBlock price="$0/month" />
+
+        <ul>
+          <IconLi>
+            No limits on available Compute, Database Storage, or Endpoints
+          </IconLi>
+          <IconLi>Standard Support</IconLi>
+        </ul>
+      </>
+    );
+  }
+
+  if (plan.name === "production") {
+    return (
+      <>
+        <PlanCostBlock price="$499/month" />
+
+        <ul>
+          <IconLi>Deploy in 15+ regions</IconLi>
+          <IconLi>Custom Domains for Apps</IconLi>
+          <IconLi>Dedicated Stacks (isolated tenancy) available</IconLi>
+          <IconLi>Available HIPAA BAA</IconLi>
+          <IconLi>Support: Choose from Standard or Premium</IconLi>
         </ul>
       </>
     );
@@ -235,42 +266,17 @@ const BulletListForPlan = ({
 
   return (
     <>
-      <PlanCostBlock price="Custom" max="Custom" />
-
-      <Section>
-        <SectionItem className="font-semibold">Includes</SectionItem>
-        <SectionItem className="font-semibold">Available</SectionItem>
-      </Section>
-
-      <Section title="Compute">
-        <SectionItem>Custom</SectionItem>
-        <SectionItem>Unlimited</SectionItem>
-      </Section>
-
-      <Section title="DB Storage">
-        <SectionItem>Custom</SectionItem>
-        <SectionItem>Unlimited</SectionItem>
-      </Section>
-
-      <Section title="Endpoints">
-        <SectionItem>Custom</SectionItem>
-        <SectionItem>Unlimited</SectionItem>
-      </Section>
+      <PlanCostBlock price="Custom Pricing" />
 
       <ul>
-        <IconLi>
-          No limits on available Compute, Database Storage, or Endpoints
-        </IconLi>
-        <IconLi>Deploy in 15+ Regions</IconLi>
         <IconLi>99.95% Uptime SLA</IconLi>
+        <IconLi>Advanced networking features like IPsec VPNs</IconLi>
+        <IconLi>Option to self-host in your AWS</IconLi>
         <IconLi>
-          Advanced Networking Features such as IPsec VPNs and VPC Peering
+          Available HITRUST inheritance and security & compliance consulting
         </IconLi>
         <IconLi>
-          Available HITRUST Inheritance and Security & Compliance Dashboard
-        </IconLi>
-        <IconLi>
-          Support: Choose from Standard, Premium, Enterprise (24/7 Support)
+          Support: Choose from Standard, Premium, Enterprise (24/7 response)
         </IconLi>
         <IconLi>
           Custom pricing and payment options with annual commitments and
@@ -349,53 +355,45 @@ export const Plans = ({
   paymentRequired: boolean;
 }) => {
   const plans = useSelector(selectPlansForView);
+  const publishedPlans = [
+    plans.development,
+    plans.production,
+    plans.enterprise,
+  ];
+
+  // Only show other plans (starter, growth, scale) if they are selected
+  let plansToShow: DeployPlan[] = publishedPlans;
+  if (selected === "starter") {
+    plansToShow = [plans.starter].concat(publishedPlans);
+  } else if (selected === "growth") {
+    plansToShow = [plans.growth].concat(publishedPlans);
+  } else if (selected === "scale") {
+    plansToShow = [plans.scale].concat(publishedPlans);
+  }
+
+  // Show 3 column layout if only 3 plans to show, otherwise 4 (when there should be 4 to show)
+  let col = "lg:grid-cols-3";
+  if (plansToShow.length > 3) {
+    col = "lg:grid-cols-4";
+  }
 
   return (
-    <div className="grid lg:grid-cols-4 md:grid-cols-2 grid-cols-1 gap-4 lg:mx-0 mx-10">
-      <PlanCard
-        plan={plans.starter}
-        available={activePlan.availablePlans.includes(plans.starter.name)}
-        selected={plans.starter.name === selected}
-        onSelectPlan={() =>
-          onSelectPlan({ planId: plans.starter.id, name: plans.starter.name })
-        }
-      />
-
-      <PlanCard
-        plan={plans.growth}
-        available={
-          !paymentRequired &&
-          activePlan.availablePlans.includes(plans.growth.name)
-        }
-        selected={plans.growth.name === selected}
-        onSelectPlan={() =>
-          onSelectPlan({ planId: plans.growth.id, name: plans.growth.name })
-        }
-      />
-
-      <PlanCard
-        plan={plans.scale}
-        available={
-          !paymentRequired &&
-          activePlan.availablePlans.includes(plans.scale.name)
-        }
-        selected={plans.scale.name === selected}
-        onSelectPlan={() =>
-          onSelectPlan({ planId: plans.scale.id, name: plans.scale.name })
-        }
-      />
-
-      <PlanCard
-        plan={plans.enterprise}
-        available={activePlan.availablePlans.includes(plans.enterprise.name)}
-        selected={plans.enterprise.name === selected}
-        onSelectPlan={() =>
-          onSelectPlan({
-            planId: plans.enterprise.id,
-            name: plans.enterprise.name,
-          })
-        }
-      />
+    <div
+      className={`grid ${col} md:grid-cols-2 grid-cols-1 gap-4 lg:mx-0 mx-10`}
+    >
+      {plansToShow.map((plan, index) => (
+        <PlanCard
+          key={plan.name}
+          plan={plan}
+          available={
+            !paymentRequired && activePlan.availablePlans.includes(plan.name)
+          }
+          selected={plan.name === selected}
+          onSelectPlan={() =>
+            onSelectPlan({ planId: plan.id, name: plan.name })
+          }
+        />
+      ))}
     </div>
   );
 };

--- a/src/ui/shared/plan.tsx
+++ b/src/ui/shared/plan.tsx
@@ -1,5 +1,5 @@
-import { selectPlansForView } from "@app/deploy";
-import { useSelector } from "@app/react";
+import { selectPlansForView, updateActivePlan } from "@app/deploy";
+import { useLoader, useSelector } from "@app/react";
 import { capitalize } from "@app/string-utils";
 import type { DeployActivePlan, DeployPlan, PlanName } from "@app/types";
 import { Button, ButtonLinkExternal } from "./button";
@@ -52,6 +52,7 @@ const PlanButton = ({
   onClick: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
   selected: boolean;
 }) => {
+  const loader = useLoader(updateActivePlan);
   if (contactUs) {
     return (
       <ButtonLinkExternal href="https://aptible.com/contact" className="w-full">
@@ -77,7 +78,7 @@ const PlanButton = ({
   }
 
   return (
-    <Button className="w-full" onClick={onClick}>
+    <Button className="w-full" onClick={onClick} isLoading={loader.isLoading}>
       Select Plan
     </Button>
   );
@@ -381,7 +382,7 @@ export const Plans = ({
     <div
       className={`grid ${col} md:grid-cols-2 grid-cols-1 gap-4 lg:mx-0 mx-10`}
     >
-      {plansToShow.map((plan, index) => (
+      {plansToShow.map((plan) => (
         <PlanCard
           key={plan.name}
           plan={plan}


### PR DESCRIPTION
This PR changes the plans we show on /plans to match . The new plans already exist in deploy-api in production (see related aptible/deploy-api#1586). Note that the new Development and Production plans **have no included resources and no base fee.** This is intentional, and should make it easier to simplify or deprecate `ActivePlans` in the future.

To show how the /plans change will change for existing users, I created a Notion doc showing the before/after for (nearly) every type of plan/payment info combination that exists today. 👉 [**QA: Changes to /plans** (Notion)](https://www.notion.so/aptible/QA-Changes-to-plans-120509e56b41805db918c165be910f8e)

The approach of making no changes to deploy-api has one downside: customers can "downgrade" to Development even if they have an existing dedicated stack. However, because this has no impact on their invoice (Development and Production both have no included resources and no base fee), combined with the fact that [a similar bug exists today](https://aptible.slack.com/archives/C05CMUW3LHX/p1729025967339289), I think this is acceptable.

To summarize, here are the expected acceptance criteria for this feature (each of which I've tested):

- ✅ A user without a payment method (i.e. a trial user) should not be able to upgrade to Development or Production
- ✅ A user currently on the Growth or Scale plan should be able to "upgrade" to Production
- ✅ A user currently on the Enterprise plan should not be able to switch plans
- ✅ A user should not see the Starter, Growth or Scale plans unless they are currently on that plan
- ✅ A user on the Starter, Growth or Scale plan should see that plan as "Current Plan"
- 🚫 A user with a dedicated stack should not be able to "downgrade" to Development (see above, I'm saying this is OK for now and we can create a ticket to fix later)


### Related PRs

- aptible/deploy-api#1586
- aptible/deploy-ui#797