### PR TITLE
Make diagnostic plot summary labels more descriptive

### DIFF
--- a/src/aptible-ai/index.ts
+++ b/src/aptible-ai/index.ts
@@ -29,6 +29,9 @@ export interface Plot {
   id: string;
   title: string;
   description: string;
+  resource_id: string;
+  resource_type: string;
+  resource_label: string;
   interpretation: string;
   analysis: string;
   unit: string;
@@ -77,7 +80,7 @@ export const handleDashboardEvent = (
         ...dashboard,
         resources: {
           ...dashboard.resources,
-          [event.resource_id]: {
+          [event.resource_label]: {
             id: event.resource_id,
             label: event.resource_label,
             type: event.resource_type,
@@ -92,10 +95,10 @@ export const handleDashboardEvent = (
         ...dashboard,
         resources: {
           ...dashboard.resources,
-          [event.resource_id]: {
-            ...dashboard.resources[event.resource_id],
+          [event.resource_label]: {
+            ...dashboard.resources[event.resource_label],
             plots: {
-              ...dashboard.resources[event.resource_id].plots,
+              ...dashboard.resources[event.resource_label].plots,
               [event.plot.id]: {
                 id: event.plot.id,
                 title: event.plot.title,
@@ -117,12 +120,14 @@ export const handleDashboardEvent = (
         ...dashboard,
         resources: {
           ...dashboard.resources,
-          [event.resource_id]: {
-            ...dashboard.resources[event.resource_id],
+          [event.resource_label]: {
+            ...dashboard.resources[event.resource_label],
             plots: {
-              ...dashboard.resources[event.resource_id].plots,
+              ...dashboard.resources[event.resource_label].plots,
               [event.plot_id]: {
-                ...dashboard.resources[event.resource_id].plots[event.plot_id],
+                ...dashboard.resources[event.resource_label].plots[
+                  event.plot_id
+                ],
                 analysis: event.analysis,
                 annotations: event.annotations,
               },
@@ -135,10 +140,10 @@ export const handleDashboardEvent = (
         ...dashboard,
         resources: {
           ...dashboard.resources,
-          [event.resource_id]: {
-            ...dashboard.resources[event.resource_id],
+          [event.resource_label]: {
+            ...dashboard.resources[event.resource_label],
             operations: [
-              ...dashboard.resources[event.resource_id].operations,
+              ...dashboard.resources[event.resource_label].operations,
               ...event.operations,
             ],
           },

--- a/src/ui/pages/diagnostics-detail.tsx
+++ b/src/ui/pages/diagnostics-detail.tsx
@@ -164,7 +164,7 @@ export const DiagnosticsDetailPage = () => {
                       className="border rounded-lg bg-white shadow-sm animate-fade-in"
                     >
                       <h3 className="font-medium text-gray-900 p-3 rounded-t-lg border-b">
-                        {plot.title}
+                        {plot.resource_label} / {plot.title}
                       </h3>
                       <div className="pb-6 px-6">
                         <div className="mt-2 min-h-[200px]">


### PR DESCRIPTION
This PR adds the resource name to each plot in the diagnostic summary, and fixes an unlikely-but-possible overlap bug when two resources of different types have the same ID.