### PR TITLE
syslog doesn't require token

### DIFF
--- a/src/ui/pages/create-log-drain.tsx
+++ b/src/ui/pages/create-log-drain.tsx
@@ -102,9 +102,9 @@ const validators = {
     if (p.url === "") return "Must provide a URL for log drain";
     if (!p.url.startsWith("https")) return "Must begin with https://";
   },
-  // insightops / syslog_tls_tcp
+  // insightops
   loggingToken: (p: CreateLogDrainProps) => {
-    if (!(p.drainType === "insightops" || p.drainType === "syslog_tls_tcp"))
+    if (!(p.drainType === "insightops"))
       return;
     if (p.loggingToken === "") return "Must provide a token for log drain.";
   },


### PR DESCRIPTION
Remove the requirement for Syslog Log Drains to have a token. The CLI and old dashboard do/did not have this requirement. 