### PR TITLE
UI for configuring LLMs

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -160,6 +160,9 @@ import { SettingsProfilePage } from "@app/ui/pages/settings-profile";
 import { SettingsTeamDiagnosticsIntegrationsPage } from "@app/ui/pages/settings-team-diagnostics-integrations";
 import { SettingsTeamDiagnosticsIntegrationsAddPage } from "@app/ui/pages/settings-team-diagnostics-integrations-add";
 import { SettingsTeamDiagnosticsIntegrationsEditPage } from "@app/ui/pages/settings-team-diagnostics-integrations-edit";
+import { SettingsTeamLlmIntegrationsPage } from "@app/ui/pages/settings-team-llm-integrations";
+import { SettingsTeamLlmIntegrationsAddPage } from "@app/ui/pages/settings-team-llm-integrations-add";
+import { SettingsTeamLlmIntegrationsEditPage } from "@app/ui/pages/settings-team-llm-integrations-edit";
 import { SourcesSetupPage } from "@app/ui/pages/sources-setup";
 import { type RouteObject, createBrowserRouter } from "react-router-dom";
 import { Tuna } from "./tuna";
@@ -959,6 +962,21 @@ export const appRoutes: RouteObject[] = [
       {
         path: routes.TEAM_DIAGNOSTICS_INTEGRATIONS_EDIT_PATH,
         element: <SettingsTeamDiagnosticsIntegrationsEditPage />,
+      },
+
+      {
+        path: routes.TEAM_LLM_INTEGRATIONS_PATH,
+        element: <SettingsTeamLlmIntegrationsPage />,
+      },
+
+      {
+        path: routes.TEAM_LLM_INTEGRATIONS_ADD_PATH,
+        element: <SettingsTeamLlmIntegrationsAddPage />,
+      },
+
+      {
+        path: routes.TEAM_LLM_INTEGRATIONS_EDIT_PATH,
+        element: <SettingsTeamLlmIntegrationsEditPage />,
       },
 
       {

--- a/src/deploy/entities.ts
+++ b/src/deploy/entities.ts
@@ -18,6 +18,7 @@ import { endpointEntities } from "./endpoint";
 import { environmentEntities } from "./environment";
 import { imageEntities } from "./image";
 import { integrationEntities } from "./integration";
+import { llmIntegrationEntities } from "./llm-integration";
 import { logDrainEntities } from "./log-drain";
 import { manualScaleRecommendationEntities } from "./manual_scale_recommendation";
 import { metricDrainEntities } from "./metric-drain";
@@ -65,4 +66,5 @@ export const entities = {
   ...customResourceEntities,
   ...edgeEntities,
   ...integrationEntities,
+  ...llmIntegrationEntities,
 };

--- a/src/deploy/llm-integration/index.ts
+++ b/src/deploy/llm-integration/index.ts
@@ -1,0 +1,214 @@
+import { api } from "@app/api";
+import { defaultEntity } from "@app/hal";
+import { schema } from "@app/schema";
+import type {
+  DeployLlmIntegration,
+  DeployLlmIntegrationResponse,
+} from "@app/types";
+
+// Deserializer for LLM integration
+export const deserializeLlmIntegration = (
+  data: DeployLlmIntegrationResponse,
+): DeployLlmIntegration => {
+  return {
+    id: data.id,
+    providerType: data.provider_type,
+    organizationId: data.organization_id,
+    apiKey: data.api_key,
+    baseUrl: data.base_url,
+    openaiOrganization: data.openai_organization,
+    apiVersion: data.api_version,
+    awsAccessKeyId: data.aws_access_key_id,
+    awsSecretAccessKey: data.aws_secret_access_key,
+    awsRegion: data.aws_region,
+    createdAt: data.created_at,
+    updatedAt: data.updated_at,
+  };
+};
+
+// Default response creator
+export const defaultLlmIntegrationResponse =
+  (): DeployLlmIntegrationResponse => {
+    const now = new Date().toISOString();
+    return {
+      id: "",
+      provider_type: "OpenaiIntegration",
+      organization_id: "",
+      api_key: "",
+      base_url: "",
+      openai_organization: "",
+      api_version: "",
+      aws_access_key_id: "",
+      aws_secret_access_key: "",
+      aws_region: "",
+      created_at: now,
+      updated_at: now,
+      _links: {
+        self: {
+          href: "",
+        },
+      },
+      _type: "llm_integration",
+    };
+  };
+
+// Basic selectors
+export const selectLlmIntegrationsAsList =
+  schema.llmIntegrations.selectTableAsList;
+export const selectLlmIntegrationById = schema.llmIntegrations.selectById;
+
+export const fetchLlmIntegrations = api.get("/llm_integrations");
+export const fetchLlmIntegration = api.get<
+  { id: string },
+  DeployLlmIntegrationResponse
+>("/llm_integrations/:id");
+
+export interface CreateLlmIntegrationParams {
+  provider_type: string;
+  organization_id: string;
+  api_key?: string;
+  base_url?: string;
+  openai_organization?: string;
+  api_version?: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
+  aws_region?: string;
+}
+
+export const createLlmIntegration = api.post<
+  CreateLlmIntegrationParams,
+  DeployLlmIntegrationResponse
+>("/llm_integrations", function* (ctx, next) {
+  const {
+    provider_type,
+    organization_id,
+    api_key,
+    base_url,
+    openai_organization,
+    api_version,
+    aws_access_key_id,
+    aws_secret_access_key,
+    aws_region,
+  } = ctx.payload;
+  const body = {
+    provider_type,
+    organization_id,
+    api_key,
+    base_url,
+    openai_organization,
+    api_version,
+    aws_access_key_id,
+    aws_secret_access_key,
+    aws_region,
+  };
+  ctx.request = ctx.req({ body: JSON.stringify(body) });
+  yield* next();
+
+  if (!ctx.json.ok) {
+    return;
+  }
+
+  const integrationId = ctx.json.value.id;
+  ctx.loader = {
+    message: `LLM Integration created (integration ID: ${integrationId})`,
+    meta: { integrationId: integrationId },
+  };
+});
+
+// Update an existing LLM integration
+export interface UpdateLlmIntegrationParams {
+  id: string;
+  api_key?: string;
+  base_url?: string;
+  openai_organization?: string;
+  api_version?: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
+  aws_region?: string;
+}
+
+export const updateLlmIntegration = api.put<UpdateLlmIntegrationParams>(
+  "/llm_integrations/:id",
+  function* (ctx, next) {
+    const {
+      api_key,
+      base_url,
+      openai_organization,
+      api_version,
+      aws_access_key_id,
+      aws_secret_access_key,
+      aws_region,
+    } = ctx.payload;
+    const body: {
+      api_key?: string;
+      base_url?: string;
+      openai_organization?: string;
+      api_version?: string;
+      aws_access_key_id?: string;
+      aws_secret_access_key?: string;
+      aws_region?: string;
+    } = {};
+
+    if (api_key !== undefined) {
+      body.api_key = api_key;
+    }
+
+    if (base_url !== undefined) {
+      body.base_url = base_url;
+    }
+
+    if (openai_organization !== undefined) {
+      body.openai_organization = openai_organization;
+    }
+
+    if (api_version !== undefined) {
+      body.api_version = api_version;
+    }
+
+    if (aws_access_key_id !== undefined) {
+      body.aws_access_key_id = aws_access_key_id;
+    }
+
+    if (aws_secret_access_key !== undefined) {
+      body.aws_secret_access_key = aws_secret_access_key;
+    }
+
+    if (aws_region !== undefined) {
+      body.aws_region = aws_region;
+    }
+
+    ctx.request = ctx.req({ body: JSON.stringify(body) });
+
+    yield* next();
+
+    if (!ctx.json.ok) {
+      return;
+    }
+
+    ctx.loader = {
+      message: "Saved changes successfully!",
+    };
+  },
+);
+
+// Delete an LLM integration
+export const deleteLlmIntegration = api.delete<{ id: string }>(
+  "/llm_integrations/:id",
+  function* (ctx, next) {
+    yield* next();
+
+    if (!ctx.json.ok) {
+      return;
+    }
+
+    yield* schema.update(schema.llmIntegrations.remove([ctx.payload.id]));
+  },
+);
+
+export const llmIntegrationEntities = {
+  llm_integration: defaultEntity({
+    id: "llm_integration",
+    deserialize: deserializeLlmIntegration,
+    save: schema.llmIntegrations.add,
+  }),
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -423,6 +423,16 @@ export const TEAM_DIAGNOSTICS_INTEGRATIONS_EDIT_PATH =
 export const teamDiagnosticsIntegrationsEditUrl = (id: string) =>
   `/settings/team/diagnostics-integrations/${id}/edit`;
 
+export const TEAM_LLM_INTEGRATIONS_PATH = "/settings/team/llm-integrations";
+export const teamLlmIntegrationsUrl = () => TEAM_LLM_INTEGRATIONS_PATH;
+export const TEAM_LLM_INTEGRATIONS_ADD_PATH =
+  "/settings/team/llm-integrations/add";
+export const teamLlmIntegrationsAddUrl = () => TEAM_LLM_INTEGRATIONS_ADD_PATH;
+export const TEAM_LLM_INTEGRATIONS_EDIT_PATH =
+  "/settings/team/llm-integrations/:id/edit";
+export const teamLlmIntegrationsEditUrl = (id: string) =>
+  `/settings/team/llm-integrations/${id}/edit`;
+
 export const CUSTOM_RESOURCES_URL = "/custom-resources";
 export const customResourcesUrl = () => CUSTOM_RESOURCES_URL;
 export const CUSTOM_RESOURCE_DETAIL_URL = "/custom-resources/:id";

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -23,6 +23,7 @@ import {
   type DeployEnvironmentStats,
   type DeployImage,
   type DeployIntegration,
+  type DeployLlmIntegration,
   type DeployLogDrain,
   type DeployMetricDrain,
   type DeployOperation,
@@ -1032,6 +1033,27 @@ export const defaultDeployIntegration = (
     port: "",
     username: "",
     database: "",
+    createdAt: now,
+    updatedAt: now,
+    ...i,
+  };
+};
+
+export const defaultDeployLlmIntegration = (
+  i: Partial<DeployLlmIntegration> = {},
+): DeployLlmIntegration => {
+  const now = new Date().toISOString();
+  return {
+    id: "",
+    providerType: "OpenaiIntegration", // Default type
+    organizationId: "",
+    apiKey: "",
+    baseUrl: "",
+    openaiOrganization: "",
+    apiVersion: "",
+    awsAccessKeyId: "",
+    awsSecretAccessKey: "",
+    awsRegion: "",
     createdAt: now,
     updatedAt: now,
     ...i,

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -103,5 +103,8 @@ export const [schema, initialState] = createSchema({
   }),
   edges: slice.table({ empty: factory.defaultDeployEdge() }),
   integrations: slice.table({ empty: factory.defaultDeployIntegration() }),
+  llmIntegrations: slice.table({
+    empty: factory.defaultDeployLlmIntegration(),
+  }),
 });
 export type WebState = typeof initialState;

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -196,6 +196,7 @@ export type ResourceType =
   | "vpn_tunnel"
   | "edge"
   | "integration"
+  | "llm_integration"
   | "unknown";
 
 // https://github.com/aptible/deploy-api/blob/3b197beaa5bcbbed991c1eac73d5c99a4fdf8f95/app/models/operation.rb#L54
@@ -797,4 +798,36 @@ export interface DeployIntegrationResponse {
     self: LinkResponse;
   };
   _type: "integration";
+}
+
+export interface DeployLlmIntegration extends Timestamps {
+  id: string;
+  providerType: string;
+  organizationId: string;
+  apiKey?: string;
+  baseUrl?: string;
+  openaiOrganization?: string;
+  apiVersion?: string;
+  awsAccessKeyId?: string;
+  awsSecretAccessKey?: string;
+  awsRegion?: string;
+}
+
+export interface DeployLlmIntegrationResponse {
+  id: string;
+  provider_type: string;
+  organization_id: string;
+  api_key?: string;
+  base_url?: string;
+  openai_organization?: string;
+  api_version?: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
+  aws_region?: string;
+  created_at: string;
+  updated_at: string;
+  _links: {
+    self: LinkResponse;
+  };
+  _type: "llm_integration";
 }

--- a/src/ui/pages/index.ts
+++ b/src/ui/pages/index.ts
@@ -127,3 +127,6 @@ export * from "./custom-resource-detail";
 export * from "./settings-team-diagnostics-integrations";
 export * from "./settings-team-diagnostics-integrations-add";
 export * from "./settings-team-diagnostics-integrations-edit";
+export * from "./settings-team-llm-integrations";
+export * from "./settings-team-llm-integrations-add";
+export * from "./settings-team-llm-integrations-edit";

--- a/src/ui/pages/settings-team-llm-integrations-add.tsx
+++ b/src/ui/pages/settings-team-llm-integrations-add.tsx
@@ -25,7 +25,7 @@ import {
 const LLM_INTEGRATION_TYPES = [
   { value: "", label: "Select LLM Provider" },
   { value: "OpenaiIntegration", label: "OpenAI" },
-  { value: "AzureIntegration", label: "Azure OpenAI" },
+  { value: "AzureIntegration", label: "Azure" },
   { value: "AnthropicIntegration", label: "Anthropic" },
   { value: "BedrockIntegration", label: "AWS Bedrock" },
 ];
@@ -192,7 +192,7 @@ function AzureForm({
           onChange={(e) =>
             setFormData({ ...formData, base_url: e.currentTarget.value })
           }
-          placeholder="e.g., https://your-resource.openai.azure.com/openai"
+          placeholder="e.g., https://example-endpoint.openai.azure.com"
         />
       </FormGroup>
 
@@ -423,7 +423,7 @@ export function SettingsTeamLlmIntegrationsAddPage() {
       <Breadcrumbs
         crumbs={[
           {
-            name: "AI/LLM Integrations",
+            name: "LLM Integrations",
             to: teamLlmIntegrationsUrl(),
           },
           { name: "Add LLM Integration", to: null },

--- a/src/ui/pages/settings-team-llm-integrations-add.tsx
+++ b/src/ui/pages/settings-team-llm-integrations-add.tsx
@@ -1,0 +1,470 @@
+import { createLlmIntegration } from "@app/deploy/llm-integration";
+import { selectOrganizationSelected } from "@app/organizations";
+import {
+  useDispatch,
+  useLoader,
+  useLoaderSuccess,
+  useSelector,
+} from "@app/react";
+import { teamLlmIntegrationsUrl } from "@app/routes";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useValidator } from "../hooks";
+import {
+  BannerMessages,
+  Box,
+  Breadcrumbs,
+  Button,
+  FormGroup,
+  Group,
+  Input,
+  Select,
+} from "../shared";
+
+// Define LLM integration types
+const LLM_INTEGRATION_TYPES = [
+  { value: "", label: "Select LLM Provider" },
+  { value: "OpenaiIntegration", label: "OpenAI" },
+  { value: "AzureIntegration", label: "Azure OpenAI" },
+  { value: "AnthropicIntegration", label: "Anthropic" },
+  { value: "BedrockIntegration", label: "AWS Bedrock" },
+];
+
+// Define form data interface
+interface FormData {
+  provider_type: string;
+  api_key?: string;
+  base_url?: string;
+  openai_organization?: string;
+  api_version?: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
+  aws_region?: string;
+}
+
+// Form validators
+const validators = {
+  provider_type: (data: FormData) =>
+    data.provider_type ? undefined : "Please select a provider type",
+
+  // OpenAI and Anthropic validators
+  api_key: (data: FormData) => {
+    if (
+      (data.provider_type === "OpenaiIntegration" ||
+        data.provider_type === "AzureIntegration" ||
+        data.provider_type === "AnthropicIntegration") &&
+      !data.api_key
+    ) {
+      return "API Key is required";
+    }
+    return undefined;
+  },
+
+  // Azure validators
+  base_url: (data: FormData) => {
+    if (data.provider_type === "AzureIntegration" && !data.base_url) {
+      return "Base URL is required";
+    }
+    return undefined;
+  },
+  api_version: (data: FormData) => {
+    if (data.provider_type === "AzureIntegration" && !data.api_version) {
+      return "API Version is required";
+    }
+    return undefined;
+  },
+
+  // AWS Bedrock validators
+  aws_access_key_id: (data: FormData) => {
+    if (
+      data.provider_type === "BedrockIntegration" &&
+      !data.aws_access_key_id
+    ) {
+      return "AWS Access Key ID is required";
+    }
+    return undefined;
+  },
+  aws_secret_access_key: (data: FormData) => {
+    if (
+      data.provider_type === "BedrockIntegration" &&
+      !data.aws_secret_access_key
+    ) {
+      return "AWS Secret Access Key is required";
+    }
+    return undefined;
+  },
+  aws_region: (data: FormData) => {
+    if (data.provider_type === "BedrockIntegration" && !data.aws_region) {
+      return "AWS Region is required";
+    }
+    return undefined;
+  },
+};
+
+// OpenAI integration form component
+function OpenAIForm({
+  formData,
+  setFormData,
+  errors,
+}: {
+  formData: FormData;
+  setFormData: (data: FormData) => void;
+  errors: Record<string, string | undefined>;
+}) {
+  return (
+    <>
+      <FormGroup
+        label="API Key"
+        htmlFor="api_key"
+        feedbackMessage={errors.api_key}
+        feedbackVariant={errors.api_key ? "danger" : "info"}
+      >
+        <Input
+          id="api_key"
+          name="api_key"
+          type="password"
+          value={formData.api_key || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, api_key: e.currentTarget.value })
+          }
+          placeholder="Your OpenAI API key"
+        />
+      </FormGroup>
+
+      <FormGroup label="Organization ID" htmlFor="openai_organization">
+        <Input
+          id="openai_organization"
+          name="openai_organization"
+          value={formData.openai_organization || ""}
+          onChange={(e) =>
+            setFormData({
+              ...formData,
+              openai_organization: e.currentTarget.value,
+            })
+          }
+          placeholder="Optional: Your OpenAI organization ID"
+        />
+      </FormGroup>
+    </>
+  );
+}
+
+// Azure integration form component
+function AzureForm({
+  formData,
+  setFormData,
+  errors,
+}: {
+  formData: FormData;
+  setFormData: (data: FormData) => void;
+  errors: Record<string, string | undefined>;
+}) {
+  return (
+    <>
+      <FormGroup
+        label="API Key"
+        htmlFor="api_key"
+        feedbackMessage={errors.api_key}
+        feedbackVariant={errors.api_key ? "danger" : "info"}
+      >
+        <Input
+          id="api_key"
+          name="api_key"
+          type="password"
+          value={formData.api_key || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, api_key: e.currentTarget.value })
+          }
+          placeholder="Your Azure OpenAI API key"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="Base URL"
+        htmlFor="base_url"
+        feedbackMessage={errors.base_url}
+        feedbackVariant={errors.base_url ? "danger" : "info"}
+      >
+        <Input
+          id="base_url"
+          name="base_url"
+          value={formData.base_url || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, base_url: e.currentTarget.value })
+          }
+          placeholder="e.g., https://your-resource.openai.azure.com/openai"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="API Version"
+        htmlFor="api_version"
+        feedbackMessage={errors.api_version}
+        feedbackVariant={errors.api_version ? "danger" : "info"}
+      >
+        <Input
+          id="api_version"
+          name="api_version"
+          value={formData.api_version || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, api_version: e.currentTarget.value })
+          }
+          placeholder="e.g., 2023-12-01-preview"
+        />
+      </FormGroup>
+    </>
+  );
+}
+
+// Anthropic integration form component
+function AnthropicForm({
+  formData,
+  setFormData,
+  errors,
+}: {
+  formData: FormData;
+  setFormData: (data: FormData) => void;
+  errors: Record<string, string | undefined>;
+}) {
+  return (
+    <>
+      <FormGroup
+        label="API Key"
+        htmlFor="api_key"
+        feedbackMessage={errors.api_key}
+        feedbackVariant={errors.api_key ? "danger" : "info"}
+      >
+        <Input
+          id="api_key"
+          name="api_key"
+          type="password"
+          value={formData.api_key || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, api_key: e.currentTarget.value })
+          }
+          placeholder="Your Anthropic API key"
+        />
+      </FormGroup>
+
+      <FormGroup label="Base URL" htmlFor="base_url">
+        <Input
+          id="base_url"
+          name="base_url"
+          value={formData.base_url || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, base_url: e.currentTarget.value })
+          }
+          placeholder="Optional: Custom base URL for Anthropic API"
+        />
+      </FormGroup>
+    </>
+  );
+}
+
+// AWS Bedrock integration form component
+function BedrockForm({
+  formData,
+  setFormData,
+  errors,
+}: {
+  formData: FormData;
+  setFormData: (data: FormData) => void;
+  errors: Record<string, string | undefined>;
+}) {
+  return (
+    <>
+      <FormGroup
+        label="AWS Access Key ID"
+        htmlFor="aws_access_key_id"
+        feedbackMessage={errors.aws_access_key_id}
+        feedbackVariant={errors.aws_access_key_id ? "danger" : "info"}
+      >
+        <Input
+          id="aws_access_key_id"
+          name="aws_access_key_id"
+          value={formData.aws_access_key_id || ""}
+          onChange={(e) =>
+            setFormData({
+              ...formData,
+              aws_access_key_id: e.currentTarget.value,
+            })
+          }
+          placeholder="Your AWS Access Key ID"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="AWS Secret Access Key"
+        htmlFor="aws_secret_access_key"
+        feedbackMessage={errors.aws_secret_access_key}
+        feedbackVariant={errors.aws_secret_access_key ? "danger" : "info"}
+      >
+        <Input
+          id="aws_secret_access_key"
+          name="aws_secret_access_key"
+          type="password"
+          value={formData.aws_secret_access_key || ""}
+          onChange={(e) =>
+            setFormData({
+              ...formData,
+              aws_secret_access_key: e.currentTarget.value,
+            })
+          }
+          placeholder="Your AWS Secret Access Key"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="AWS Region"
+        htmlFor="aws_region"
+        feedbackMessage={errors.aws_region}
+        feedbackVariant={errors.aws_region ? "danger" : "info"}
+      >
+        <Input
+          id="aws_region"
+          name="aws_region"
+          value={formData.aws_region || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, aws_region: e.currentTarget.value })
+          }
+          placeholder="e.g., us-east-1"
+        />
+      </FormGroup>
+    </>
+  );
+}
+
+export function SettingsTeamLlmIntegrationsAddPage() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const org = useSelector(selectOrganizationSelected);
+
+  // Form state
+  const [formData, setFormData] = useState<FormData>({
+    provider_type: "",
+  });
+
+  // Validation
+  const [errors, validate] = useValidator<FormData, typeof validators>(
+    validators,
+  );
+
+  // Set up API action
+  const action = createLlmIntegration({
+    provider_type: formData.provider_type,
+    organization_id: org.id,
+    api_key: formData.api_key,
+    base_url: formData.base_url,
+    openai_organization: formData.openai_organization,
+    api_version: formData.api_version,
+    aws_access_key_id: formData.aws_access_key_id,
+    aws_secret_access_key: formData.aws_secret_access_key,
+    aws_region: formData.aws_region,
+  });
+
+  const loader = useLoader(action);
+
+  // Form submission
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!validate(formData)) {
+      return;
+    }
+    dispatch(action);
+  };
+
+  // Handle success
+  useLoaderSuccess(loader, () => {
+    navigate(teamLlmIntegrationsUrl());
+  });
+
+  // Render form fields based on selected integration type
+  const renderIntegrationForm = () => {
+    switch (formData.provider_type) {
+      case "OpenaiIntegration":
+        return (
+          <OpenAIForm
+            formData={formData}
+            setFormData={setFormData}
+            errors={errors}
+          />
+        );
+      case "AzureIntegration":
+        return (
+          <AzureForm
+            formData={formData}
+            setFormData={setFormData}
+            errors={errors}
+          />
+        );
+      case "AnthropicIntegration":
+        return (
+          <AnthropicForm
+            formData={formData}
+            setFormData={setFormData}
+            errors={errors}
+          />
+        );
+      case "BedrockIntegration":
+        return (
+          <BedrockForm
+            formData={formData}
+            setFormData={setFormData}
+            errors={errors}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Group>
+      <Breadcrumbs
+        crumbs={[
+          {
+            name: "AI/LLM Integrations",
+            to: teamLlmIntegrationsUrl(),
+          },
+          { name: "Add LLM Integration", to: null },
+        ]}
+      />
+
+      <Box>
+        <form onSubmit={onSubmit}>
+          <Group>
+            <BannerMessages {...loader} />
+
+            <FormGroup
+              label="LLM Provider"
+              htmlFor="provider_type"
+              feedbackMessage={errors.provider_type}
+              feedbackVariant={errors.provider_type ? "danger" : "info"}
+            >
+              <Select
+                id="provider_type"
+                options={LLM_INTEGRATION_TYPES}
+                onSelect={(opt) =>
+                  setFormData({ ...formData, provider_type: opt.value })
+                }
+                value={formData.provider_type}
+              />
+            </FormGroup>
+
+            {renderIntegrationForm()}
+
+            <div className="mt-4">
+              <Button
+                type="submit"
+                isLoading={loader.isLoading}
+                disabled={formData.provider_type === ""}
+              >
+                Add LLM Integration
+              </Button>
+            </div>
+          </Group>
+        </form>
+      </Box>
+    </Group>
+  );
+}

--- a/src/ui/pages/settings-team-llm-integrations-edit.tsx
+++ b/src/ui/pages/settings-team-llm-integrations-edit.tsx
@@ -1,0 +1,606 @@
+import {
+  deleteLlmIntegration,
+  fetchLlmIntegration,
+  fetchLlmIntegrations,
+  selectLlmIntegrationById,
+  updateLlmIntegration,
+} from "@app/deploy/llm-integration";
+import {
+  useCache,
+  useDispatch,
+  useLoader,
+  useLoaderSuccess,
+  useQuery,
+  useSelector,
+} from "@app/react";
+import { teamLlmIntegrationsUrl } from "@app/routes";
+import type { DeployLlmIntegration } from "@app/types";
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useValidator } from "../hooks";
+import {
+  BannerMessages,
+  Box,
+  Breadcrumbs,
+  Button,
+  FormGroup,
+  Group,
+  Input,
+  tokens,
+} from "../shared";
+
+// Define form data interface
+interface FormData {
+  api_key?: string;
+  base_url?: string;
+  openai_organization?: string;
+  api_version?: string;
+  aws_access_key_id?: string;
+  aws_secret_access_key?: string;
+  aws_region?: string;
+}
+
+// Form validators
+const validators = {
+  // OpenAI and Anthropic validators
+  api_key: (data: FormData, type?: string) => {
+    if (
+      (type === "OpenaiIntegration" ||
+        type === "AzureIntegration" ||
+        type === "AnthropicIntegration") &&
+      !data.api_key
+    ) {
+      return "API Key is required";
+    }
+    return undefined;
+  },
+
+  // Azure validators
+  base_url: (data: FormData, type?: string) => {
+    if (type === "AzureIntegration" && !data.base_url) {
+      return "Base URL is required";
+    }
+    return undefined;
+  },
+  api_version: (data: FormData, type?: string) => {
+    if (type === "AzureIntegration" && !data.api_version) {
+      return "API Version is required";
+    }
+    return undefined;
+  },
+
+  // AWS Bedrock validators
+  aws_access_key_id: (data: FormData, type?: string) => {
+    if (type === "BedrockIntegration" && !data.aws_access_key_id) {
+      return "AWS Access Key ID is required";
+    }
+    return undefined;
+  },
+  aws_secret_access_key: (data: FormData, type?: string) => {
+    if (
+      type === "BedrockIntegration" &&
+      data.aws_secret_access_key === "" // Only validate if it's empty string, not undefined (to allow keeping existing)
+    ) {
+      return "AWS Secret Access Key is required";
+    }
+    return undefined;
+  },
+  aws_region: (data: FormData, type?: string) => {
+    if (type === "BedrockIntegration" && !data.aws_region) {
+      return "AWS Region is required";
+    }
+    return undefined;
+  },
+};
+
+// Format provider type for display
+function formatProviderType(type: string): string {
+  if (type === "OpenaiIntegration") return "OpenAI";
+  if (type === "AzureIntegration") return "Azure OpenAI";
+  if (type === "AnthropicIntegration") return "Anthropic";
+  if (type === "BedrockIntegration") return "AWS Bedrock";
+  return type.replace("Integration", "");
+}
+
+// OpenAI integration form component
+function OpenAIForm({
+  formData,
+  setFormData,
+  errors,
+}: {
+  formData: FormData;
+  setFormData: (data: FormData) => void;
+  errors: Record<string, string | undefined>;
+}) {
+  return (
+    <>
+      <FormGroup
+        label="API Key"
+        htmlFor="api_key"
+        feedbackMessage={errors.api_key}
+        feedbackVariant={errors.api_key ? "danger" : "info"}
+        description="Enter a new API key or leave blank to keep the current one"
+      >
+        <Input
+          id="api_key"
+          name="api_key"
+          type="password"
+          value={formData.api_key || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, api_key: e.currentTarget.value })
+          }
+          placeholder="Leave blank to keep current API key"
+        />
+      </FormGroup>
+
+      <FormGroup label="Organization ID" htmlFor="openai_organization">
+        <Input
+          id="openai_organization"
+          name="openai_organization"
+          value={formData.openai_organization || ""}
+          onChange={(e) =>
+            setFormData({
+              ...formData,
+              openai_organization: e.currentTarget.value,
+            })
+          }
+          placeholder="Optional: Your OpenAI organization ID"
+        />
+      </FormGroup>
+    </>
+  );
+}
+
+// Azure integration form component
+function AzureForm({
+  formData,
+  setFormData,
+  errors,
+}: {
+  formData: FormData;
+  setFormData: (data: FormData) => void;
+  errors: Record<string, string | undefined>;
+}) {
+  return (
+    <>
+      <FormGroup
+        label="API Key"
+        htmlFor="api_key"
+        feedbackMessage={errors.api_key}
+        feedbackVariant={errors.api_key ? "danger" : "info"}
+        description="Enter a new API key or leave blank to keep the current one"
+      >
+        <Input
+          id="api_key"
+          name="api_key"
+          type="password"
+          value={formData.api_key || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, api_key: e.currentTarget.value })
+          }
+          placeholder="Leave blank to keep current API key"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="Base URL"
+        htmlFor="base_url"
+        feedbackMessage={errors.base_url}
+        feedbackVariant={errors.base_url ? "danger" : "info"}
+      >
+        <Input
+          id="base_url"
+          name="base_url"
+          value={formData.base_url || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, base_url: e.currentTarget.value })
+          }
+          placeholder="e.g., https://your-resource.openai.azure.com/openai"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="API Version"
+        htmlFor="api_version"
+        feedbackMessage={errors.api_version}
+        feedbackVariant={errors.api_version ? "danger" : "info"}
+      >
+        <Input
+          id="api_version"
+          name="api_version"
+          value={formData.api_version || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, api_version: e.currentTarget.value })
+          }
+          placeholder="e.g., 2023-12-01-preview"
+        />
+      </FormGroup>
+    </>
+  );
+}
+
+// Anthropic integration form component
+function AnthropicForm({
+  formData,
+  setFormData,
+  errors,
+}: {
+  formData: FormData;
+  setFormData: (data: FormData) => void;
+  errors: Record<string, string | undefined>;
+}) {
+  return (
+    <>
+      <FormGroup
+        label="API Key"
+        htmlFor="api_key"
+        feedbackMessage={errors.api_key}
+        feedbackVariant={errors.api_key ? "danger" : "info"}
+        description="Enter a new API key or leave blank to keep the current one"
+      >
+        <Input
+          id="api_key"
+          name="api_key"
+          type="password"
+          value={formData.api_key || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, api_key: e.currentTarget.value })
+          }
+          placeholder="Leave blank to keep current API key"
+        />
+      </FormGroup>
+
+      <FormGroup label="Base URL" htmlFor="base_url">
+        <Input
+          id="base_url"
+          name="base_url"
+          value={formData.base_url || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, base_url: e.currentTarget.value })
+          }
+          placeholder="Optional: Custom base URL for Anthropic API"
+        />
+      </FormGroup>
+    </>
+  );
+}
+
+// AWS Bedrock integration form component
+function BedrockForm({
+  formData,
+  setFormData,
+  errors,
+}: {
+  formData: FormData;
+  setFormData: (data: FormData) => void;
+  errors: Record<string, string | undefined>;
+}) {
+  return (
+    <>
+      <FormGroup
+        label="AWS Access Key ID"
+        htmlFor="aws_access_key_id"
+        feedbackMessage={errors.aws_access_key_id}
+        feedbackVariant={errors.aws_access_key_id ? "danger" : "info"}
+      >
+        <Input
+          id="aws_access_key_id"
+          name="aws_access_key_id"
+          value={formData.aws_access_key_id || ""}
+          onChange={(e) =>
+            setFormData({
+              ...formData,
+              aws_access_key_id: e.currentTarget.value,
+            })
+          }
+          placeholder="Your AWS Access Key ID"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="AWS Secret Access Key"
+        htmlFor="aws_secret_access_key"
+        feedbackMessage={errors.aws_secret_access_key}
+        feedbackVariant={errors.aws_secret_access_key ? "danger" : "info"}
+        description="Enter a new secret key or leave blank to keep the current one"
+      >
+        <Input
+          id="aws_secret_access_key"
+          name="aws_secret_access_key"
+          type="password"
+          value={formData.aws_secret_access_key || ""}
+          onChange={(e) =>
+            setFormData({
+              ...formData,
+              aws_secret_access_key: e.currentTarget.value,
+            })
+          }
+          placeholder="Leave blank to keep current secret key"
+        />
+      </FormGroup>
+
+      <FormGroup
+        label="AWS Region"
+        htmlFor="aws_region"
+        feedbackMessage={errors.aws_region}
+        feedbackVariant={errors.aws_region ? "danger" : "info"}
+      >
+        <Input
+          id="aws_region"
+          name="aws_region"
+          value={formData.aws_region || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, aws_region: e.currentTarget.value })
+          }
+          placeholder="e.g., us-east-1"
+        />
+      </FormGroup>
+    </>
+  );
+}
+
+// Render form fields based on integration type
+function IntegrationForm({
+  integration,
+  onSubmit,
+  loader,
+}: {
+  integration: DeployLlmIntegration;
+  onSubmit: (formData: FormData) => void;
+  loader: {
+    isLoading: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    message: string;
+  };
+}) {
+  // Form state
+  const [formData, setFormData] = useState<FormData>({
+    api_key: "",
+    base_url: integration.baseUrl,
+    openai_organization: integration.openaiOrganization,
+    api_version: integration.apiVersion,
+    aws_access_key_id: integration.awsAccessKeyId,
+    aws_secret_access_key: "",
+    aws_region: integration.awsRegion,
+  });
+
+  // Update form data when integration data loads
+  useEffect(() => {
+    setFormData({
+      api_key: "", // Don't prefill sensitive data
+      base_url: integration.baseUrl,
+      openai_organization: integration.openaiOrganization,
+      api_version: integration.apiVersion,
+      aws_access_key_id: integration.awsAccessKeyId,
+      aws_secret_access_key: "", // Don't prefill sensitive data
+      aws_region: integration.awsRegion,
+    });
+  }, [
+    integration.id,
+    integration.baseUrl,
+    integration.openaiOrganization,
+    integration.apiVersion,
+    integration.awsAccessKeyId,
+    integration.awsRegion,
+  ]);
+
+  // Validation
+  const [errors, validate] = useValidator<FormData, typeof validators>(
+    validators,
+  );
+
+  // Form submission handler
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // Validate form with the selected provider type
+    if (!validate(formData, integration.providerType)) {
+      return;
+    }
+    onSubmit(formData);
+  };
+
+  // Render the appropriate form based on integration type
+  const renderTypeSpecificForm = () => {
+    switch (integration.providerType) {
+      case "OpenaiIntegration":
+        return (
+          <OpenAIForm
+            formData={formData}
+            setFormData={setFormData}
+            errors={errors}
+          />
+        );
+      case "AzureIntegration":
+        return (
+          <AzureForm
+            formData={formData}
+            setFormData={setFormData}
+            errors={errors}
+          />
+        );
+      case "AnthropicIntegration":
+        return (
+          <AnthropicForm
+            formData={formData}
+            setFormData={setFormData}
+            errors={errors}
+          />
+        );
+      case "BedrockIntegration":
+        return (
+          <BedrockForm
+            formData={formData}
+            setFormData={setFormData}
+            errors={errors}
+          />
+        );
+      default:
+        return (
+          <div>Unsupported integration type: {integration.providerType}</div>
+        );
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Group>
+        <BannerMessages {...loader} />
+
+        <FormGroup
+          label="LLM Provider"
+          htmlFor="provider_type"
+          description="Provider type cannot be changed after creation."
+        >
+          <Input
+            id="provider_type"
+            name="provider_type"
+            value={formatProviderType(integration.providerType)}
+            disabled
+          />
+        </FormGroup>
+
+        {renderTypeSpecificForm()}
+
+        <div className="mt-4">
+          <Button type="submit" isLoading={loader.isLoading}>
+            Save Changes
+          </Button>
+        </div>
+      </Group>
+    </form>
+  );
+}
+
+export function SettingsTeamLlmIntegrationsEditPage() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { id = "" } = useParams<{ id: string }>();
+
+  useQuery(fetchLlmIntegration({ id }));
+  const integration = useSelector((s) => selectLlmIntegrationById(s, { id }));
+
+  // Set up API actions
+  const [updateAction, setUpdateAction] = useState(() =>
+    updateLlmIntegration({ id }),
+  );
+  const loader = useLoader(updateAction);
+
+  // Set up delete action
+  const deleteAction = deleteLlmIntegration({ id });
+  const deleteLoader = useLoader(deleteAction);
+
+  // Set up integrations fetch for refreshing the list
+  const integrationsCache = useCache(fetchLlmIntegrations());
+
+  // Handle success for update
+  useLoaderSuccess(loader, () => {
+    navigate(teamLlmIntegrationsUrl());
+  });
+
+  // Handle success for delete
+  useLoaderSuccess(deleteLoader, () => {
+    // Refresh the integrations list before navigating
+    integrationsCache.trigger();
+    navigate(teamLlmIntegrationsUrl());
+  });
+
+  // Submission handler - update the action with form data
+  const handleSubmit = (formData: FormData) => {
+    // Only include fields that are defined (to keep current values if not changed)
+    const updatePayload: Record<string, any> = { id };
+
+    // Only include api_key if it's not empty (to keep existing value)
+    if (formData.api_key) {
+      updatePayload.api_key = formData.api_key;
+    }
+
+    // Include other fields if they're defined
+    if (formData.base_url !== undefined) {
+      updatePayload.base_url = formData.base_url;
+    }
+
+    if (formData.openai_organization !== undefined) {
+      updatePayload.openai_organization = formData.openai_organization;
+    }
+
+    if (formData.api_version !== undefined) {
+      updatePayload.api_version = formData.api_version;
+    }
+
+    if (formData.aws_access_key_id !== undefined) {
+      updatePayload.aws_access_key_id = formData.aws_access_key_id;
+    }
+
+    // Only include aws_secret_access_key if it's not empty (to keep existing value)
+    if (formData.aws_secret_access_key) {
+      updatePayload.aws_secret_access_key = formData.aws_secret_access_key;
+    }
+
+    if (formData.aws_region !== undefined) {
+      updatePayload.aws_region = formData.aws_region;
+    }
+
+    const action = updateLlmIntegration({ id, ...updatePayload });
+    setUpdateAction(action);
+    dispatch(action);
+  };
+
+  // Handler for delete action
+  const handleDelete = () => {
+    dispatch(deleteAction);
+  };
+
+  // Navigate away if id is missing
+  useEffect(() => {
+    if (!id) {
+      navigate(teamLlmIntegrationsUrl());
+    }
+  }, [id, navigate]);
+
+  // Show nothing while navigating away for missing ID
+  if (!id || !integration) {
+    return null;
+  }
+
+  return (
+    <Group>
+      <Breadcrumbs
+        crumbs={[
+          {
+            name: "AI/LLM Integrations",
+            to: teamLlmIntegrationsUrl(),
+          },
+          { name: "Edit LLM Integration", to: null },
+        ]}
+      />
+
+      <Box>
+        <IntegrationForm
+          integration={integration}
+          onSubmit={handleSubmit}
+          loader={loader}
+        />
+      </Box>
+
+      <Box>
+        <Group>
+          <BannerMessages {...deleteLoader} />
+
+          <h3 className={tokens.type.h3}>Delete LLM Integration</h3>
+
+          <div>
+            <Button
+              variant="delete"
+              onClick={handleDelete}
+              requireConfirm
+              isLoading={deleteLoader.isLoading}
+            >
+              Delete Integration
+            </Button>
+          </div>
+        </Group>
+      </Box>
+    </Group>
+  );
+}

