### PR TITLE
Fix chart axes and improper combination

### DIFF
--- a/src/aptible-ai/index.ts
+++ b/src/aptible-ai/index.ts
@@ -84,6 +84,8 @@ export interface Plot {
   unit: string;
   series: Series[];
   annotations: Annotation[];
+  x_axis_range: [string, string];
+  y_axis_range: [number, number];
 }
 
 export interface Resource {

--- a/src/ui/hooks/use-dashboard.ts
+++ b/src/ui/hooks/use-dashboard.ts
@@ -56,6 +56,8 @@ const handleDashboardEvent = (
                 unit: event.plot.unit,
                 series: event.plot.series,
                 annotations: event.plot.annotations,
+                x_axis_range: event.plot.x_axis_range,
+                y_axis_range: event.plot.y_axis_range,
               },
             },
           },

--- a/src/ui/shared/diagnostics/line-chart.tsx
+++ b/src/ui/shared/diagnostics/line-chart.tsx
@@ -54,7 +54,7 @@ export const DiagnosticsLineChart = ({
     labels: string[];
     datasets: Array<{
       label: string;
-      data: number[];
+      data: { x: string; y: number }[];
     }>;
   };
   xAxisMin: string;
@@ -68,7 +68,8 @@ export const DiagnosticsLineChart = ({
   synchronizedHoverContext: React.Context<HoverState>;
 }) => {
   const { timestamp, setTimestamp } = useContext(synchronizedHoverContext);
-  const chartRef = React.useRef<ChartJS<"line">>();
+  const chartRef =
+    React.useRef<ChartJS<"line", { x: string; y: number }[], unknown>>();
 
   // Truncate sha256 resource names to 8 chars
   const datasets = originalDatasets.map((dataset) => ({

--- a/src/ui/shared/diagnostics/line-chart.tsx
+++ b/src/ui/shared/diagnostics/line-chart.tsx
@@ -37,7 +37,11 @@ export const DiagnosticsLineChart = ({
   showLegend = true,
   keyId,
   chart: { labels, datasets: originalDatasets, title },
+  xAxisMin,
+  xAxisMax,
   xAxisUnit,
+  yAxisMin,
+  yAxisMax,
   yAxisLabel,
   yAxisUnit,
   annotations = [],
@@ -53,7 +57,11 @@ export const DiagnosticsLineChart = ({
       data: number[];
     }>;
   };
+  xAxisMin: string;
+  xAxisMax: string;
   xAxisUnit: TimeUnit;
+  yAxisMin?: number;
+  yAxisMax?: number;
   yAxisLabel?: string;
   yAxisUnit?: string;
   annotations?: Annotation[];
@@ -195,6 +203,8 @@ export const DiagnosticsLineChart = ({
         },
         scales: {
           x: {
+            min: xAxisMin,
+            max: xAxisMax,
             border: {
               color: "#111920",
             },
@@ -224,7 +234,8 @@ export const DiagnosticsLineChart = ({
             type: "time",
           },
           y: {
-            min: 0,
+            min: yAxisMin ?? 0,
+            max: yAxisMax,
             border: {
               display: false,
             },

--- a/src/ui/shared/diagnostics/resource.tsx
+++ b/src/ui/shared/diagnostics/resource.tsx
@@ -142,6 +142,8 @@ export const DiagnosticsResource = ({
                             data: series.points.map((point) => point.value),
                           })),
                         }}
+                        xAxisMin={plot.x_axis_range[0]}
+                        xAxisMax={plot.x_axis_range[1]}
                         xAxisUnit="minute"
                         yAxisLabel={undefined}
                         yAxisUnit={plot.unit}

--- a/src/ui/shared/diagnostics/resource.tsx
+++ b/src/ui/shared/diagnostics/resource.tsx
@@ -139,7 +139,10 @@ export const DiagnosticsResource = ({
                             ) || [],
                           datasets: plot.series.map((series) => ({
                             label: series.label,
-                            data: series.points.map((point) => point.value),
+                            data: series.points.map((point) => ({
+                              x: point.timestamp,
+                              y: point.value,
+                            })),
                           })),
                         }}
                         xAxisMin={plot.x_axis_range[0]}


### PR DESCRIPTION
This PR fixes a subtle bug that was causing axes of the charts to become misaligned, and sometimes rendering charts with multiple series improperly.

Here's an example, where the `billing_events` service of `sbx-main-deploy-api-background` had restarted with a new container ID. The existing implementation overlays the series, even though the second container's metrics should come after the first.

## Before
<img width="728" alt="Screenshot 2025-02-10 at 4 12 06 PM" src="https://github.com/user-attachments/assets/a8b5f1d4-3c23-4787-9add-44a83b43d54e" />

## After
<img width="726" alt="Screenshot 2025-02-10 at 4 11 07 PM" src="https://github.com/user-attachments/assets/3f202a68-8616-42fd-8d5b-0d689f0ae10e" />

