### PR TITLE
Add support for displaying correlated anomalies and summaries for diagnostic dashboards

### DIFF
--- a/src/ui/hooks/use-dashboard.ts
+++ b/src/ui/hooks/use-dashboard.ts
@@ -1,4 +1,4 @@
-import type { Message, Resource } from "@app/aptible-ai";
+import type { Message, Plot, Resource } from "@app/aptible-ai";
 import { selectAptibleAiUrl } from "@app/config";
 import { useSelector } from "@app/react";
 import { selectAccessToken } from "@app/token";
@@ -10,6 +10,8 @@ type Dashboard = {
     [key: string]: Resource;
   };
   messages: Message[];
+  summary: string;
+  ranked_plots: Plot[];
 };
 
 type UseDashboardParams = {
@@ -107,6 +109,12 @@ const handleDashboardEvent = (
           },
         ],
       };
+    case "SummaryGenerated":
+      return {
+        ...dashboard,
+        summary: event.summary,
+        ranked_plots: event.plots,
+      };
     default:
       console.log(`Unhandled event type ${event?.type}`, event);
       return dashboard;
@@ -125,6 +133,8 @@ export const useDashboard = ({
   const [dashboard, setDashboard] = useState<Dashboard>({
     resources: {},
     messages: [],
+    summary: "",
+    ranked_plots: [],
   });
   const [hasShownCompletion, setHasShownCompletion] = useState(false);
 

--- a/src/ui/hooks/use-dashboard.ts
+++ b/src/ui/hooks/use-dashboard.ts
@@ -150,6 +150,9 @@ export const useDashboard = ({
         start_time: startTime,
         end_time: endTime,
       },
+      heartbeat: {
+        timeout: 60000 * 30, // 30 minutes
+      },
     },
     socketConnected,
   );

--- a/src/ui/pages/diagnostics-detail.tsx
+++ b/src/ui/pages/diagnostics-detail.tsx
@@ -5,9 +5,9 @@ import { useDashboard } from "../hooks/use-dashboard";
 import { AppSidebarLayout } from "../layouts";
 import { Breadcrumbs } from "../shared";
 import { HoverContext } from "../shared/diagnostics/hover";
+import { DiagnosticsLineChart } from "../shared/diagnostics/line-chart";
 import { DiagnosticsMessages } from "../shared/diagnostics/messages";
 import { DiagnosticsResource } from "../shared/diagnostics/resource";
-import { DiagnosticsLineChart } from "../shared/diagnostics/line-chart";
 
 export const DiagnosticsDetailPage = () => {
   const [searchParams] = useSearchParams();
@@ -60,39 +60,47 @@ export const DiagnosticsDetailPage = () => {
               <h2 className="text-lg font-semibold">Summary</h2>
               <div className="text-gray-500">{dashboard.summary}</div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
-                {Object.entries(dashboard.ranked_plots).map(([plotId, plot]) => (
-                  <div key={plotId} className="border rounded-lg bg-white shadow-sm animate-fade-in">
-                    <h3 className="font-medium text-gray-900 p-3 rounded-t-lg border-b">
-                      {plot.title}
-                    </h3>
-                    <div className="pb-6 px-6">
-                      <div className="mt-2 min-h-[200px]">
-                        <DiagnosticsLineChart
-                          showLegend={true}
-                          keyId={plot.id}
-                          chart={{
-                            title: " ",
-                            labels: plot.series[0]?.points.map((point) => point.timestamp) || [],
-                            datasets: plot.series.map((series) => ({
-                              label: series.label,
-                              data: series.points.map((point) => ({
-                                x: point.timestamp,
-                                y: point.value,
+                {Object.entries(dashboard.ranked_plots).map(
+                  ([plotId, plot]) => (
+                    <div
+                      key={plotId}
+                      className="border rounded-lg bg-white shadow-sm animate-fade-in"
+                    >
+                      <h3 className="font-medium text-gray-900 p-3 rounded-t-lg border-b">
+                        {plot.title}
+                      </h3>
+                      <div className="pb-6 px-6">
+                        <div className="mt-2 min-h-[200px]">
+                          <DiagnosticsLineChart
+                            showLegend={true}
+                            keyId={plot.id}
+                            chart={{
+                              title: " ",
+                              labels:
+                                plot.series[0]?.points.map(
+                                  (point) => point.timestamp,
+                                ) || [],
+                              datasets: plot.series.map((series) => ({
+                                label: series.label,
+                                data: series.points.map((point) => ({
+                                  x: point.timestamp,
+                                  y: point.value,
+                                })),
                               })),
-                            })),
-                          }}
-                          xAxisMin={plot.x_axis_range[0]}
-                          xAxisMax={plot.x_axis_range[1]}
-                          xAxisUnit="minute"
-                          yAxisLabel={undefined}
-                          yAxisUnit={plot.unit}
-                          annotations={plot.annotations}
-                          synchronizedHoverContext={HoverContext}
-                        />
+                            }}
+                            xAxisMin={plot.x_axis_range[0]}
+                            xAxisMax={plot.x_axis_range[1]}
+                            xAxisUnit="minute"
+                            yAxisLabel={undefined}
+                            yAxisUnit={plot.unit}
+                            annotations={plot.annotations}
+                            synchronizedHoverContext={HoverContext}
+                          />
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ))}
+                  ),
+                )}
               </div>
             </>
           )}

--- a/src/ui/pages/diagnostics-detail.tsx
+++ b/src/ui/pages/diagnostics-detail.tsx
@@ -7,6 +7,7 @@ import { Breadcrumbs } from "../shared";
 import { HoverContext } from "../shared/diagnostics/hover";
 import { DiagnosticsMessages } from "../shared/diagnostics/messages";
 import { DiagnosticsResource } from "../shared/diagnostics/resource";
+import { DiagnosticsLineChart } from "../shared/diagnostics/line-chart";
 
 export const DiagnosticsDetailPage = () => {
   const [searchParams] = useSearchParams();
@@ -53,6 +54,48 @@ export const DiagnosticsDetailPage = () => {
             showAllMessages={showAllMessages}
             setShowAllMessages={setShowAllMessages}
           />
+
+          {dashboard.summary && (
+            <>
+              <h2 className="text-lg font-semibold">Summary</h2>
+              <div className="text-gray-500">{dashboard.summary}</div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-2">
+                {Object.entries(dashboard.ranked_plots).map(([plotId, plot]) => (
+                  <div key={plotId} className="border rounded-lg bg-white shadow-sm animate-fade-in">
+                    <h3 className="font-medium text-gray-900 p-3 rounded-t-lg border-b">
+                      {plot.title}
+                    </h3>
+                    <div className="pb-6 px-6">
+                      <div className="mt-2 min-h-[200px]">
+                        <DiagnosticsLineChart
+                          showLegend={true}
+                          keyId={plot.id}
+                          chart={{
+                            title: " ",
+                            labels: plot.series[0]?.points.map((point) => point.timestamp) || [],
+                            datasets: plot.series.map((series) => ({
+                              label: series.label,
+                              data: series.points.map((point) => ({
+                                x: point.timestamp,
+                                y: point.value,
+                              })),
+                            })),
+                          }}
+                          xAxisMin={plot.x_axis_range[0]}
+                          xAxisMax={plot.x_axis_range[1]}
+                          xAxisUnit="minute"
+                          yAxisLabel={undefined}
+                          yAxisUnit={plot.unit}
+                          annotations={plot.annotations}
+                          synchronizedHoverContext={HoverContext}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
 
           <h2 className="text-lg font-semibold mb-2">Resources</h2>
           <div className="space-y-4">

--- a/src/ui/shared/diagnostics/resource.tsx
+++ b/src/ui/shared/diagnostics/resource.tsx
@@ -81,7 +81,7 @@ export const DiagnosticsResource = ({
   endTime: string;
   synchronizedHoverContext: React.Context<HoverState>;
 }) => {
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(true);
 
   return (
     <div className="border rounded-lg p-4">


### PR DESCRIPTION
This PR adds support for displaying "ranked" plots (e.g., those that Hotshot found interesting and potentially correlated) and summary text.

> ⚠️ This PR must accompany https://github.com/aptible/hotshot/pull/12 when deployed.

![Screenshot 2025-02-20 at 17 36 22@2x](https://github.com/user-attachments/assets/0636b45b-86c0-4c51-a947-c5d64793a840)