--- a/src/ui/pages/settings-team-llm-integrations.tsx
+++ b/src/ui/pages/settings-team-llm-integrations.tsx
@@ -1,0 +1,104 @@
+import {
+  fetchLlmIntegrations,
+  selectLlmIntegrationsAsList,
+} from "@app/deploy/llm-integration";
+import { useQuery, useSelector } from "@app/react";
+import {
+  teamLlmIntegrationsAddUrl,
+  teamLlmIntegrationsEditUrl,
+} from "@app/routes";
+import type { DeployLlmIntegration } from "@app/types";
+import {
+  ActionBar,
+  ButtonLink,
+  EmptyTr,
+  Group,
+  IconPlusCircle,
+  TBody,
+  THead,
+  Table,
+  Td,
+  Th,
+  TitleBar,
+  Tr,
+  tokens,
+} from "../shared";
+
+// Format the provider type for display
+function formatProviderType(type: string): string {
+  if (type === "OpenaiIntegration") return "OpenAI";
+  if (type === "AzureIntegration") return "Azure OpenAI";
+  if (type === "AnthropicIntegration") return "Anthropic";
+  if (type === "BedrockIntegration") return "AWS Bedrock";
+  return type.replace("Integration", "");
+}
+
+function LlmIntegrationRow({
+  integration,
+}: { integration: DeployLlmIntegration }) {
+  return (
+    <Tr key={integration.id}>
+      <Td>
+        <div className={tokens.type.darker}>
+          {formatProviderType(integration.providerType)}
+        </div>
+        {integration.baseUrl && (
+          <div className="text-sm text-black-500">{integration.baseUrl}</div>
+        )}
+      </Td>
+      <Td variant="right">
+        <ButtonLink
+          to={teamLlmIntegrationsEditUrl(integration.id)}
+          size="sm"
+          className="w-fit justify-self-end inline-flex"
+        >
+          Edit
+        </ButtonLink>
+      </Td>
+    </Tr>
+  );
+}
+
+export function SettingsTeamLlmIntegrationsPage() {
+  useQuery(fetchLlmIntegrations());
+  const integrations = useSelector(selectLlmIntegrationsAsList);
+
+  return (
+    <Group>
+      <TitleBar description="Manage AI/LLM integrations for advanced features">
+        AI/LLM Integrations
+      </TitleBar>
+
+      <div className="flex justify-end mb-4">
+        <ActionBar>
+          <ButtonLink to={teamLlmIntegrationsAddUrl()}>
+            <IconPlusCircle variant="sm" className="mr-2" />
+            Add LLM Integration
+          </ButtonLink>
+        </ActionBar>
+      </div>
+
+      <Table>
+        <THead>
+          <Th>Integration</Th>
+          <Th variant="right">Actions</Th>
+        </THead>
+
+        <TBody>
+          {integrations.length === 0 ? (
+            <EmptyTr colSpan={2}>
+              No LLM integrations found. Add an integration to use AI features.
+            </EmptyTr>
+          ) : (
+            integrations.map((integration) => (
+              <LlmIntegrationRow
+                key={integration.id}
+                integration={integration}
+              />
+            ))
+          )}
+        </TBody>
+      </Table>
+    </Group>
+  );
+}

