### PR TITLE
add placement to database header info

### DIFF
--- a/src/ui/layouts/endpoint-detail-layout.tsx
+++ b/src/ui/layouts/endpoint-detail-layout.tsx
@@ -171,6 +171,8 @@ export function EndpointDatabaseHeaderInfo({
         </DetailInfoItem>
 
         <DetailInfoItem title="IP Allowlist">{txt.ipAllowlist}</DetailInfoItem>
+
+        <DetailInfoItem title="Placement">{txt.placement}</DetailInfoItem>
       </DetailInfoGrid>
     </DetailHeader>
   );


### PR DESCRIPTION
[sc-32780]

Adding placement information to the header for Database Endpoints. 

This information was already displayed from the Database's endpoint tab, but not from the Endpoint-specific header.

<img width="924" alt="Screenshot 2025-04-24 at 1 18 07 PM" src="https://github.com/user-attachments/assets/1616a180-4afa-482e-8a98-9e161940b2f3" />


<img width="866" alt="Screenshot 2025-04-24 at 1 17 48 PM" src="https://github.com/user-attachments/assets/1eadcf4a-1b36-43dc-a8b6-c23d98e30faf" />
