### PR TITLE
add site selection for datadog metric drains

### DIFF
--- a/src/app/test/create-metric-drain.test.tsx
+++ b/src/app/test/create-metric-drain.test.tsx
@@ -48,6 +48,11 @@ describe("Create Metric Drain flow", () => {
       const apiKey = await screen.findByRole("textbox", { name: /API Key/ });
       await act(() => userEvent.type(apiKey, "some-api-key"));
 
+      const ddSite = await screen.findByRole("textbox", {
+        name: /Datadog Site/,
+      });
+      await act(() => userEvent.type(ddSite, "US1"));
+
       const btn = await screen.findByRole("button", {
         name: /Save Metric Drain/,
       });

--- a/src/app/test/create-metric-drain.test.tsx
+++ b/src/app/test/create-metric-drain.test.tsx
@@ -48,10 +48,10 @@ describe("Create Metric Drain flow", () => {
       const apiKey = await screen.findByRole("textbox", { name: /API Key/ });
       await act(() => userEvent.type(apiKey, "some-api-key"));
 
-      const ddSite = await screen.findByRole("textbox", {
+      const siteSelector = await screen.findByRole("combobox", {
         name: /Datadog Site/,
       });
-      await act(() => userEvent.type(ddSite, "US1"));
+      await act(() => userEvent.selectOptions(siteSelector, "US1"));
 
       const btn = await screen.findByRole("button", {
         name: /Save Metric Drain/,

--- a/src/deploy/metric-drain/index.ts
+++ b/src/deploy/metric-drain/index.ts
@@ -160,16 +160,27 @@ interface CreateInfluxDb2MetricDrain extends CreateMetricDrainBase {
   port?: string;
 }
 
-interface CreateDatabaseMetricDrain extends CreateMetricDrainBase {
+interface CreateDatadogMetricDrain extends CreateMetricDrainBase {
   drainType: "datadog";
   apiKey: string;
+  ddSite: string;
 }
+
+export const datadogSites: Record<string, string> = {
+  US1: "https://app.datadoghq.com",
+  US3: "https://us3.datadoghq.com",
+  US5: "https://us5.datadoghq.com",
+  EU1: "https://app.datadoghq.eu",
+  "US1-FED": "https://app.ddog-gov.com",
+};
+
+export const datadogPath = "/api/v1/series";
 
 export type CreateMetricDrainProps =
   | CreateInfluxDbEnvMetricDrain
   | CreateInfluxDb1MetricDrain
   | CreateInfluxDb2MetricDrain
-  | CreateDatabaseMetricDrain;
+  | CreateDatadogMetricDrain;
 
 export const createMetricDrain = api.post<
   CreateMetricDrainProps,
@@ -214,9 +225,14 @@ export const createMetricDrain = api.post<
       },
     });
   } else if (ctx.payload.drainType === "datadog") {
+    const site = ctx.payload.ddSite || "US1";
+    const series_url = datadogSites[site] + datadogPath;
     body = JSON.stringify({
       ...preBody,
-      drain_configuration: { api_key: ctx.payload.apiKey },
+      drain_configuration: {
+        api_key: ctx.payload.apiKey,
+        series_url: series_url,
+      },
     });
   }
 

--- a/src/ui/pages/create-metric-drain.tsx
+++ b/src/ui/pages/create-metric-drain.tsx
@@ -1,6 +1,7 @@
 import {
   type CreateMetricDrainProps,
   type MetricDrainType,
+  datadogSites,
   fetchDatabasesByEnvId,
   provisionMetricDrain,
   selectEnvironmentById,
@@ -92,6 +93,11 @@ const validators = {
     if (p.drainType !== "datadog") return;
     if (p.apiKey === "") return "Must provide a Datadog API key";
   },
+  ddSite: (p: CreateMetricDrainProps) => {
+    if (p.drainType !== "datadog") return;
+    if (!(p.ddSite in datadogSites) && p.ddSite !== "")
+      return `Must provide a Datadog Site in ${Object.keys(datadogSites).join(", ")}`;
+  },
 };
 
 export const CreateMetricDrainPage = () => {
@@ -105,6 +111,7 @@ export const CreateMetricDrainPage = () => {
   const [dbId, setDbId] = useState("");
   const [handle, setHandle] = useState("");
   const [apiKey, setApiKey] = useState("");
+  const [ddSite, setDdSite] = useState("");
   const [protocol, setProtocol] = useState<"http" | "https">("https");
   const [hostname, setHostname] = useState("");
   const [port, setPort] = useState("");
@@ -147,6 +154,7 @@ export const CreateMetricDrainPage = () => {
         ...def,
         drainType: "datadog",
         apiKey,
+        ddSite,
       };
     }
 
@@ -259,33 +267,50 @@ export const CreateMetricDrainPage = () => {
           ) : null}
 
           {drainType === "datadog" ? (
-            <FormGroup
-              label="API Key"
-              htmlFor="api-key"
-              description={
-                <div>
-                  <p>
-                    Create a new API Key in Datadog under{" "}
-                    <ExternalLink
-                      variant="info"
-                      href="https://app.datadoghq.com/account/settings#api"
-                    >
-                      Integrations / APIs
-                    </ExternalLink>{" "}
-                    (or reuse an existing one) and paste it here.
-                  </p>
-                </div>
-              }
-              feedbackMessage={errors.apiKey}
-              feedbackVariant={errors.apiKey ? "danger" : "info"}
-            >
-              <Input
-                type="text"
-                id="api-key"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.currentTarget.value)}
-              />
-            </FormGroup>
+            <>
+              <FormGroup
+                label="API Key"
+                htmlFor="api-key"
+                description={
+                  <div>
+                    <p>
+                      Create a new API Key in Datadog under{" "}
+                      <ExternalLink
+                        variant="info"
+                        href="https://app.datadoghq.com/account/settings#api"
+                      >
+                        Integrations / APIs
+                      </ExternalLink>{" "}
+                      (or reuse an existing one) and paste it here.
+                    </p>
+                  </div>
+                }
+                feedbackMessage={errors.apiKey}
+                feedbackVariant={errors.apiKey ? "danger" : "info"}
+              >
+                <Input
+                  type="text"
+                  id="api-key"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.currentTarget.value)}
+                />
+              </FormGroup>
+
+              <FormGroup
+                label="Datadog Site"
+                htmlFor="dd-site"
+                description={`Enter the Datadog Site to use. Valid sites are ${Object.keys(datadogSites).join(", ")}. If left blank, we assume US1.`}
+                feedbackMessage={errors.ddSite}
+                feedbackVariant={errors.ddSite ? "danger" : "info"}
+              >
+                <Input
+                  type="text"
+                  id="dd-site"
+                  value={ddSite}
+                  onChange={(e) => setDdSite(e.currentTarget.value)}
+                />
+              </FormGroup>
+            </>
           ) : null}
 
           {drainType === "influxdb" || drainType === "influxdb2" ? (

--- a/src/ui/pages/create-metric-drain.tsx
+++ b/src/ui/pages/create-metric-drain.tsx
@@ -113,7 +113,7 @@ export const CreateMetricDrainPage = () => {
   const [dbId, setDbId] = useState("");
   const [handle, setHandle] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [ddSite, setDdSite] = useState("");
+  const [ddSite, setDdSite] = useState("US1");
   const [protocol, setProtocol] = useState<"http" | "https">("https");
   const [hostname, setHostname] = useState("");
   const [port, setPort] = useState("");

--- a/src/ui/pages/create-metric-drain.tsx
+++ b/src/ui/pages/create-metric-drain.tsx
@@ -1,7 +1,6 @@
 import {
   type CreateMetricDrainProps,
   type MetricDrainType,
-  datadogSites,
   fetchDatabasesByEnvId,
   provisionMetricDrain,
   selectEnvironmentById,
@@ -39,6 +38,14 @@ const options: SelectOption<MetricDrainType>[] = [
   { value: "influxdb", label: "InfluxDb v1 (anywhere)" },
   { value: "influxdb2", label: "InfluxDb v2 (anywhere)" },
   { value: "datadog", label: "Datadog" },
+];
+
+const datadogSiteOptions: SelectOption[] = [
+  { label: "US1", value: "US1" },
+  { label: "US3", value: "US3" },
+  { label: "US5", value: "US5" },
+  { label: "EU1", value: "EU1" },
+  { label: "US1-FED", value: "US1-FED" },
 ];
 
 const validators = {
@@ -92,11 +99,6 @@ const validators = {
   apiKey: (p: CreateMetricDrainProps) => {
     if (p.drainType !== "datadog") return;
     if (p.apiKey === "") return "Must provide a Datadog API key";
-  },
-  ddSite: (p: CreateMetricDrainProps) => {
-    if (p.drainType !== "datadog") return;
-    if (!(p.ddSite in datadogSites) && p.ddSite !== "")
-      return `Must provide a Datadog Site in ${Object.keys(datadogSites).join(", ")}`;
   },
 };
 
@@ -299,15 +301,13 @@ export const CreateMetricDrainPage = () => {
               <FormGroup
                 label="Datadog Site"
                 htmlFor="dd-site"
-                description={`Enter the Datadog Site to use. Valid sites are ${Object.keys(datadogSites).join(", ")}. If left blank, we assume US1.`}
-                feedbackMessage={errors.ddSite}
-                feedbackVariant={errors.ddSite ? "danger" : "info"}
+                description="Select the Datadog Site to use."
               >
-                <Input
-                  type="text"
+                <Select
+                  ariaLabel="Datadog Site"
                   id="dd-site"
-                  value={ddSite}
-                  onChange={(e) => setDdSite(e.currentTarget.value)}
+                  options={datadogSiteOptions}
+                  onSelect={(opt) => setDdSite(opt.value)}
                 />
               </FormGroup>
             </>

--- a/src/ui/pages/create-metric-drain.tsx
+++ b/src/ui/pages/create-metric-drain.tsx
@@ -1,6 +1,7 @@
 import {
   type CreateMetricDrainProps,
   type MetricDrainType,
+  datadogSites,
   fetchDatabasesByEnvId,
   provisionMetricDrain,
   selectEnvironmentById,
@@ -40,8 +41,8 @@ const options: SelectOption<MetricDrainType>[] = [
   { value: "datadog", label: "Datadog" },
 ];
 
-const datadogSiteOptions: SelectOption[] = Object.keys(datadogSites).map((site) => (
-  { label: site, value: site })
+const datadogSiteOptions: SelectOption[] = Object.keys(datadogSites).map(
+  (site) => ({ label: site, value: site }),
 );
 
 const validators = {

--- a/src/ui/pages/create-metric-drain.tsx
+++ b/src/ui/pages/create-metric-drain.tsx
@@ -40,13 +40,9 @@ const options: SelectOption<MetricDrainType>[] = [
   { value: "datadog", label: "Datadog" },
 ];
 
-const datadogSiteOptions: SelectOption[] = [
-  { label: "US1", value: "US1" },
-  { label: "US3", value: "US3" },
-  { label: "US5", value: "US5" },
-  { label: "EU1", value: "EU1" },
-  { label: "US1-FED", value: "US1-FED" },
-];
+const datadogSiteOptions: SelectOption[] = Object.keys(datadogSites).map((site) => (
+  { label: site, value: site })
+);
 
 const validators = {
   // all


### PR DESCRIPTION
[sc-32711]

Similar to Log Drains, Datadog Metric Drains can be in different sites. Allow this to be configured on metric drain creation in the UI. 

A difference between this and our CLI `--site` is that this updates series_url regardless. If no site is explicitly stated in the CLI, we assume US1 but don't set series_url. 