### PR TITLE
Clear synchronized ChartJS popovers when the mouse leaves a chart

### DIFF
--- a/src/ui/shared/diagnostics/line-chart.tsx
+++ b/src/ui/shared/diagnostics/line-chart.tsx
@@ -105,6 +105,19 @@ export const DiagnosticsLineChart = ({
     chart.update();
   }, [timestamp, labels, datasets]);
 
+  // Reset the timestamp when the mouse leaves the chart
+  useEffect(() => {
+    const chart = chartRef.current?.canvas;
+    if (!chart) return;
+
+    const onMouseOut = () => setTimestamp(null);
+    chart.addEventListener("mouseout", onMouseOut);
+
+    return () => {
+      chart.removeEventListener("mouseout", onMouseOut);
+    };
+  }, [setTimestamp]);
+
   const formatYAxisTick = (value: number, unit?: string) => {
     const unitStr = unit?.trim() ?? "";
 


### PR DESCRIPTION
This PR fixes [#31132](https://app.shortcut.com/aptible/story/31132/synchronized-chart-popovers-don-t-disappear-when-a-user-stops-hovering), where synchronized chart popovers would remain even after the user's mouse stops hovering a chart.

![hover-popovers-fixed](https://github.com/user-attachments/assets/475319d4-7d4f-4922-86a1-c5bc5a2754b3)
