### PR TITLE
add total cost row to environment and stack tables

### DIFF
--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -1,6 +1,7 @@
 import {
   fetchCostsByStacks,
   fetchStacks,
+  formatCurrency,
   getStackTypeTitle,
   selectAppsCountByStack,
   selectDatabasesCountByStack,
@@ -32,6 +33,7 @@ import {
   PaginateBar,
   StackItemView,
   TBody,
+  TFoot,
   THead,
   Table,
   Td,
@@ -168,6 +170,9 @@ function StackList() {
     return stacks;
   }, [stacks, sortKey, sortDirection, envCounts, appCounts, dbCounts]);
 
+  // Calculate total cost of all stacks
+  const totalCost = stacks.reduce((sum, stack) => sum + (stack.cost || 0), 0);
+
   const paginated = usePaginate(sortedStacks);
 
   const SortIcon = () => (
@@ -270,6 +275,21 @@ function StackList() {
             <StackListRow key={stack.id} stack={stack} />
           ))}
         </TBody>
+
+        {paginated.data.length > 0 && (
+          <TFoot>
+            <Tr className="font-medium">
+              <Td colSpan={8} className="text-right font-semibold text-black">
+                Total Est. Monthly Cost
+              </Td>
+              <Td>
+                <span className="font-semibold text-black">
+                  {formatCurrency(totalCost)}
+                </span>
+              </Td>
+            </Tr>
+          </TFoot>
+        )}
       </Table>
     </Group>
   );

--- a/src/ui/shared/environment/environment-list.tsx
+++ b/src/ui/shared/environment/environment-list.tsx
@@ -35,7 +35,7 @@ import {
   PaginateBar,
   TitleBar,
 } from "../resource-list-view";
-import { EmptyTr, TBody, THead, Table, Td, Th, Tr } from "../table";
+import { EmptyTr, TBody, TFoot, THead, Table, Td, Th, Tr } from "../table";
 import { tokens } from "../tokens";
 
 interface EnvironmentCellProps {
@@ -160,6 +160,10 @@ export function EnvironmentList({
     selectEnvironmentsForTableSearch(s, { search, stackId, sortBy, sortDir }),
   );
   const paginated = usePaginate(envs);
+
+  // Calculate total cost of all environments
+  const totalCost = envs.reduce((sum, env) => sum + (env.cost || 0), 0);
+
   const onSort = (key: keyof DeployEnvironmentRow) => {
     if (key === sortBy) {
       setSortDir(sortDir === "asc" ? "desc" : "asc");
@@ -252,7 +256,7 @@ export function EnvironmentList({
         </THead>
 
         <TBody>
-          {paginated.data.length === 0 ? <EmptyTr colSpan={5} /> : null}
+          {paginated.data.length === 0 ? <EmptyTr colSpan={6} /> : null}
           {paginated.data.map((env) => (
             <Tr key={env.id}>
               <EnvironmentPrimaryCell env={env} />
@@ -264,6 +268,24 @@ export function EnvironmentList({
             </Tr>
           ))}
         </TBody>
+
+        {paginated.data.length > 0 && (
+          <TFoot>
+            <Tr className="font-medium">
+              <Td colSpan={5} className="text-right font-semibold text-black">
+                Total Est. Monthly Cost
+              </Td>
+              <Td>
+                <CostEstimateTooltip
+                  cost={totalCost}
+                  text={`Total includes all environments across all pages of results. \
+This is an estimate of the total cost across selected environments for one month, \
+and excludes some costs, such as account-level and stack-level costs.`}
+                />
+              </Td>
+            </Tr>
+          </TFoot>
+        )}
       </Table>
     </Group>
   );

--- a/src/ui/shared/table.tsx
+++ b/src/ui/shared/table.tsx
@@ -33,6 +33,12 @@ export const TBody = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
+export const TFoot = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <tfoot className="bg-gray-50 border-t border-gray-300">{children}</tfoot>
+  );
+};
+
 export const Tr = ({
   children,
   className = "",


### PR DESCRIPTION
Adds a total estimated monthly cost row to both the Environments and Stacks tables. The total:
- Appears at the bottom of each table when there are items listed
- Sums costs across all pages of filtered results
- Uses the existing cost tooltip component with clarifying text about what's included
- Maintains consistent styling with the rest of the table using TFoot

<img width="249" alt="image" src="https://github.com/user-attachments/assets/0d6e9d55-eaf9-4327-b445-704eb5b3a09a" />