--- a/src/ui/pages/settings-team-llm-integrations.tsx
+++ b/src/ui/pages/settings-team-llm-integrations.tsx
@@ -65,8 +65,8 @@ export function SettingsTeamLlmIntegrationsPage() {
 
   return (
     <Group>
-      <TitleBar description="Manage AI/LLM integrations for advanced features">
-        AI/LLM Integrations
+      <TitleBar description="Manage LLM integrations for advanced features">
+        LLM Integrations
       </TitleBar>
 
       <div className="flex justify-end mb-4">
@@ -87,7 +87,7 @@ export function SettingsTeamLlmIntegrationsPage() {
         <TBody>
           {integrations.length === 0 ? (
             <EmptyTr colSpan={2}>
-              No LLM integrations found. Add an integration to use AI features.
+              No LLM integrations found. Add an integration to use LLM features.
             </EmptyTr>
           ) : (
             integrations.map((integration) => (

--- a/src/ui/shared/settings-sidebar.tsx
+++ b/src/ui/shared/settings-sidebar.tsx
@@ -169,7 +169,7 @@ export function SettingsSidebar() {
 
         {(hasBetaFeatures || hasDiagnosticsPoc) && (
           <NavLink className={navLink} to={teamLlmIntegrationsUrl()}>
-            AI/LLM Integrations
+            LLM Integrations
           </NavLink>
         )}
 

--- a/src/ui/shared/settings-sidebar.tsx
+++ b/src/ui/shared/settings-sidebar.tsx
@@ -15,6 +15,7 @@ import {
   teamContactsUrl,
   teamDiagnosticsIntegrationsUrl,
   teamGithubIntegrationUrl,
+  teamLlmIntegrationsUrl,
   teamMembersUrl,
   teamPendingInvitesUrl,
   teamRolesUrl,
@@ -163,6 +164,12 @@ export function SettingsSidebar() {
         {(hasBetaFeatures || hasDiagnosticsPoc) && (
           <NavLink className={navLink} to={teamDiagnosticsIntegrationsUrl()}>
             Diagnostics Integrations
+          </NavLink>
+        )}
+
+        {(hasBetaFeatures || hasDiagnosticsPoc) && (
+          <NavLink className={navLink} to={teamLlmIntegrationsUrl()}>
+            AI/LLM Integrations
           </NavLink>
         )}
 


### PR DESCRIPTION
This PR adds a UI for configuring LLM integrations (visible to orgs with `hasBetaFeatures` or `hasDiagnosticsPoc`). It supports:
- OpenAI
- Azure
- Anthropic
- AWS Bedrock

<img width="1554" alt="Screenshot 2025-04-03 at 11 05 16 AM" src="https://github.com/user-attachments/assets/c7ea5df7-7439-4f99-99da-9bcd9adff318" />

Depending on the provider chosen, the form and validations change:

<img width="1110" alt="Screenshot 2025-04-03 at 11 05 47 AM" src="https://github.com/user-attachments/assets/e675c140-152e-4f54-bf6e-46a946efe916" />

LLM Integrations can be edited and deleted:

<img width="1110" alt="Screenshot 2025-04-03 at 11 05 31 AM" src="https://github.com/user-attachments/assets/7ec86333-b349-46b3-9a46-687209e3bb26" />

