### PR TITLE
Update autoscaling UI wording and defaults for post release cooldown

### DIFF
--- a/src/deploy/service-sizing-policy/index.ts
+++ b/src/deploy/service-sizing-policy/index.ts
@@ -52,7 +52,7 @@ export const defaultServiceSizingPolicyResponse = (
     percentile: 99,
     post_scale_up_cooldown_seconds: 60,
     post_scale_down_cooldown_seconds: 300,
-    post_release_cooldown_seconds: 300,
+    post_release_cooldown_seconds: 60,
     mem_cpu_ratio_r_threshold: 4,
     mem_cpu_ratio_c_threshold: 2,
     mem_scale_up_threshold: 0.9,

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -705,7 +705,7 @@ export const defaultServiceSizingPolicy = (
     percentile: 99,
     postScaleUpCooldownSeconds: 60,
     postScaleDownCooldownSeconds: 300,
-    postReleaseCooldownSeconds: 300,
+    postReleaseCooldownSeconds: 60,
     memCpuRatioRThreshold: 4,
     memCpuRatioCThreshold: 2,
     memScaleUpThreshold: 0.9,

--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -793,7 +793,7 @@ const AutoscalingSection = ({
                   </FormGroup>
                   <FormGroup
                     splitWidthInputs
-                    description="The number of seconds to wait after a general scale to potentially take another action"
+                    description="The number of seconds ignore in metrics after a scale event to allow for service stabilization"
                     label="Post Release Cooldown"
                     htmlFor="release-cooldown"
                   >


### PR DESCRIPTION
This won't actually go out until the deploy-api side is released, but in preparation, we want to make sure the interfaces have updated language and defaults.

https://github.com/aptible/deploy-api/pull/1684 and https://aptible.slack.com/archives/C022BUSF0B1/p1738846349350639 for full context.