### PR TITLE
Allow the deploy job to be triggered manually

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,12 @@ name: deploy
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Docker image tag to deploy'
+        required: true
+        type: string
 
 jobs:
   build:
@@ -22,6 +28,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: quay.io/aptible/cloud-ui
+          tags: |
+            type=raw,value=${{ github.event.inputs.tag || github.ref_name }}
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v2
@@ -45,11 +53,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: aptible/aptible-deploy-action@v4
-        if: startsWith(github.ref, 'refs/tags/v')
         with:
           app: 'app-ui'
           environment: 'aptible-production'
-          docker_img: 'quay.io/aptible/cloud-ui:${{ github.ref_name }}'
+          docker_img: 'quay.io/aptible/cloud-ui:${{ github.event.inputs.tag || github.ref_name }}'
           docker_repository_url: https://quay.io/repository/aptible/cloud-ui
           username: ${{ secrets.APTIBLE_ROBOT_USERNAME }}
           password: ${{ secrets.APTIBLE_ROBOT_PASSWORD }}


### PR DESCRIPTION
This PR adds a `workflow_dispatch` trigger to the deploy workflow to enable it to be triggered manually.