### PR TITLE
Fix: Service Pricing Calculator Shows Actual Container Count

### DIFF
--- a/src/ui/shared/service-pricing-calc.tsx
+++ b/src/ui/shared/service-pricing-calc.tsx
@@ -47,8 +47,8 @@ export function ServicePricingCalc({
         <Label>Estimated Cost Breakdown</Label>
         <div className="grid grid-cols-[auto,1fr] gap-x-3 text-black-500">
           <div>
-            1 x {service.containerMemoryLimitMb / 1024} GB container x{" "}
-            {formatCurrency(costPerGBHour)} per GB/hour
+            {service.containerCount} x {service.containerMemoryLimitMb / 1024}{" "}
+            GB container x {formatCurrency(costPerGBHour)} per GB/hour
           </div>
           <div>= {formatCurrency(containerCost)}/month</div>
           {disk == null ? null : (


### PR DESCRIPTION
## Problem
The service pricing calculator was displaying "1 x" for container count in the cost breakdown, regardless of the actual number of containers configured. This made the cost breakdown confusing when services were scaled to multiple containers.

## Solution
Updated the service pricing calculator to use `service.containerCount` instead of the hard-coded "1 x" value. This ensures the cost breakdown accurately reflects the actual number of containers being used.

### Before
1 x 7 GB container x $0.05 per GB/hour = $4,943.20/month

### After
2 x 7 GB container x $0.05 per GB/hour = $4,943.20/month

## Testing
- [x] Verify cost breakdown shows correct container count for services with multiple containers
- [x] Verify cost breakdown updates when scaling containers up/down
- [x] Confirm total cost calculation remains accurate

<img width="903" alt="image" src="https://github.com/user-attachments/assets/7db86c48-0cd6-4531-8d68-1124d8f5744b" />
