### PR TITLE
Add the diagnostics creation form to the custom resource detail page

### DIFF
--- a/src/ui/hooks/use-dashboard.ts
+++ b/src/ui/hooks/use-dashboard.ts
@@ -3,6 +3,7 @@ import { selectAptibleAiUrl } from "@app/config";
 import { updateDashboard } from "@app/deploy/dashboard";
 import { fetchDashboard, selectDashboardById } from "@app/deploy/dashboard";
 import { useDispatch, useQuery, useSelector } from "@app/react";
+import { camelToSnakeCase } from "@app/string-utils";
 import { selectAccessToken } from "@app/token";
 import type { DeployDashboard } from "@app/types/deploy";
 import { useEffect, useState } from "react";
@@ -109,6 +110,7 @@ const useHotshotDashboard = ({
       queryParams: {
         token: accessToken,
         resource_id: dashboard.resourceId,
+        resource_type: camelToSnakeCase(dashboard.resourceType),
         symptom_description: dashboard.symptoms,
         start_time: dashboard.rangeBegin,
         end_time: dashboard.rangeEnd,

--- a/src/ui/pages/custom-resource-detail.tsx
+++ b/src/ui/pages/custom-resource-detail.tsx
@@ -17,6 +17,7 @@ import {
   TitleBar,
 } from "../shared";
 import { DependencyGraph } from "../shared/dependency-graph";
+import { DiagnosticsCreateForm } from "./diagnostics-create";
 
 export const CustomResourceDetailPage = () => {
   const { id = "" } = useParams();
@@ -74,6 +75,14 @@ export const CustomResourceDetailPage = () => {
       <Box>
         <h2 className="text-lg font-medium mb-4">Relationships</h2>
         <DependencyGraph resourceItem={resourceItem} />
+      </Box>
+
+      <Box>
+        <DiagnosticsCreateForm
+          resourceId={id}
+          resourceType="CustomResource"
+          resourceName={resource.handle}
+        />
       </Box>
 
       <Group className="mt-4 flex w-fit">


### PR DESCRIPTION
This PR adds the diagnostics creation form to the custom resource detail page, and updates the websocket connection to include the resource type as a parameter.

![Screenshot 2025-04-02 at 16 00 29@2x](https://github.com/user-attachments/assets/188f74de-3d30-4eb7-84ba-10887ec78577)
