### PR TITLE
Add scale_up_step and scale_down_step inputs for HAS

### DIFF
--- a/src/app/test/app-detail-service-scale.test.tsx
+++ b/src/app/test/app-detail-service-scale.test.tsx
@@ -240,12 +240,17 @@ describe("AppDetailServiceScalePage", () => {
         const scaleUpInput = await screen.findByLabelText(
           "Scale Up Threshold (CPU Usage)",
         );
+        const scaleUpStepInput = await screen.findByLabelText("Scale Up Steps");
+        const scaleDownStepInput =
+          await screen.findByLabelText("Scale Down Steps");
 
         // Check initial values
         expect(minContainersInput).toHaveValue(2);
         expect(maxContainersInput).toHaveValue(4);
         expect(scaleDownInput).toHaveValue(0.1);
         expect(scaleUpInput).toHaveValue(0.9);
+        expect(scaleDownStepInput).toHaveValue(1);
+        expect(scaleUpStepInput).toHaveValue(1);
 
         // Change the value to 1 should show a warning
         fireEvent.change(minContainersInput, { target: { value: 1 } });

--- a/src/deploy/service-sizing-policy/index.ts
+++ b/src/deploy/service-sizing-policy/index.ts
@@ -29,6 +29,8 @@ export interface DeployServiceSizingPolicyResponse {
   max_containers: number | null;
   min_cpu_threshold: number | null;
   max_cpu_threshold: number | null;
+  scale_up_step: number;
+  scale_down_step: number;
   created_at: string;
   updated_at: string;
   _links: {
@@ -61,6 +63,8 @@ export const defaultServiceSizingPolicyResponse = (
     max_containers: 4,
     min_cpu_threshold: 0.1,
     max_cpu_threshold: 0.9,
+    scale_up_step: 1,
+    scale_down_step: 1,
     created_at: now,
     updated_at: now,
     _type: "service_sizing_policy",
@@ -94,6 +98,8 @@ export const deserializeDeployServiceSizingPolicy = (
     maximumMemory: payload.maximum_memory,
     minContainers: payload.min_containers,
     maxContainers: payload.max_containers,
+    scaleUpStep: payload.scale_up_step,
+    scaleDownStep: payload.scale_down_step,
     minCpuThreshold: payload.min_cpu_threshold,
     maxCpuThreshold: payload.max_cpu_threshold,
     createdAt: payload.created_at,
@@ -155,6 +161,8 @@ export interface ServiceSizingPolicyEditProps {
   maxContainers: number | null;
   minCpuThreshold: number | null;
   maxCpuThreshold: number | null;
+  scaleUpStep: number;
+  scaleDownStep: number;
 }
 
 const serializeServiceSizingPolicyEditProps = (
@@ -177,6 +185,8 @@ const serializeServiceSizingPolicyEditProps = (
   max_containers: payload.maxContainers,
   min_cpu_threshold: payload.minCpuThreshold,
   max_cpu_threshold: payload.maxCpuThreshold,
+  scale_up_step: payload.scaleUpStep,
+  scale_down_step: payload.scaleDownStep,
 });
 
 export interface ModifyServiceSizingPolicyProps

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -702,6 +702,8 @@ export const defaultServiceSizingPolicy = (
     maxContainers: 4,
     minCpuThreshold: 0.1,
     maxCpuThreshold: 0.9,
+    scaleUpStep: 1,
+    scaleDownStep: 1,
     createdAt: now,
     updatedAt: now,
     ...m,

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -653,6 +653,8 @@ export interface DeployServiceSizingPolicy extends Timestamps {
   maxContainers: number | null;
   minCpuThreshold: number | null;
   maxCpuThreshold: number | null;
+  scaleUpStep: number;
+  scaleDownStep: number;
 }
 
 export interface DeploySource {

--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -134,6 +134,16 @@ const PolicySummary = ({
             value: policy.maxCpuThreshold?.toString() || "",
           },
         );
+        if (policy.scaleUpStep > 1)
+          data.push({
+            key: "Scale Up Steps",
+            value: policy.scaleUpStep.toString(),
+          });
+        if (policy.scaleDownStep > 1)
+          data.push({
+            key: "Scale Down Steps",
+            value: policy.scaleDownStep.toString(),
+          });
         break;
       case "vertical":
         data.push(
@@ -527,7 +537,7 @@ const AutoscalingSection = ({
                       </h2>
                       <FormGroup
                         splitWidthInputs
-                        description="Containers are scaled one at a time sequentially"
+                        description="Containers are scaled based on scale up steps, sequentially"
                         feedbackMessage={
                           errors.minContainers ||
                           ((nextPolicy.minContainers ?? 0) < 2
@@ -558,7 +568,7 @@ const AutoscalingSection = ({
                       </FormGroup>
                       <FormGroup
                         splitWidthInputs
-                        description="Containers are scaled one at a time sequentially"
+                        description="Containers are scaled based on scale up steps, sequentially"
                         feedbackMessage={errors.maxContainers}
                         feedbackVariant="danger"
                         label="Maximum Container Count"
@@ -575,6 +585,50 @@ const AutoscalingSection = ({
                           onChange={(e) =>
                             updatePolicy(
                               "maxContainers",
+                              Number.parseInt(e.currentTarget.value, 10),
+                            )
+                          }
+                        />
+                      </FormGroup>
+                      <FormGroup
+                        splitWidthInputs
+                        description="How many containers to increase by on an autoscale event"
+                        label="Scale Up Steps"
+                        htmlFor="scale-up-step"
+                      >
+                        <Input
+                          id="scale-up-step"
+                          name="scale-up-step"
+                          type="number"
+                          value={nextPolicy.scaleUpStep || "1"}
+                          min="1"
+                          max="9999"
+                          placeholder=""
+                          onChange={(e) =>
+                            updatePolicy(
+                              "scaleUpStep",
+                              Number.parseInt(e.currentTarget.value, 10),
+                            )
+                          }
+                        />
+                      </FormGroup>
+                      <FormGroup
+                        splitWidthInputs
+                        description="How many containers to decrease by on an autoscale event"
+                        label="Scale Down Steps"
+                        htmlFor="scale-down-step"
+                      >
+                        <Input
+                          id="scale-down-step"
+                          name="scale-down-step"
+                          type="number"
+                          value={nextPolicy.scaleDownStep || "1"}
+                          min="1"
+                          max="9999"
+                          placeholder=""
+                          onChange={(e) =>
+                            updatePolicy(
+                              "scaleDownStep",
                               Number.parseInt(e.currentTarget.value, 10),
                             )
                           }


### PR DESCRIPTION
Depends on https://github.com/aptible/deploy-api/pull/1593

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/82df151d-ca99-4661-8999-451c52ca33a4">
Also changed the policy summary, these new fields ONLY show up if they're not a value of `1`
<img width="990" alt="image" src="https://github.com/user-attachments/assets/fb466db1-0c3b-49e1-8d55-7961525c5361">
