### PR TITLE
improve clarity on disabling db backups

### DIFF
--- a/src/ui/pages/database-detail-settings.tsx
+++ b/src/ui/pages/database-detail-settings.tsx
@@ -338,8 +338,8 @@ const DatabaseNameChange = ({ database }: DbProps) => {
         description={
           <p>
             When disabled, there will be no new automatic backups taken of this
-            database. This does not automatically delete any existing taken
-            backups.{" "}
+            database, and no final database backups will be made. This does not
+            automatically delete any existing taken backups.{" "}
             <a
               href="https://www.aptible.com/docs/core-concepts/managed-databases/managing-databases/database-backups#excluding-a-database-from-new-automatic-backups"
               target="_blank"


### PR DESCRIPTION
Improve clarity on language around disabling db backups, to clarity that it will also prevent final backups from being made when the database is deprovisioned. Hold for @benjodo to merge.