### PR TITLE
Fix a hook usage violation

### DIFF
--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -172,8 +172,8 @@ function AppPageHeader() {
   const crumbs = [
     { name: environment.handle, to: environmentAppsUrl(environment.id) },
   ];
-  const hasBetaFeatures =
-    useSelector(selectHasBetaFeatures) || useSelector(selectIsImpersonated);
+  const isImpersonated = useSelector(selectIsImpersonated);
+  const hasBetaFeatures = useSelector(selectHasBetaFeatures) || isImpersonated;
   const hasConfigAccess = useSelector((s) =>
     selectUserHasPerms(s, { envId: app.environmentId, scope: "read" }),
   );

--- a/src/ui/shared/application-sidebar.tsx
+++ b/src/ui/shared/application-sidebar.tsx
@@ -62,8 +62,8 @@ export const ApplicationSidebar = () => {
   const hasSystemStatus =
     systemStatus?.description && systemStatus?.indicator !== "none";
   const navigate = useNavigate();
-  const hasBetaFeatures =
-    useSelector(selectHasBetaFeatures) || useSelector(selectIsImpersonated);
+  const isImpersonated = useSelector(selectIsImpersonated);
+  const hasBetaFeatures = useSelector(selectHasBetaFeatures) || isImpersonated;
   const navigation = [
     { name: "Stacks", to: stacksUrl(), icon: <IconLayers /> },
     { name: "Environments", to: environmentsUrl(), icon: <IconGlobe /> },


### PR DESCRIPTION
This PR fixes an issue that was causing an intermittent error when refreshing the page in some parts of the app.

In React, you can't call hooks conditionally. For whatever reason, this particular style of conditional use was not caught by any of the local development guardrails, and does not raise an error until built into a production bundle.