### PR TITLE
fix(metrics): always fetch the service's current release

### DIFF
--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -4,6 +4,7 @@ import {
   fetchDatabaseImageById,
   fetchDatabaseImages,
   fetchEndpointsByServiceId,
+  fetchRelease,
 } from "@app/deploy";
 import {
   calcMetrics,
@@ -66,6 +67,7 @@ export function DatabaseHeader({
   // Query additional data that subpages need
   useQuery(fetchEndpointsByServiceId({ id: database.serviceId }));
   useQuery(fetchBackupsByDatabaseId({ id: database.id }));
+  useQuery(fetchRelease({ id: service.currentReleaseId }));
 
   const metrics = calcMetrics([service]);
   useQuery(fetchDiskById({ id: database.diskId }));

--- a/src/ui/pages/app-detail-service-metrics.tsx
+++ b/src/ui/pages/app-detail-service-metrics.tsx
@@ -2,6 +2,7 @@ import { dateFromToday } from "@app/date";
 import {
   calcMetrics,
   fetchApp,
+  fetchRelease,
   selectReleasesByServiceAfterDate,
   selectServiceById,
 } from "@app/deploy";
@@ -47,6 +48,7 @@ export function AppDetailServiceMetricsPage() {
     }),
   );
   const service = useSelector((s) => selectServiceById(s, { id: serviceId }));
+  useQuery(fetchRelease({ id: service.currentReleaseId }));
 
   // we always go back exactly one week, though it might be a bit too far for some that way
   // we do not have to refetch this if the component state changes as this is fairly expensive


### PR DESCRIPTION
For any given App or DB service, we fetch a page's worth of Releases (e.g. 40 releases).  If a user performs a rollback to a previous release that is outside the last 40 releases then we were not pulling those metrics.

This PR ensures that we always fetch the current release for a service.