### PR TITLE
Require new elasticsearch databases to have at least 1GB of memory

### DIFF
--- a/src/ui/pages/create-database.tsx
+++ b/src/ui/pages/create-database.tsx
@@ -20,7 +20,7 @@ import {
   existValidator,
   handleValidator,
 } from "@app/validator";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useDatabaseScaler, useValidator } from "../hooks";
 import { EnvironmentDetailLayout } from "../layouts";
@@ -108,6 +108,17 @@ export const CreateDatabasePage = () => {
     navigate(environmentActivityUrl(envId));
   });
 
+  useEffect(() => {
+    if (imgSelected?.type === "elasticsearch") {
+      if (scaler.containerSize < 1024) {
+        dispatchScaler({
+          type: "containerSize",
+          payload: 1024,
+        });
+      }
+    }
+  }, [imgSelected?.type, scaler.containerSize]);
+
   if (!envId) {
     return (
       <EnvSelectorPage
@@ -157,6 +168,7 @@ export const CreateDatabasePage = () => {
             <ContainerSizeInput
               scaler={scaler}
               dispatchScaler={dispatchScaler}
+              minSize={imgSelected?.type === "elasticsearch" ? 1024 : 0}
             />
             <CpuShareView
               cpuShare={requestedContainerProfile.cpuShare}

--- a/src/ui/pages/create-database.tsx
+++ b/src/ui/pages/create-database.tsx
@@ -108,6 +108,8 @@ export const CreateDatabasePage = () => {
     navigate(environmentActivityUrl(envId));
   });
 
+  // Elasticsearch requires at least 1GB to start up
+  const minContainerSize = imgSelected?.type === "elasticsearch" ? 1024 : 0;
   useEffect(() => {
     if (imgSelected?.type === "elasticsearch") {
       if (scaler.containerSize < 1024) {
@@ -168,7 +170,7 @@ export const CreateDatabasePage = () => {
             <ContainerSizeInput
               scaler={scaler}
               dispatchScaler={dispatchScaler}
-              minSize={imgSelected?.type === "elasticsearch" ? 1024 : 0}
+              minSize={minContainerSize}
             />
             <CpuShareView
               cpuShare={requestedContainerProfile.cpuShare}

--- a/src/ui/shared/db/scale-options.tsx
+++ b/src/ui/shared/db/scale-options.tsx
@@ -38,18 +38,20 @@ export function CpuShareView({
 export function ContainerSizeInput({
   scaler,
   dispatchScaler,
+  minSize = 0,
 }: {
   scaler: DbScaleOptions;
   dispatchScaler: (a: DbScaleAction) => void;
+  minSize?: number;
 }) {
-  const containerSizeOptions = containerSizesByProfile(
-    scaler.containerProfile,
-  ).map((containerSizeOption) => {
-    return {
-      label: `${containerSizeOption / 1024} GB`,
-      value: `${containerSizeOption}`,
-    };
-  });
+  const containerSizeOptions = containerSizesByProfile(scaler.containerProfile)
+    .filter((containerSizeOption) => containerSizeOption >= minSize)
+    .map((containerSizeOption) => {
+      return {
+        label: `${containerSizeOption / 1024} GB`,
+        value: `${containerSizeOption}`,
+      };
+    });
   return (
     <FormGroup
       splitWidthInputs


### PR DESCRIPTION
Elasticsearch databases can't start without at least 1GB of memory. This PR removes that option on the create database page when elasticsearch is selected as the type.