### PR TITLE
make container ports editable for tcp/tls endpoints

### DIFF
--- a/src/deploy/endpoint/endpoint.test.ts
+++ b/src/deploy/endpoint/endpoint.test.ts
@@ -2,7 +2,37 @@
 
 import { createId } from "@app/mocks";
 import { defaultDeployEndpoint } from "@app/schema";
-import { getEndpointDisplayHost, getEndpointUrl } from "./index";
+import {
+  getEndpointDisplayHost,
+  getEndpointUrl,
+  parsePortsStrToNum,
+} from "./index";
+
+describe("parsePortsStrToNum", () => {
+  describe("when parsing comma-separated ports", () => {
+    it("should convert to number array", () => {
+      expect(parsePortsStrToNum("8080,9000,3000")).toEqual([8080, 9000, 3000]);
+    });
+  });
+
+  describe("when parsing space-separated ports", () => {
+    it("should convert to number array", () => {
+      expect(parsePortsStrToNum("8080 9000 3000")).toEqual([8080, 9000, 3000]);
+    });
+  });
+
+  describe("when handling empty strings", () => {
+    it("should return empty array", () => {
+      expect(parsePortsStrToNum("")).toEqual([]);
+    });
+  });
+
+  describe("when filtering empty items", () => {
+    it("should ignore empty items", () => {
+      expect(parsePortsStrToNum("8080,,9000")).toEqual([8080, 9000]);
+    });
+  });
+});
 
 describe("getDisplayHost", () => {
   describe("when no endpoint is provided", () => {

--- a/src/deploy/endpoint/index.ts
+++ b/src/deploy/endpoint/index.ts
@@ -916,6 +916,10 @@ export const canHaveTokenHeader = (enp: DeployEndpoint) => {
   );
 };
 
+export const isTlsOrTcp = (enp: DeployEndpoint) => {
+  return enp.type === "tls" || enp.type === "tcp";
+};
+
 export const getContainerPort = (
   enp: Pick<DeployEndpoint, "containerPort" | "containerPorts">,
   exposedPorts: number[],
@@ -926,7 +930,7 @@ export const getContainerPort = (
     port = `${ports[0]}`;
   }
   if (enp.containerPorts.length > 0) {
-    return enp.containerPorts.join(",");
+    return enp.containerPorts.join(", ");
   }
   return enp.containerPort || `Default (${port})`;
 };

--- a/src/deploy/endpoint/index.ts
+++ b/src/deploy/endpoint/index.ts
@@ -37,7 +37,7 @@ export interface DeployEndpointResponse {
   acme_status: string;
   container_exposed_ports: string[] | null;
   container_port: string | null;
-  container_ports: string[];
+  container_ports: number[];
   default: boolean;
   docker_name: string | null;
   elastic_load_balancer_name: string | null;
@@ -735,6 +735,7 @@ interface EndpointPatchProps {
   id: string;
   ipAllowlist: string[];
   containerPort: string;
+  containerPorts: number[];
   certId: string;
   tokenHeader: string | undefined;
 }
@@ -744,6 +745,7 @@ export interface EndpointUpdateProps extends EndpointPatchProps {
   privKey?: string;
   envId: string;
   requiresCert: boolean;
+  enpType?: EndpointType;
 }
 
 const patchEndpoint = api.patch<EndpointPatchProps>(
@@ -753,6 +755,7 @@ const patchEndpoint = api.patch<EndpointPatchProps>(
     const data: Record<string, any> = {
       ip_whitelist: ctx.payload.ipAllowlist,
       container_port: ctx.payload.containerPort,
+      container_ports: ctx.payload.containerPorts,
       token_header: ctx.payload.tokenHeader,
     };
     if (ctx.payload.certId) {
@@ -792,6 +795,7 @@ export const updateEndpoint = thunks.create<EndpointUpdateProps>(
       id: ctx.payload.id,
       ipAllowlist: ctx.payload.ipAllowlist,
       containerPort: ctx.payload.containerPort,
+      containerPorts: ctx.payload.containerPorts,
       certId,
       tokenHeader: ctx.payload.tokenHeader,
     });
@@ -977,4 +981,11 @@ export const getEndpointText = (enp: DeployEndpoint) => {
 
 export const parseIpStr = (ips: string) => {
   return ips.split(/\s+/).filter(Boolean);
+};
+
+export const parsePortsStrToNum = (ports: string) => {
+  return ports
+    .split(/[,\s]+/)
+    .filter(Boolean)
+    .map((port) => Number(port));
 };

--- a/src/deploy/endpoint/index.ts
+++ b/src/deploy/endpoint/index.ts
@@ -745,7 +745,7 @@ export interface EndpointUpdateProps extends EndpointPatchProps {
   privKey?: string;
   envId: string;
   requiresCert: boolean;
-  enpType?: EndpointType;
+  enpType: EndpointType;
 }
 
 const patchEndpoint = api.patch<EndpointPatchProps>(

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -494,6 +494,17 @@ export const testEndpoint = defaultEndpointResponse({
   },
 });
 
+export const testTlsEndpoint = defaultEndpointResponse({
+  id: createId(),
+  type: "tls",
+  _links: {
+    service: defaultHalHref(
+      `${testEnv.apiUrl}/services/${testServiceRails.id}`,
+    ),
+    certificate: defaultHalHref(),
+  },
+});
+
 export const testPlan = defaultPlanResponse({
   id: createId(),
 });

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -95,7 +95,7 @@ export interface DeployEndpoint extends Provisionable, Timestamps {
   acmeStatus: AcmeStatus;
   containerExposedPorts: any;
   containerPort: string;
-  containerPorts: string[];
+  containerPorts: number[];
   default: boolean;
   dockerName: string;
   externalHost: string;

--- a/src/ui/layouts/endpoint-detail-layout.tsx
+++ b/src/ui/layouts/endpoint-detail-layout.tsx
@@ -7,6 +7,7 @@ import {
   getContainerPort,
   getEndpointText,
   getEndpointUrl,
+  isTlsOrTcp,
   pollFetchEndpoint,
   requiresAcmeSetup,
   selectAppById,
@@ -114,7 +115,11 @@ export function EndpointAppHeaderInfo({
         </DetailInfoItem>
         <DetailInfoItem title="IP Allowlist">{txt.ipAllowlist}</DetailInfoItem>
         <DetailInfoItem title="Placement">{txt.placement}</DetailInfoItem>
-        <DetailInfoItem title="Port">{portTxt}</DetailInfoItem>
+        {isTlsOrTcp(enp) ? (
+          <DetailInfoItem title="Ports">{portTxt}</DetailInfoItem>
+        ) : (
+          <DetailInfoItem title="Port">{portTxt}</DetailInfoItem>
+        )}
         <DetailInfoItem title="Status">
           <EndpointStatusPill status={enp.status} />
         </DetailInfoItem>

--- a/src/ui/pages/endpoint-detail-settings.test.tsx
+++ b/src/ui/pages/endpoint-detail-settings.test.tsx
@@ -119,7 +119,7 @@ describe("EndpointSettings for an Endpoint associated with an App", () => {
       const btn = await screen.findByRole("button", { name: /Save Changes/ });
       fireEvent.click(btn);
 
-      await screen.findByText(/Current container ports: 5000,5001/);
+      await screen.findByText(/Current container ports: 5000, 5001/);
       await screen.findByText(/Operations show real-time changes to resources/);
     });
   });

--- a/src/ui/pages/endpoint-detail-settings.test.tsx
+++ b/src/ui/pages/endpoint-detail-settings.test.tsx
@@ -78,7 +78,7 @@ describe("EndpointSettings for an Endpoint associated with an App", () => {
       await screen.findByText(/Operations show real-time changes to resources/);
     });
   });
-
+  //TODO: add test checking container ports, using a TCP/TLS endpoint.
   describe("when endpoint does not require a cert", () => {
     it("should *not* display cert selector", async () => {
       server.use(...verifiedUserHandlers());

--- a/src/ui/pages/endpoint-detail-settings.tsx
+++ b/src/ui/pages/endpoint-detail-settings.tsx
@@ -4,6 +4,7 @@ import {
   getContainerPort,
   isRequiresCert,
   parseIpStr,
+  parsePortsStrToNum,
   selectAppById,
   selectEndpointById,
   selectImageById,
@@ -37,7 +38,22 @@ import {
 } from "../shared";
 
 const validators = {
-  port: (data: EndpointUpdateProps) => portValidator(data.containerPort),
+  port: (data: EndpointUpdateProps) => {
+    if (data.enpType !== "tls" && data.enpType !== "tcp") {
+      return portValidator(data.containerPort);
+    }
+  },
+  ports: (data: EndpointUpdateProps) => {
+    if (data.enpType === "tls" || data.enpType === "tcp") {
+      const errs: string[] = [];
+      data.containerPorts.forEach((port) => {
+        const result = portValidator(port.toString());
+        if (result) errs.push(`[${port}] is not between 1 and 65535`);
+      });
+      if (errs.length === 0) return;
+      return errs.join(", ");
+    }
+  },
   ipAllowlist: (data: EndpointUpdateProps) => ipValidator(data.ipAllowlist),
   cert: (data: EndpointUpdateProps) => {
     if (data.requiresCert && data.certId === "" && data.cert === "") {
@@ -66,8 +82,10 @@ const EndpointSettings = ({ endpointId }: { endpointId: string }) => {
   const hasTokenHeaderFeature = useSelector(selectHasTokenHeaderFeature);
   const exposedPorts = image.exposedPorts;
   const origAllowlist = enp.ipWhitelist.join("\n");
+  const origContainerPorts = exposedPorts.join("s");
   const [ipAllowlist, setIpAllowlist] = useState(origAllowlist);
   const [port, setPort] = useState(enp.containerPort);
+  const [ports, setPorts] = useState(origContainerPorts);
   const [certId, setCertId] = useState(enp.certificateId);
   const [cert, setCert] = useState("");
   const [privKey, setPrivKey] = useState("");
@@ -83,6 +101,9 @@ const EndpointSettings = ({ endpointId }: { endpointId: string }) => {
     setPort(enp.containerPort);
   }, [enp.containerPort]);
   useEffect(() => {
+    setPorts(origContainerPorts);
+  }, [origContainerPorts]);
+  useEffect(() => {
     setCertId(enp.certificateId);
   }, [enp.certificateId]);
 
@@ -90,6 +111,7 @@ const EndpointSettings = ({ endpointId }: { endpointId: string }) => {
     id: endpointId,
     ipAllowlist: parseIpStr(ipAllowlist),
     containerPort: port,
+    containerPorts: parsePortsStrToNum(ports),
     certId,
     envId: service.environmentId,
     cert,
@@ -100,10 +122,11 @@ const EndpointSettings = ({ endpointId }: { endpointId: string }) => {
   };
   const ipsSame = origAllowlist === ipAllowlist;
   const portSame = enp.containerPort === port;
+  const portsSame = origContainerPorts === ports;
   const certSame = enp.certificateId === certId;
   const tokenSame = enp.tokenHeader === tokenHeader;
   const isDisabled =
-    ipsSame && portSame && certSame && cert === "" && tokenSame;
+    ipsSame && portSame && portsSame && certSame && cert === "" && tokenSame;
   const curPortText = getContainerPort(enp, exposedPorts);
   const loader = useLoader(updateEndpoint);
   const [errors, validate] = useValidator<
@@ -201,22 +224,42 @@ const EndpointSettings = ({ endpointId }: { endpointId: string }) => {
       </>
     ) : null;
 
+  const isTlsOrTcp = enp.type === "tls" || enp.type === "tcp";
+
   const portForm = service.appId ? (
-    <FormGroup
-      label="Container Port"
-      description={`Current container port: ${curPortText}`}
-      htmlFor="port"
-      feedbackMessage={errors.port}
-      feedbackVariant={errors.port ? "danger" : "info"}
-    >
-      <Input
-        type="text"
-        id="port"
-        name="port"
-        value={port}
-        onChange={(e) => setPort(e.currentTarget.value)}
-      />
-    </FormGroup>
+    isTlsOrTcp ? (
+      <FormGroup
+        label="Container Ports"
+        description={`Current container ports: ${curPortText}`}
+        htmlFor="ports"
+        feedbackMessage={errors.ports}
+        feedbackVariant={errors.ports ? "danger" : "info"}
+      >
+        <Input
+          type="text"
+          id="ports"
+          name="ports"
+          value={ports}
+          onChange={(e) => setPorts(e.currentTarget.value)}
+        />
+      </FormGroup>
+    ) : (
+      <FormGroup
+        label="Container Port"
+        description={`Current container port: ${curPortText}`}
+        htmlFor="port"
+        feedbackMessage={errors.port}
+        feedbackVariant={errors.port ? "danger" : "info"}
+      >
+        <Input
+          type="text"
+          id="port"
+          name="port"
+          value={port}
+          onChange={(e) => setPort(e.currentTarget.value)}
+        />
+      </FormGroup>
+    )
   ) : null;
 
   const tokenEditForm =

--- a/src/ui/pages/endpoint-detail-settings.tsx
+++ b/src/ui/pages/endpoint-detail-settings.tsx
@@ -3,6 +3,7 @@ import {
   fetchImageById,
   getContainerPort,
   isRequiresCert,
+  isTlsOrTcp,
   parseIpStr,
   parsePortsStrToNum,
   selectAppById,
@@ -82,7 +83,7 @@ const EndpointSettings = ({ endpointId }: { endpointId: string }) => {
   const hasTokenHeaderFeature = useSelector(selectHasTokenHeaderFeature);
   const exposedPorts = image.exposedPorts;
   const origAllowlist = enp.ipWhitelist.join("\n");
-  const origContainerPorts = exposedPorts.join("s");
+  const origContainerPorts = enp.containerPorts.join(", ");
   const [ipAllowlist, setIpAllowlist] = useState(origAllowlist);
   const [port, setPort] = useState(enp.containerPort);
   const [ports, setPorts] = useState(origContainerPorts);
@@ -224,10 +225,8 @@ const EndpointSettings = ({ endpointId }: { endpointId: string }) => {
       </>
     ) : null;
 
-  const isTlsOrTcp = enp.type === "tls" || enp.type === "tcp";
-
   const portForm = service.appId ? (
-    isTlsOrTcp ? (
+    isTlsOrTcp(enp) ? (
       <FormGroup
         label="Container Ports"
         description={`Current container ports: ${curPortText}`}

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -36,7 +36,7 @@ export function ipValidator(ips: string[]) {
 export function portValidator(port = "") {
   if (!port) return;
   const msg = "Port must be a number between 1 and 65535";
-  const portNum = Number.parseInt(port, 10);
+  const portNum = Number(port);
   if (Number.isNaN(portNum)) return msg;
   if (portNum <= 0) return msg;
   if (portNum >= 65535) return msg;


### PR DESCRIPTION
[sc-32570]

This PR allows `container_ports` to be edited for TCP and TLS endpoints. The current iteration of the endpoint edits forms only changes `container_port,` which is not relevant for TCP and TLS endpoints and hits a validation error. 

It also changes the port validation from using `Number.parseInt` to just `Number,` since the former has weird behavior — for example, `8asdfsadfsaf` would be considered `8` by the validator.