### PR TITLE
"Pending" isn't a valid operation status

### DIFF
--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -1,4 +1,4 @@
-import {
+RUNNimport {
   type FilterOpProps,
   type PaginateProps,
   type Retryable,
@@ -797,7 +797,7 @@ export const createReadableStatus = (status: OperationStatus): string => {
     case "queued":
       return "QUEUED";
     case "running":
-      return "PENDING";
+      return "RUNNING";
     case "succeeded":
       return "DONE";
     case "failed":


### PR DESCRIPTION
This was more of a nit before activity filtering made it obvious that "PENDING" isn't actually a status in the API
![Screenshot 2024-12-12 at 15 00 06](https://github.com/user-attachments/assets/0a75bd96-e9b8-499c-bc81-88e671b22911)

