### PR TITLE
Force chart annotations to be an array

### DIFF
--- a/src/chart/chartjs-plugin-annotations.ts
+++ b/src/chart/chartjs-plugin-annotations.ts
@@ -23,7 +23,7 @@ export const annotationsPlugin = {
   id: "annotations",
   afterDraw: (chart: ChartJS, args: any, options: any) => {
     const ctx = chart.ctx;
-    const annotations = chart.options?.plugins?.annotations || [];
+    const annotations = Array.from(chart.options?.plugins?.annotations || []);
 
     annotations.forEach((annotation: any) => {
       // Convert timestamps to numbers for the time scale


### PR DESCRIPTION
Fixes an error where charts would not display if there were no annotations: https://aptible.slack.com/archives/C03R1L20YSW/p1738860094160489