### PR TITLE
[sc-32581] Software Catalog improvements

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -164,7 +164,11 @@ import { SettingsTeamLlmIntegrationsPage } from "@app/ui/pages/settings-team-llm
 import { SettingsTeamLlmIntegrationsAddPage } from "@app/ui/pages/settings-team-llm-integrations-add";
 import { SettingsTeamLlmIntegrationsEditPage } from "@app/ui/pages/settings-team-llm-integrations-edit";
 import { SourcesSetupPage } from "@app/ui/pages/sources-setup";
-import { type RouteObject, createBrowserRouter } from "react-router-dom";
+import {
+  Navigate,
+  type RouteObject,
+  createBrowserRouter,
+} from "react-router-dom";
 import { Tuna } from "./tuna";
 
 const trackingPatch = (appRoute: RouteObject) => ({
@@ -618,12 +622,22 @@ export const appRoutes: RouteObject[] = [
       },
 
       {
-        path: routes.CUSTOM_RESOURCES_URL,
+        path: routes.SOFTWARE_CATALOG_URL,
         element: <CustomResourcesPage />,
       },
       {
-        path: routes.CUSTOM_RESOURCE_DETAIL_URL,
+        path: routes.SOFTWARE_CATALOG_DETAIL_URL,
         element: <CustomResourceDetailPage />,
+      },
+      {
+        path: routes.CUSTOM_RESOURCES_URL,
+        element: <Navigate to={routes.SOFTWARE_CATALOG_URL} replace />,
+      },
+      {
+        path: routes.CUSTOM_RESOURCE_DETAIL_URL,
+        element: (
+          <Navigate to={routes.softwareCatalogDetailUrl(":id")} replace />
+        ),
       },
 
       {

--- a/src/deploy/edge/index.ts
+++ b/src/deploy/edge/index.ts
@@ -94,7 +94,7 @@ export const fetchDependencyEdgesByResource = api.get<{
   resourceType: DeployEdgeType;
   timeRangeStart: string;
 }>(
-  "/edges?root_resource_id=:resourceId&root_resource_type=:resourceType&only_relationship_types[]=depends_on&time_range_start=:timeRangeStart&max_distance=1",
+  "/edges?root_resource_id=:resourceId&root_resource_type=:resourceType&time_range_start=:timeRangeStart&max_distance=1",
 );
 
 export const createEdge = api.post<

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -433,11 +433,18 @@ export const TEAM_LLM_INTEGRATIONS_EDIT_PATH =
 export const teamLlmIntegrationsEditUrl = (id: string) =>
   `/settings/team/llm-integrations/${id}/edit`;
 
+export const SOFTWARE_CATALOG_URL = "/software-catalog";
+export const softwareCatalogUrl = () => SOFTWARE_CATALOG_URL;
+export const SOFTWARE_CATALOG_DETAIL_URL = "/software-catalog/:id";
+export const softwareCatalogDetailUrl = (id: string) =>
+  `/software-catalog/${id}`;
+
+// Legacy URLs with redirects
 export const CUSTOM_RESOURCES_URL = "/custom-resources";
-export const customResourcesUrl = () => CUSTOM_RESOURCES_URL;
+export const customResourcesUrl = () => SOFTWARE_CATALOG_URL;
 export const CUSTOM_RESOURCE_DETAIL_URL = "/custom-resources/:id";
 export const customResourceDetailUrl = (id: string) =>
-  `/custom-resources/${id}`;
+  softwareCatalogDetailUrl(id);
 
 export const SOURCES_PATH = "/sources";
 export const sourcesUrl = () => SOURCES_PATH;

--- a/src/ui/pages/custom-resource-detail.tsx
+++ b/src/ui/pages/custom-resource-detail.tsx
@@ -3,7 +3,7 @@ import {
   selectCustomResourceById,
 } from "@app/deploy/custom-resource";
 import { useQuery, useSelector } from "@app/react";
-import { customResourcesUrl } from "@app/routes";
+import { softwareCatalogUrl } from "@app/routes";
 import type { ResourceItem } from "@app/search";
 import { useParams } from "react-router-dom";
 import { AppSidebarLayout } from "../layouts";
@@ -28,8 +28,8 @@ export const CustomResourceDetailPage = () => {
   if (!resource) {
     return (
       <AppSidebarLayout>
-        <TitleBar description="Loading custom resource details...">
-          Custom Resource Details
+        <TitleBar description="Loading resource details...">
+          Software Catalog Details
         </TitleBar>
       </AppSidebarLayout>
     );
@@ -44,9 +44,7 @@ export const CustomResourceDetailPage = () => {
 
   return (
     <AppSidebarLayout>
-      <TitleBar description="View custom resource details">
-        {resource.handle}
-      </TitleBar>
+      <TitleBar description="View resource details">{resource.handle}</TitleBar>
 
       <Box className="mb-4">
         <h2 className="text-lg font-medium mb-4">Resource Details</h2>
@@ -90,8 +88,8 @@ export const CustomResourceDetailPage = () => {
       </Box>
 
       <Group className="mt-4 flex w-fit">
-        <ButtonLink to={customResourcesUrl()} size="md">
-          Back to Custom Resources
+        <ButtonLink to={softwareCatalogUrl()} size="md">
+          Back to Software Catalog
         </ButtonLink>
       </Group>
     </AppSidebarLayout>

--- a/src/ui/pages/custom-resources.tsx
+++ b/src/ui/pages/custom-resources.tsx
@@ -39,9 +39,7 @@ export const CustomResourcesPage = () => {
 
   return (
     <AppSidebarLayout>
-      <TitleBar description="Manage your custom resources.">
-        Custom Resources
-      </TitleBar>
+      <TitleBar description="Manage your resources.">Software Catalog</TitleBar>
 
       <FilterBar>
         <div className="flex justify-between">
@@ -55,7 +53,7 @@ export const CustomResourcesPage = () => {
         </div>
 
         <Group variant="horizontal" size="lg" className="items-center mt-1">
-          <DescBar>{paginated.totalItems} Custom Resources</DescBar>
+          <DescBar>{paginated.totalItems} Resources</DescBar>
           <PaginateBar {...paginated} />
         </Group>
       </FilterBar>

--- a/src/ui/pages/custom-resources.tsx
+++ b/src/ui/pages/custom-resources.tsx
@@ -1,18 +1,24 @@
 import { fetchCustomResources } from "@app/deploy/custom-resource";
+import { selectCustomResourcesByResourceType } from "@app/deploy/custom-resource";
 import { selectCustomResourcesForTableSearch } from "@app/deploy/search";
 import { useQuery, useSelector } from "@app/react";
 import { customResourceDetailUrl } from "@app/routes";
+import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { usePaginate } from "../hooks/use-paginate";
 import { AppSidebarLayout } from "../layouts";
 import {
+  Box,
+  Button,
   ButtonLink,
   DescBar,
   EmptyTr,
   FilterBar,
   Group,
   InputSearch,
+  Label,
   PaginateBar,
+  Select,
   TBody,
   THead,
   Table,
@@ -27,15 +33,63 @@ export const CustomResourcesPage = () => {
 
   const [params, setParams] = useSearchParams();
   const search = params.get("search") || "";
+  const resourceType = params.get("resource_type") || "all";
+
+  const FILTER_ALL = "all";
+  const [resourceTypeFilter, setResourceTypeFilter] = useState(resourceType);
+
   const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    setParams({ search: ev.currentTarget.value }, { replace: true });
+    setParams(
+      {
+        search: ev.currentTarget.value,
+        resource_type: resourceType,
+      },
+      { replace: true },
+    );
   };
 
-  const customResources = useSelector((s) =>
+  // Get all custom resources for search and to extract available resource types
+  const allCustomResources = useSelector((s) =>
     selectCustomResourcesForTableSearch(s, { search }),
   );
 
-  const paginated = usePaginate(customResources);
+  // Extract unique resource types for the filter dropdown
+  const uniqueResourceTypes = [
+    ...new Set(allCustomResources.map((res) => res.resourceType)),
+  ].sort();
+  const resourceTypeOptions = [
+    { label: "All", value: FILTER_ALL },
+    ...uniqueResourceTypes.map((type) => ({
+      label: type,
+      value: type,
+    })),
+  ];
+
+  // Filter resources by type if a specific type is selected
+  const filteredResources = useSelector((s) =>
+    resourceType === FILTER_ALL
+      ? selectCustomResourcesForTableSearch(s, { search })
+      : selectCustomResourcesByResourceType(s, { resourceType }).filter((res) =>
+          res.handle.toLowerCase().includes(search.toLowerCase()),
+        ),
+  );
+
+  const paginated = usePaginate(filteredResources);
+
+  const onFilter = () => {
+    setParams(
+      {
+        search,
+        resource_type: resourceTypeFilter,
+      },
+      { replace: true },
+    );
+  };
+
+  const onReset = () => {
+    setResourceTypeFilter(FILTER_ALL);
+    setParams({ search }, { replace: true });
+  };
 
   return (
     <AppSidebarLayout>
@@ -57,6 +111,44 @@ export const CustomResourcesPage = () => {
           <PaginateBar {...paginated} />
         </Group>
       </FilterBar>
+
+      <Box>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            onFilter();
+          }}
+        >
+          <Group>
+            <Group variant="horizontal">
+              <div className="flex-1">
+                <Label htmlFor="resource-type-selector">Resource Type</Label>
+                <Select
+                  id="resource-type-selector"
+                  value={resourceTypeFilter}
+                  options={resourceTypeOptions}
+                  onSelect={(opt) => setResourceTypeFilter(opt.value)}
+                  className="w-full"
+                />
+              </div>
+            </Group>
+
+            <hr />
+
+            <Group
+              variant="horizontal"
+              className="items-center justify-between"
+            >
+              <Group variant="horizontal" size="sm">
+                <Button type="submit">Filter</Button>
+                <Button variant="white" onClick={onReset}>
+                  Reset
+                </Button>
+              </Group>
+            </Group>
+          </Group>
+        </form>
+      </Box>
 
       <Table>
         <THead>

--- a/src/ui/pages/home.tsx
+++ b/src/ui/pages/home.tsx
@@ -1,13 +1,29 @@
+import { FETCH_REQUIRED_DATA } from "@app/bootup";
 import { selectHasDiagnosticsPocFeature } from "@app/organizations";
 import { useSelector } from "@app/react";
-import { diagnosticsUrl, environmentsUrl } from "@app/routes";
+import { environmentsUrl, softwareCatalogUrl } from "@app/routes";
+import { schema } from "@app/schema";
 import { Navigate } from "react-router";
+import { Loading } from "../shared";
 
 export const HomePage = () => {
+  const loader = useSelector((s) =>
+    schema.loaders.selectById(s, { id: FETCH_REQUIRED_DATA }),
+  );
   const hasDiagnosticsPoc = useSelector(selectHasDiagnosticsPocFeature);
+
+  // Wait for required data to be loaded before redirecting
+  if (loader.status !== "success") {
+    return (
+      <div className="flex h-screen w-screen items-center justify-center">
+        <Loading text="Loading" />
+      </div>
+    );
+  }
+
   return (
     <Navigate
-      to={hasDiagnosticsPoc ? diagnosticsUrl() : environmentsUrl()}
+      to={hasDiagnosticsPoc ? softwareCatalogUrl() : environmentsUrl()}
       replace
     />
   );

--- a/src/ui/shared/application-sidebar.tsx
+++ b/src/ui/shared/application-sidebar.tsx
@@ -9,7 +9,6 @@ import {
   activityUrl,
   appsUrl,
   billingMethodUrl,
-  customResourcesUrl,
   databaseUrl,
   deployUrl,
   deploymentsUrl,
@@ -19,6 +18,7 @@ import {
   searchUrl,
   securityDashboardUrl,
   servicesUrl,
+  softwareCatalogUrl,
   sourcesUrl,
   stacksUrl,
   supportUrl,
@@ -91,8 +91,8 @@ export const ApplicationSidebar = () => {
             icon: <IconDiagnostics />,
           },
           {
-            name: "Custom Resources",
-            to: customResourcesUrl(),
+            name: "Software Catalog",
+            to: softwareCatalogUrl(),
             icon: <IconCloud />,
           },
         ]

--- a/src/ui/shared/dependencies/custom-nodes.tsx
+++ b/src/ui/shared/dependencies/custom-nodes.tsx
@@ -2,7 +2,7 @@ import { selectCustomResourceById } from "@app/deploy";
 import { useSelector } from "@app/react";
 import { softwareCatalogDetailUrl } from "@app/routes";
 import { Link } from "react-router";
-import { IconCylinder } from "../icons";
+import { IconUserCircle } from "../icons";
 import { IconCloud } from "../icons";
 import { type ResourceNodeProps, StandardNode } from "./node";
 
@@ -12,14 +12,19 @@ export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
   let icon = <IconCloud />;
 
   if (resource?.resourceType) {
-    if (resource.resourceType.includes(":ecs_service")) {
+    // Determine icon based on resource type
+    if (resource.resourceType === "aws:ecs_service") {
       icon = <img src="/resource-types/logo-ecs.png" alt="ECS Service" />;
-    } else if (resource.resourceType.includes(":rds_database")) {
+    } else if (resource.resourceType === "aws:rds_database") {
       icon = <img src="/resource-types/logo-rds.png" alt="RDS Database" />;
-    } else if (resource.resourceType.includes(":redis_database")) {
-      icon = <img src="/database-types/logo-redis.png" alt="Redis Database" />;
-    } else if (resource.resourceType.includes(":database:")) {
-      icon = <IconCylinder />;
+    } else if (resource.resourceType === "aws:elb") {
+      icon = <img src="/resource-types/logo-vhost.png" alt="ELB" />;
+    } else if (resource.resourceType.includes("k8s:")) {
+      icon = <img src="/resource-types/logo-eks.png" alt="Kubernetes Resource" />;
+    } else if (resource.resourceType === "datadog:service") {
+      icon = <img src="/resource-types/logo-datadog.png" alt="Datadog Service" />;
+    } else if (resource.resourceType === "datadog:team") {
+      icon = <IconUserCircle />;
     }
   }
 

--- a/src/ui/shared/dependencies/custom-nodes.tsx
+++ b/src/ui/shared/dependencies/custom-nodes.tsx
@@ -6,10 +6,37 @@ import { IconUserCircle } from "../icons";
 import { IconCloud } from "../icons";
 import { type ResourceNodeProps, StandardNode } from "./node";
 
+// Function to hash a string to a number between 0 and max-1
+const hashString = (str: string, max: number): number => {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 31 + str.charCodeAt(i)) % max;
+  }
+  return Math.abs(hash);
+};
+
+// Available background color classes from Tailwind's palette
+// Using -50 variants for subtle background colors
+const bgColorClasses = [
+  "bg-orange-50",
+  "bg-amber-50",
+  "bg-green-50",
+  "bg-emerald-50",
+  "bg-teal-50",
+  "bg-sky-50",
+  "bg-blue-50",
+  "bg-violet-50",
+  "bg-purple-50",
+  "bg-fuchsia-50",
+  "bg-pink-50",
+  "bg-rose-50",
+];
+
 export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
   const resource = useSelector((s) => selectCustomResourceById(s, { id }));
 
   let icon = <IconCloud />;
+  let bgColor = "bg-gray-50"; // Default color
 
   if (resource?.resourceType) {
     // Determine icon based on resource type
@@ -26,6 +53,10 @@ export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
     } else if (resource.resourceType === "datadog:team") {
       icon = <IconUserCircle />;
     }
+
+    // Determine background color based on hash of resource type
+    const colorIndex = hashString(resource.resourceType, bgColorClasses.length);
+    bgColor = bgColorClasses[colorIndex];
   }
 
   let providerIconUrl = undefined;
@@ -35,8 +66,17 @@ export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
     }
   }
 
+  // Don't override the background color if it's the root node
+  if (isRoot) {
+    bgColor = "bg-white";
+  }
+
   return (
-    <StandardNode isRoot={isRoot} providerIconUrl={providerIconUrl}>
+    <StandardNode
+      isRoot={isRoot}
+      providerIconUrl={providerIconUrl}
+      bgColor={bgColor}
+    >
       <div className="flex flex-col">
         <div className="flex gap-x-1 items-center">
           <div className="flex w-5 h-5 items-center justify-center">{icon}</div>

--- a/src/ui/shared/dependencies/custom-nodes.tsx
+++ b/src/ui/shared/dependencies/custom-nodes.tsx
@@ -6,37 +6,10 @@ import { IconUserCircle } from "../icons";
 import { IconCloud } from "../icons";
 import { type ResourceNodeProps, StandardNode } from "./node";
 
-// Function to hash a string to a number between 0 and max-1
-const hashString = (str: string, max: number): number => {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = (hash * 31 + str.charCodeAt(i)) % max;
-  }
-  return Math.abs(hash);
-};
-
-// Available background color classes from Tailwind's palette
-// Using -50 variants for subtle background colors
-const bgColorClasses = [
-  "bg-orange-50",
-  "bg-amber-50",
-  "bg-green-50",
-  "bg-emerald-50",
-  "bg-teal-50",
-  "bg-sky-50",
-  "bg-blue-50",
-  "bg-violet-50",
-  "bg-purple-50",
-  "bg-fuchsia-50",
-  "bg-pink-50",
-  "bg-rose-50",
-];
-
 export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
   const resource = useSelector((s) => selectCustomResourceById(s, { id }));
 
   let icon = <IconCloud />;
-  let bgColor = "bg-gray-50"; // Default color
 
   if (resource?.resourceType) {
     // Determine icon based on resource type
@@ -57,10 +30,6 @@ export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
     } else if (resource.resourceType === "datadog:team") {
       icon = <IconUserCircle />;
     }
-
-    // Determine background color based on hash of resource type
-    const colorIndex = hashString(resource.resourceType, bgColorClasses.length);
-    bgColor = bgColorClasses[colorIndex];
   }
 
   let providerIconUrl = undefined;
@@ -70,17 +39,8 @@ export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
     }
   }
 
-  // Don't override the background color if it's the root node
-  if (isRoot) {
-    bgColor = "bg-white";
-  }
-
   return (
-    <StandardNode
-      isRoot={isRoot}
-      providerIconUrl={providerIconUrl}
-      bgColor={bgColor}
-    >
+    <StandardNode isRoot={isRoot} providerIconUrl={providerIconUrl}>
       <div className="flex flex-col">
         <div className="flex gap-x-1 items-center">
           <div className="flex w-5 h-5 items-center justify-center">{icon}</div>

--- a/src/ui/shared/dependencies/custom-nodes.tsx
+++ b/src/ui/shared/dependencies/custom-nodes.tsx
@@ -47,9 +47,13 @@ export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
     } else if (resource.resourceType === "aws:elb") {
       icon = <img src="/resource-types/logo-vhost.png" alt="ELB" />;
     } else if (resource.resourceType.includes("k8s:")) {
-      icon = <img src="/resource-types/logo-eks.png" alt="Kubernetes Resource" />;
+      icon = (
+        <img src="/resource-types/logo-eks.png" alt="Kubernetes Resource" />
+      );
     } else if (resource.resourceType === "datadog:service") {
-      icon = <img src="/resource-types/logo-datadog.png" alt="Datadog Service" />;
+      icon = (
+        <img src="/resource-types/logo-datadog.png" alt="Datadog Service" />
+      );
     } else if (resource.resourceType === "datadog:team") {
       icon = <IconUserCircle />;
     }

--- a/src/ui/shared/dependencies/custom-nodes.tsx
+++ b/src/ui/shared/dependencies/custom-nodes.tsx
@@ -1,6 +1,6 @@
 import { selectCustomResourceById } from "@app/deploy";
 import { useSelector } from "@app/react";
-import { customResourceDetailUrl } from "@app/routes";
+import { softwareCatalogDetailUrl } from "@app/routes";
 import { Link } from "react-router";
 import { IconCylinder } from "../icons";
 import { IconCloud } from "../icons";
@@ -32,20 +32,27 @@ export const CustomResourceNode = ({ id, isRoot }: ResourceNodeProps) => {
 
   return (
     <StandardNode isRoot={isRoot} providerIconUrl={providerIconUrl}>
-      <div className="flex gap-x-1 items-center">
-        <div className="flex w-5 h-5 items-center justify-center">{icon}</div>
-        <div className="overflow-hidden text-ellipsis whitespace-nowrap font-mono">
-          {isRoot ? (
-            <span className="">{resource?.handle}</span>
-          ) : (
-            <Link
-              className="text-gray-500 underline hover:no-underline"
-              to={customResourceDetailUrl(id)}
-            >
-              {resource?.handle}
-            </Link>
-          )}
+      <div className="flex flex-col">
+        <div className="flex gap-x-1 items-center">
+          <div className="flex w-5 h-5 items-center justify-center">{icon}</div>
+          <div className="overflow-hidden text-ellipsis whitespace-nowrap font-mono">
+            {isRoot ? (
+              <span className="">{resource?.handle}</span>
+            ) : (
+              <Link
+                className="text-gray-500 underline hover:no-underline"
+                to={softwareCatalogDetailUrl(id)}
+              >
+                {resource?.handle}
+              </Link>
+            )}
+          </div>
         </div>
+        {resource?.resourceType && (
+          <div className="text-xs text-gray-400 font-mono ml-6 mt-1 overflow-hidden text-ellipsis whitespace-nowrap">
+            {resource.resourceType}
+          </div>
+        )}
       </div>
     </StandardNode>
   );

--- a/src/ui/shared/dependencies/edges.tsx
+++ b/src/ui/shared/dependencies/edges.tsx
@@ -32,6 +32,7 @@ export const AnomalyHistoryEdge = ({
   style = {},
   markerEnd,
   data,
+  label,
 }: AnomalyHistoryEdgeProps) => {
   const [edgePath] = getBezierPath({
     sourceX,
@@ -46,6 +47,9 @@ export const AnomalyHistoryEdge = ({
 
   const midX = (sourceX + targetX) / 2;
   const midY = (sourceY + targetY) / 2;
+
+  // Format relationship type by replacing underscores with spaces
+  const relationshipLabel = data?.label ? data.label.replace(/_/g, " ") : "";
 
   return (
     <>
@@ -63,6 +67,11 @@ export const AnomalyHistoryEdge = ({
 
             <div className="group-hover:visible invisible absolute -top-7 w-auto p-6">
               <div className="flex flex-col bg-white shadow border rounded-md p-2 z-20 whitespace-nowrap">
+                {relationshipLabel && (
+                  <div className="font-medium border-b pb-1 mb-2">
+                    {relationshipLabel}
+                  </div>
+                )}
                 {Object.entries(data?.anomalyHistory || {}).map(
                   ([dashboardId, anomalyHistory]) => {
                     return (
@@ -90,6 +99,12 @@ export const AnomalyHistoryEdge = ({
   );
 };
 
+interface DegradedEdgeProps extends EdgeProps {
+  data?: {
+    label?: string;
+  };
+}
+
 export const DegradedEdge = ({
   sourceX,
   sourceY,
@@ -99,8 +114,9 @@ export const DegradedEdge = ({
   targetPosition,
   style = {},
   markerEnd,
+  data,
   label,
-}: EdgeProps) => {
+}: DegradedEdgeProps) => {
   const [edgePath] = getBezierPath({
     sourceX,
     sourceY,
@@ -114,6 +130,9 @@ export const DegradedEdge = ({
 
   const midX = (sourceX + targetX) / 2;
   const midY = (sourceY + targetY) / 2;
+
+  // Format the relationship type from the label by replacing underscores with spaces
+  const relationshipLabel = data?.label ? data.label.replace(/_/g, " ") : "";
 
   return (
     <>
@@ -133,11 +152,9 @@ export const DegradedEdge = ({
             <IconAlertCircle color="white" className="w-4 h-4" />
           </div>
 
-          {label && (
-            <div className="peer-hover:block hidden absolute -top-10 left-6 w-auto bg-black text-white rounded-md p-2 z-20 whitespace-nowrap">
-              <div>{label}</div>
-            </div>
-          )}
+          <div className="peer-hover:block hidden absolute -top-10 left-6 w-auto bg-black text-white rounded-md p-2 z-20 whitespace-nowrap">
+            {relationshipLabel && <div>{relationshipLabel}</div>}
+          </div>
         </div>
       </EdgeLabelRenderer>
     </>

--- a/src/ui/shared/dependencies/graph.tsx
+++ b/src/ui/shared/dependencies/graph.tsx
@@ -66,6 +66,14 @@ export const DependencyGraph = ({
     deletable: false,
     selectable: false,
     focusable: false,
+    style: {
+      strokeWidth: 1,
+    },
+    labelStyle: {
+      fontSize: 10,
+      fill: "gray",
+      fontFamily: "monospace",
+    },
   };
 
   return (

--- a/src/ui/shared/dependencies/node.tsx
+++ b/src/ui/shared/dependencies/node.tsx
@@ -7,18 +7,20 @@ export interface StandardNodeProps {
   children: React.ReactNode;
   isRoot: boolean;
   providerIconUrl?: string;
+  bgColor?: string;
 }
 
 export const StandardNode = ({
   children,
   isRoot,
   providerIconUrl,
+  bgColor,
 }: StandardNodeProps) => {
   return (
     <div
       className={`w-64 text-xs px-3 py-2 shadow border rounded-lg relative ${
-        isRoot ? "border-blue-300 bg-white" : "border-black-100 bg-gray-50"
-      }`}
+        isRoot ? "border-blue-300" : "border-black-100"
+      } ${bgColor || (isRoot ? "bg-white" : "bg-gray-50")}`}
     >
       {providerIconUrl && (
         <div className="flex w-6 h-6 absolute -top-3 -left-3 bg-white rounded-full border items-center justify-center p-0.5">

--- a/src/ui/shared/dependencies/node.tsx
+++ b/src/ui/shared/dependencies/node.tsx
@@ -7,20 +7,18 @@ export interface StandardNodeProps {
   children: React.ReactNode;
   isRoot: boolean;
   providerIconUrl?: string;
-  bgColor?: string;
 }
 
 export const StandardNode = ({
   children,
   isRoot,
   providerIconUrl,
-  bgColor,
 }: StandardNodeProps) => {
   return (
     <div
       className={`w-64 text-xs px-3 py-2 shadow border rounded-lg relative ${
-        isRoot ? "border-blue-300" : "border-black-100"
-      } ${bgColor || (isRoot ? "bg-white" : "bg-gray-50")}`}
+        isRoot ? "border-blue-300 bg-white" : "border-black-100 bg-gray-50"
+      }`}
     >
       {providerIconUrl && (
         <div className="flex w-6 h-6 absolute -top-3 -left-3 bg-white rounded-full border items-center justify-center p-0.5">

--- a/src/ui/shared/dependencies/single-resource-item.tsx
+++ b/src/ui/shared/dependencies/single-resource-item.tsx
@@ -145,6 +145,8 @@ const getAllEdges = (
         ),
         animated: true,
         data: { label: edge.relationshipType },
+        // Add visible label to all edges with formatted relationship type
+        label: edge.relationshipType.replace(/_/g, " "),
       };
 
       if (degradedEdges[edge.id]) {
@@ -167,6 +169,8 @@ const getAllEdges = (
         edgeData.data = {
           ...edgeData.data,
           anomalyHistory,
+          // Ensure the label is also passed in data for edge components
+          label: edge.relationshipType,
         };
       }
 


### PR DESCRIPTION
A handful of improvements to the Software Catalog, in separate commits:

- Rename UI label and route from Custom Resources -> Software Catalog
- Update resource icons to match currently existing resource types
- Add resource type to React Flow node display
- Show all edge types, not just depends_on
- Annotate edges in React Flow diagrams with relationship_type
- Correctly route to /software-catalog from / if selectHasDiagnosticsPocFeature
- Add ability to filter by resource type to Software Catalog

Loom showing the improvements here: https://www.loom.com/share/77bded5ddf334a548c6163e68a275e59

I had a commit that rendered resource nodes in different colors by resource type (12988c56acc28f7ef2fea4afbfe0b10c225e16b7) but on second thought I removed it: I think the addition of logos makes the color coding less important and I can't confidently say the color coding is aesthetically better.