### PR TITLE
block SCIM access for trial orgs

### DIFF
--- a/src/ui/shared/settings-sidebar.tsx
+++ b/src/ui/shared/settings-sidebar.tsx
@@ -21,6 +21,7 @@ import {
 } from "@app/routes";
 import cn from "classnames";
 import { NavLink } from "react-router-dom";
+import { useTrialNotice } from "../hooks/use-trial-notice";
 import { IconExternalLink, IconLock } from "./icons";
 import { tokens } from "./tokens";
 import { Tooltip } from "./tooltip";
@@ -37,6 +38,7 @@ export function SettingsSidebar() {
   const hasManyOrgs = useSelector(selectHasManyOrgs);
   const isAccountOwner = useSelector((s) => selectIsAccountOwner(s, { orgId }));
   const hasBetaFeatures = useSelector(selectHasBetaFeatures);
+  const { hasTrialNoPayment } = useTrialNotice();
 
   const navLink = ({ isActive }: { isActive: boolean }) =>
     cn(navButton, { [inactive]: !isActive, [active]: isActive });
@@ -112,7 +114,7 @@ export function SettingsSidebar() {
           </span>
         )}
 
-        {isAccountOwner && !hasManyOrgs ? (
+        {isAccountOwner && !hasManyOrgs && !hasTrialNoPayment ? (
           <NavLink className={navLink} to={teamScimUrl()}>
             Provisioning
           </NavLink>
@@ -120,7 +122,11 @@ export function SettingsSidebar() {
           <span className={navLink({ isActive: false })}>
             Provisioning
             <Tooltip
-              text="Must be account owner with a single assigned organization"
+              text={
+                hasTrialNoPayment
+                  ? "Feature not available for trial users"
+                  : "Must be account owner with a single assigned organization"
+              }
               fluid
             >
               <IconLock variant="sm" className="ml-1 opacity-60" />


### PR DESCRIPTION
Add conditional to prevent SCIM / Provisioning menu item when the organization is in trial with no payment:

<img width="387" alt="image" src="https://github.com/user-attachments/assets/5cf9989d-7f45-4cf0-9be3-b98acfa2fb88">

https://app.shortcut.com/aptible/story/29074/limit-scim-access-to-paid-plans-only