### PR TITLE
Do not send disk-size on DB scale unless it has changed

### DIFF
--- a/src/app/test/database-detail-scale.test.tsx
+++ b/src/app/test/database-detail-scale.test.tsx
@@ -5,6 +5,7 @@ import {
   server,
   stacksWithResources,
   testAccount,
+  testDatabaseOp,
   testDatabasePostgres,
   testDisk,
   testEnv,
@@ -113,6 +114,75 @@ describe("DatabaseScalePage", () => {
     expect(
       screen.queryByText(/Operations show real-time/),
     ).not.toBeInTheDocument();
+  });
+
+  describe("when disk size is not changed", () => {
+    it("does not send disk_size to API", async () => {
+      let lastRequestBody = { disk_size: 100 };
+
+      server.use(
+        rest.get(`${testEnv.apiUrl}/services/:id`, (_, res, ctx) => {
+          return res(ctx.json(testServicePostgres));
+        }),
+        rest.get(`${testEnv.apiUrl}/disks/:id`, async (_, res, ctx) => {
+          return res(ctx.json(testDisk));
+        }),
+        rest.get(`${testEnv.apiUrl}/operations/:id/logs`, (_, res, ctx) => {
+          return res(ctx.text("/mock"));
+        }),
+        rest.get(`${testEnv.apiUrl}/mock`, (_, res, ctx) => {
+          return res(ctx.text("complete"));
+        }),
+        rest.post(
+          `${testEnv.apiUrl}/databases/:id/operations`,
+          async (req, res, ctx) => {
+            lastRequestBody = await req.json();
+            return res(ctx.json(testDatabaseOp));
+          },
+        ),
+        ...verifiedUserHandlers(),
+        ...stacksWithResources({
+          accounts: [testAccount],
+          databases: [testDatabasePostgres],
+          services: [],
+        }),
+      );
+      const { App, store } = setupAppIntegrationTest({
+        initEntries: [databaseScaleUrl(`${testDatabasePostgres.id}`)],
+      });
+
+      await waitForBootup(store);
+
+      render(<App />);
+
+      await waitForEnv(store, testAccount.id);
+      await waitForData(store, (state) => {
+        return hasDeployDatabase(
+          selectDatabaseById(state, { id: `${testDatabasePostgres.id}` }),
+        );
+      });
+      await waitForData(store, (state) => {
+        return hasDeployService(
+          selectServiceById(state, { id: `${testServicePostgres.id}` }),
+        );
+      });
+
+      await screen.findByText(
+        /Optimize container performance with a custom profile./,
+      );
+      const btn = await screen.findByRole("button", { name: /Save Changes/ });
+      expect(btn).toBeDisabled();
+
+      const containerSize =
+        await screen.findByLabelText(/Memory per Container/);
+      await act(() => userEvent.selectOptions(containerSize, "4096"));
+
+      expect(btn).toBeEnabled();
+      fireEvent.click(btn);
+
+      expect(await screen.findByText("Database Details")).toBeInTheDocument();
+      expect(lastRequestBody.disk_size).toEqual(0);
+    });
   });
 
   describe("when changing container profile", () => {

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -599,6 +599,13 @@ export interface DatabaseScaleProps {
   containerSize?: number;
   containerProfile?: InstanceClass;
   recId?: string;
+  originalValues: DatabaseScaleOriginal;
+}
+
+export interface DatabaseScaleOriginal {
+  diskSize?: number;
+  containerSize?: number;
+  containerProfile?: InstanceClass;
 }
 
 export const restartDatabase = api.post<
@@ -660,6 +667,7 @@ export const scaleDatabase = api.post<
     containerProfile,
     containerSize,
     recId = "",
+    originalValues,
   } = ctx.payload;
   const db = yield* select((s: WebState) => selectDatabaseById(s, { id }));
   const service = yield* select((s: WebState) =>
@@ -669,10 +677,13 @@ export const scaleDatabase = api.post<
   const body = {
     type: "restart",
     id,
-    disk_size: diskSize,
+    disk_size: 0 as number | undefined,
     container_size: containerSize,
     instance_profile: containerProfile,
   };
+  if (originalValues.diskSize !== diskSize) {
+    body.disk_size = diskSize;
+  }
   ctx.request = ctx.req({ body: JSON.stringify(body) });
   yield* next();
 

--- a/src/ui/pages/database-detail-scale.tsx
+++ b/src/ui/pages/database-detail-scale.tsx
@@ -93,6 +93,11 @@ export const DatabaseScalePage = () => {
     id,
     recId: takingRec ? rec.id : "",
     ...scaler,
+    originalValues: {
+      diskSize: disk.size,
+      containerSize: service.containerMemoryLimitMb,
+      containerProfile: service.instanceClass,
+    },
   });
 
   const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => {


### PR DESCRIPTION
There's a validation on deploy-api to make sure there are 7 hours in-between disk resizes, but since we always send disk_size, the validation assumes ALL scale operations resize the disk. This fixes that