### PR TITLE
Support form fixes: line breaks and attachment error display

### DIFF
--- a/src/deploy/support/index.ts
+++ b/src/deploy/support/index.ts
@@ -54,7 +54,7 @@ export const resetSupportTicket = thunks.create(
 interface AttachmentProps {
   attachment: File;
   callback: (p: { token: string; filename: string }) => void;
-  errorCallback?: (message: string) => void;
+  errorCallback?: (message: string | null) => void;
 }
 
 export const uploadAttachment = api.post<AttachmentProps>(
@@ -69,11 +69,11 @@ export const uploadAttachment = api.post<AttachmentProps>(
     yield* next();
 
     if (!ctx.json.ok) {
-      const errorMessage =
-        ctx.json.error?.message ||
-        (typeof ctx.json.value?.message === "string"
-          ? ctx.json.value.message
-          : "File upload failed. Please try again.");
+      let errorMessage = "File upload failed. Please try again.";
+
+      if (ctx.json.error && typeof ctx.json.error.message === "string") {
+        errorMessage = ctx.json.error.message;
+      }
 
       // Call errorCallback if provided
       if (ctx.payload.errorCallback) {


### PR DESCRIPTION
## Summary ##

  This PR improves the user experience of the support form by addressing two issues:
- Line break preservation: Message text now maintains formatting when submitted by converting newlines to HTML <br /> tags
- File upload error handling: Better error visibility for attachment uploads, showing clear feedback when files are rejected

## Changes ##

- Added conversion of newlines to HTML <br /> tags in support form messages before submission
- Implemented error state management for file uploads with a dedicated error banner
- Extended the API interface with an error callback mechanism to properly surface API errors
- Applied consistent error styling using the existing Banner component

<img width="561" alt="image" src="https://github.com/user-attachments/assets/004a0acf-2bfc-474c-b2ca-ced6dac1f0a6" />

## Testing Plan ##

1. Line break preservation:
- Enter a message with multiple paragraphs in the support form
- Submit the form and verify line breaks appear correctly in the support ticket
2. File upload error handling:
- Attempt to upload an unsupported file format (verify the allowed formats in the error message)
- Confirm that an error message appears in a red banner below the upload section
- Upload a valid file and verify the error message disappears
- Check that adding multiple files in succession works correctly