### PR TITLE
Remove quotes from build-args in the deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
             VITE_SENTRY_DSN=${{ secrets.PROD_SENTRY_DSN }}
             VITE_ORIGIN=app
             VITE_METRIC_TUNNEL_URL=https://metrictunnel-nextgen.aptible.com
-            VITE_APTIBLE_AI_URL="wss://app-86559.on-aptible.com"
+            VITE_APTIBLE_AI_URL=wss://app-86559.on-aptible.com
             VITE_TUNA_ENABLED=true
             VITE_MINTLIFY_CHAT_KEY=${{ secrets.MINTLIFY_CHAT_KEY }}
             VITE_STRIPE_PUBLISHABLE_KEY=${{ secrets.STRIPE_PUBLISHABLE_KEY }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -32,7 +32,7 @@ jobs:
             VITE_LEGACY_DASHBOARD_URL=https://dashboard-sbx-main.aptible-sandbox.com
             VITE_METRIC_TUNNEL_URL=https://metrictunnel-sbx-main.aptible-sandbox.com
             VITE_PORTAL_URL=https://portal-sbx-main.aptible-sandbox.com
-            VITE_APTIBLE_AI_URL="wss://app-86559.on-aptible.com"
+            VITE_APTIBLE_AI_URL=wss://app-86559.on-aptible.com
             SENTRY_AUTH_TOKEN=${{ secrets.STAGING_SENTRY_AUTH_TOKEN }}
             SENTRY_ORG=aptible
             SENTRY_PROJECT=app-ui-sbx-main


### PR DESCRIPTION
Apparently the `build-args` option of the `docker/build-push-action` treats quotes literally. This PR removes them for the `VITE_APTIBLE_AI_URL` values.