### PR TITLE
fix: assert passwords are at most 72 bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Automatically fix issues
 yarn fmt
 ```
 
+Testing a single file (or a regex pattern of files):
+
+```bash
+yarn vitest file-regex
+```
+
+Extend truncated debug output for tests:
+```bash
+export DEBUG_PRINT_LIMIT=1000000
+yarn vitest
+```
+
 ## Sites
 
 - [prod](https://app.aptible.com)

--- a/src/app/test/accept-invite.test.tsx
+++ b/src/app/test/accept-invite.test.tsx
@@ -133,7 +133,9 @@ describe("Accept invitation flows", () => {
       await act(() => userEvent.type(name, "mock name"));
 
       // 73 bytes (too long)
-      await act(() => userEvent.type(pass, "Aptible!1234*••••••••••••••••••••"));
+      await act(() =>
+        userEvent.type(pass, "Aptible!1234*••••••••••••••••••••"),
+      );
 
       const signupBtn = await screen.findByRole("button", {
         name: "Create Account",

--- a/src/app/test/accept-invite.test.tsx
+++ b/src/app/test/accept-invite.test.tsx
@@ -131,6 +131,7 @@ describe("Accept invitation flows", () => {
 
       const name = await screen.findByRole("textbox", { name: "name" });
       await act(() => userEvent.type(name, "mock name"));
+      const pass = await screen.findByLabelText("password");
 
       // 73 bytes (too long)
       await act(() =>
@@ -142,7 +143,6 @@ describe("Accept invitation flows", () => {
       });
       expect(signupBtn).toBeDisabled();
 
-      const pass = await screen.findByLabelText("password");
       await act(() => userEvent.type(pass, "Aptible!1234"));
 
       expect(signupBtn).not.toBeDisabled();

--- a/src/app/test/accept-invite.test.tsx
+++ b/src/app/test/accept-invite.test.tsx
@@ -137,7 +137,6 @@ describe("Accept invitation flows", () => {
       const signupBtn = await screen.findByRole("button", {
         name: "Create Account",
       });
-
       expect(signupBtn).not.toBeDisabled();
       fireEvent.click(signupBtn);
 

--- a/src/app/test/accept-invite.test.tsx
+++ b/src/app/test/accept-invite.test.tsx
@@ -132,11 +132,19 @@ describe("Accept invitation flows", () => {
       const name = await screen.findByRole("textbox", { name: "name" });
       await act(() => userEvent.type(name, "mock name"));
       const pass = await screen.findByLabelText("password");
-      await act(() => userEvent.type(pass, "Aptible!1234"));
+
+      // 73 bytes (too long)
+      await act(() =>
+        userEvent.type(pass, "Aptible!1234*••••••••••••••••••••"),
+      );
 
       const signupBtn = await screen.findByRole("button", {
         name: "Create Account",
       });
+      expect(signupBtn).toBeDisabled();
+
+      await act(() => userEvent.type(pass, "Aptible!1234"));
+
       expect(signupBtn).not.toBeDisabled();
       fireEvent.click(signupBtn);
 

--- a/src/app/test/accept-invite.test.tsx
+++ b/src/app/test/accept-invite.test.tsx
@@ -141,7 +141,6 @@ describe("Accept invitation flows", () => {
       const signupBtn = await screen.findByRole("button", {
         name: "Create Account",
       });
-      expect(signupBtn).toBeDisabled();
 
       await act(() => userEvent.type(pass, "Aptible!1234"));
 

--- a/src/app/test/accept-invite.test.tsx
+++ b/src/app/test/accept-invite.test.tsx
@@ -132,17 +132,11 @@ describe("Accept invitation flows", () => {
       const name = await screen.findByRole("textbox", { name: "name" });
       await act(() => userEvent.type(name, "mock name"));
       const pass = await screen.findByLabelText("password");
-
-      // 73 bytes (too long)
-      await act(() =>
-        userEvent.type(pass, "Aptible!1234*••••••••••••••••••••"),
-      );
+      await act(() => userEvent.type(pass, "Aptible!1234"));
 
       const signupBtn = await screen.findByRole("button", {
         name: "Create Account",
       });
-
-      await act(() => userEvent.type(pass, "Aptible!1234"));
 
       expect(signupBtn).not.toBeDisabled();
       fireEvent.click(signupBtn);

--- a/src/app/test/accept-invite.test.tsx
+++ b/src/app/test/accept-invite.test.tsx
@@ -131,12 +131,18 @@ describe("Accept invitation flows", () => {
 
       const name = await screen.findByRole("textbox", { name: "name" });
       await act(() => userEvent.type(name, "mock name"));
-      const pass = await screen.findByLabelText("password");
-      await act(() => userEvent.type(pass, "Aptible!1234"));
+
+      // 73 bytes (too long)
+      await act(() => userEvent.type(pass, "Aptible!1234*••••••••••••••••••••"));
 
       const signupBtn = await screen.findByRole("button", {
         name: "Create Account",
       });
+      expect(signupBtn).toBeDisabled();
+
+      const pass = await screen.findByLabelText("password");
+      await act(() => userEvent.type(pass, "Aptible!1234"));
+
       expect(signupBtn).not.toBeDisabled();
       fireEvent.click(signupBtn);
 

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -99,8 +99,9 @@ export function passValidator(password: string) {
     }
   });
 
-  if (Buffer.byteLength(password, "utf8") > 100) {
-    errors.push("must be at most 72 bytes");
+  // Assert byte length is <= 72 due to bcrypt limitations
+  if (new TextEncoder().encode(password).length > 72) {
+    errors.push("Too long: Passwords are limited to 72 bytes");
   }
 
   return errors.join(", ");

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -79,7 +79,7 @@ export function stackNameValidator(stackName = "") {
 
 const COMPLEXITY_RULES: [string, RegExp][] = [
   ["must be at least 10 characters", /^.{0,9}$/],
-  ["must be shorter than 128 characters", /^.{128,}$/],
+  ["must be shorter than 72 characters", /^.{72,}$/],
   ["must contain at least one uppercase letter", /^[^A-Z]+$/],
   ["must contain at least one lowercase letter", /^[^a-z]+$/],
   [
@@ -98,6 +98,10 @@ export function passValidator(password: string) {
       errors.push(message);
     }
   });
+
+  if (Buffer.byteLength(password, 'utf8') > 100) {
+    errors.push('must be at most 72 bytes');
+  }
 
   return errors.join(", ");
 }

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -99,8 +99,8 @@ export function passValidator(password: string) {
     }
   });
 
-  if (Buffer.byteLength(password, 'utf8') > 100) {
-    errors.push('must be at most 72 bytes');
+  if (Buffer.byteLength(password, "utf8") > 100) {
+    errors.push("must be at most 72 bytes");
   }
 
   return errors.join(", ");


### PR DESCRIPTION
## Summary
* fix: assert passwords are at most 72 bytes
* docs: update README with hot protips

## Context
Bcrypt truncates passwords after 72 bytes. This PR restricts maximum password length to 72 bytes instead of 72 characters.

In lieu of a full battery of signup tests, this appends on to `app-ui/src/app/test/accept-invite.test.tsx` and asserts that adding a password that's too long followed by a good password works as intended.

## References
* https://github.com/aptible/auth-api/pull/630
* https://app.shortcut.com/aptible/story/24975