### PR TITLE
Diagnostics chart cleanup

### DIFF
--- a/src/ui/shared/diagnostics/resource.tsx
+++ b/src/ui/shared/diagnostics/resource.tsx
@@ -1,5 +1,6 @@
 import type { Resource } from "@app/aptible-ai";
 import type React from "react";
+import { useState } from "react";
 import {
   IconBox,
   IconCloud,
@@ -28,6 +29,43 @@ const ResourceIcon = ({ type }: { type: Resource["type"] }) => {
     default:
       return <IconCloud />;
   }
+};
+
+const AnalysisSection = ({ analysis }: { analysis: string }) => {
+  const [showAnalysis, setShowAnalysis] = useState(false);
+  const toggleAnalysis = () => setShowAnalysis((show) => !show);
+  const getAnalysisText = (analysis: string) => {
+    if (!showAnalysis) return `${analysis.slice(0, 75).trim()} [...]`;
+    return analysis;
+  };
+  const analysisText = getAnalysisText(analysis);
+
+  if (!analysis) return null;
+
+  return (
+    <div
+      className="mt-4 bg-orange-100 p-3 rounded-md cursor-pointer"
+      onClick={toggleAnalysis}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggleAnalysis();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="flex items-start gap-2">
+        <IconInfo className="w-4 h-4 mt-1 text-yellow-600 flex-shrink-0" />
+        <div>
+          <p className="text-gray-600">
+            <strong className="mr-1">Analysis:</strong>
+            {analysisText}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export const DiagnosticsResource = ({
@@ -88,20 +126,7 @@ export const DiagnosticsResource = ({
                   <h4 className="font-medium text-gray-900 p-3 rounded-t-lg border-b">
                     {plot.title}
                   </h4>
-                  <div className="p-6">
-                    {plot.interpretation && (
-                      <div className="mt-4 bg-orange-100 p-3 rounded-md">
-                        <div className="flex items-start gap-2">
-                          <IconInfo className="w-4 h-4 mt-1 text-yellow-600 flex-shrink-0" />
-                          <div>
-                            <p className="text-gray-600">
-                              <strong className="mr-1">Interpretation:</strong>
-                              {plot.interpretation}
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    )}
+                  <div className="pb-6 px-6">
                     <div className="mt-2 min-h-[200px]">
                       <DiagnosticsLineChart
                         showLegend={true}
@@ -124,14 +149,7 @@ export const DiagnosticsResource = ({
                         synchronizedHoverContext={synchronizedHoverContext}
                       />
                     </div>
-                    {plot.analysis && (
-                      <div className="mt-4">
-                        <p className="mt-1 text-gray-500 text-xs">
-                          <strong>Analysis: </strong>
-                          {plot.analysis}
-                        </p>
-                      </div>
-                    )}
+                    <AnalysisSection analysis={plot.analysis} />
                   </div>
                 </div>
               ))}

--- a/src/ui/shared/diagnostics/resource.tsx
+++ b/src/ui/shared/diagnostics/resource.tsx
@@ -118,7 +118,7 @@ export const DiagnosticsResource = ({
                           })),
                         }}
                         xAxisUnit="minute"
-                        yAxisLabel={plot.title}
+                        yAxisLabel={undefined}
                         yAxisUnit={plot.unit}
                         annotations={plot.annotations}
                         synchronizedHoverContext={synchronizedHoverContext}


### PR DESCRIPTION
This PR cleans up the charts on the diagnostic dashboard page: 

- Removes the Y axis label since it's represented in the tick labels
- Remove the interpretation section (it's for the LLM) and use its styling for a toggleable analysis section instead

> ⚠️ Note: this pairs with https://github.com/aptible/hotshot/pull/11, which adds some fidelity to the plot title.

## Before

<img width="1912" alt="Screenshot 2025-02-07 at 5 46 48 PM" src="https://github.com/user-attachments/assets/9e350c56-f2a4-4d71-9692-922892f31b8b" />

## After

<img width="1912" alt="Screenshot 2025-02-07 at 5 41 10 PM" src="https://github.com/user-attachments/assets/7c7651ab-f101-48d3-a0ab-87a052de0ecf" />
