### PR TITLE
Allow configuration of stop timeout in service deployment settings

### DIFF
--- a/src/app/test/app-detail-service-settings.test.tsx
+++ b/src/app/test/app-detail-service-settings.test.tsx
@@ -11,7 +11,9 @@ import {
 } from "@app/mocks";
 import { appServiceSettingsPathUrl } from "@app/routes";
 import { setupAppIntegrationTest, waitForBootup, waitForData } from "@app/test";
+import type { DeployServiceResponse } from "@app/types";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 
 describe("AppDetailServiceSettingsPage", () => {
@@ -37,7 +39,7 @@ describe("AppDetailServiceSettingsPage", () => {
       return hasDeployApp(selectAppById(state, { id: `${testApp.id}` }));
     });
 
-    await screen.findByText(/Service Settings/);
+    await screen.findByText(/Service Deployment Settings/);
     const zddCheckbox = await screen.findByRole("checkbox", {
       name: "zero-downtime",
     });
@@ -77,8 +79,8 @@ describe("AppDetailServiceSettingsPage", () => {
         return hasDeployApp(selectAppById(state, { id: `${testApp.id}` }));
       });
 
-      await screen.findByText(/Service Settings/);
-      await screen.findByText(/managed through the following Endpoints/);
+      await screen.findByText(/Service Deployment Settings/);
+      await screen.findByText(/for services with endpoints/);
       const zddCheckbox = screen.queryByRole("checkbox", {
         name: "zero-downtime",
       });
@@ -87,6 +89,147 @@ describe("AppDetailServiceSettingsPage", () => {
       });
       expect(zddCheckbox).not.toBeInTheDocument();
       expect(simpleHealthcheckCheckbox).not.toBeInTheDocument();
+    });
+  });
+
+  describe("stop timeout configuration", () => {
+    it("should handle stop timeout configuration", async () => {
+      const updatedService: DeployServiceResponse = { ...testServiceRails };
+      server.use(
+        ...verifiedUserHandlers(),
+        ...stacksWithResources({
+          accounts: [testAccount],
+          apps: [testApp],
+          services: [updatedService],
+        }),
+        rest.put(`${testEnv.apiUrl}/services/:id`, async (req, res, ctx) => {
+          const data = await req.json();
+          Object.assign(updatedService, data);
+          return res(ctx.json(updatedService));
+        }),
+      );
+
+      const { App, store } = setupAppIntegrationTest({
+        initEntries: [
+          appServiceSettingsPathUrl(`${testApp.id}`, `${testServiceRails.id}`),
+        ],
+      });
+
+      await waitForBootup(store);
+
+      render(<App />);
+      await waitForData(store, (state) => {
+        return hasDeployApp(selectAppById(state, { id: `${testApp.id}` }));
+      });
+
+      const stopTimeoutInput = await screen.findByLabelText(/Stop Timeout/);
+      expect(stopTimeoutInput).toBeInTheDocument();
+      expect(stopTimeoutInput).toHaveAttribute("type", "number");
+      expect(stopTimeoutInput).toHaveAttribute("max", "900");
+      expect(stopTimeoutInput).toHaveAttribute("min", "0");
+
+      await userEvent.clear(stopTimeoutInput);
+      await userEvent.type(stopTimeoutInput, "300");
+      expect(stopTimeoutInput).toHaveValue(300);
+
+      await userEvent.clear(stopTimeoutInput);
+      await userEvent.type(stopTimeoutInput, "1000");
+      expect(stopTimeoutInput).toHaveValue(900);
+
+      await userEvent.clear(stopTimeoutInput);
+      await userEvent.type(stopTimeoutInput, "-1");
+      expect(stopTimeoutInput).toHaveValue(0);
+    });
+
+    it("should handle null stop timeout value", async () => {
+      const updatedService: DeployServiceResponse = {
+        ...testServiceRails,
+        stop_timeout: null,
+      };
+      server.use(
+        ...verifiedUserHandlers(),
+        ...stacksWithResources({
+          accounts: [testAccount],
+          apps: [testApp],
+          services: [updatedService],
+        }),
+        rest.put(`${testEnv.apiUrl}/services/:id`, async (req, res, ctx) => {
+          const data = await req.json();
+          Object.assign(updatedService, data);
+          return res(ctx.json(updatedService));
+        }),
+      );
+
+      const { App, store } = setupAppIntegrationTest({
+        initEntries: [
+          appServiceSettingsPathUrl(`${testApp.id}`, `${testServiceRails.id}`),
+        ],
+      });
+
+      await waitForBootup(store);
+
+      render(<App />);
+      await waitForData(store, (state) => {
+        return hasDeployApp(selectAppById(state, { id: `${testApp.id}` }));
+      });
+
+      const stopTimeoutInput = await screen.findByLabelText(/Stop Timeout/);
+      expect(stopTimeoutInput).toHaveValue(null);
+
+      await userEvent.clear(stopTimeoutInput);
+      await userEvent.type(stopTimeoutInput, "300");
+      expect(stopTimeoutInput).toHaveValue(300);
+
+      await userEvent.clear(stopTimeoutInput);
+      expect(stopTimeoutInput).toHaveValue(null);
+    });
+
+    it("should handle save button state correctly", async () => {
+      const updatedService: DeployServiceResponse = {
+        ...testServiceRails,
+        stop_timeout: 300,
+      };
+      server.use(
+        ...verifiedUserHandlers(),
+        ...stacksWithResources({
+          accounts: [testAccount],
+          apps: [testApp],
+          services: [updatedService],
+        }),
+        rest.put(`${testEnv.apiUrl}/services/:id`, async (req, res, ctx) => {
+          const data = await req.json();
+          Object.assign(updatedService, data);
+          return res(ctx.json(updatedService));
+        }),
+      );
+
+      const { App, store } = setupAppIntegrationTest({
+        initEntries: [
+          appServiceSettingsPathUrl(`${testApp.id}`, `${testServiceRails.id}`),
+        ],
+      });
+
+      await waitForBootup(store);
+
+      render(<App />);
+      await waitForData(store, (state) => {
+        return hasDeployApp(selectAppById(state, { id: `${testApp.id}` }));
+      });
+
+      const stopTimeoutInput = await screen.findByLabelText(/Stop Timeout/);
+      const saveButton = await screen.findByRole("button", {
+        name: /Save Changes/,
+      });
+
+      expect(saveButton).toBeDisabled();
+
+      await userEvent.clear(stopTimeoutInput);
+      await userEvent.type(stopTimeoutInput, "400");
+      expect(saveButton).toBeEnabled();
+
+      await userEvent.clear(stopTimeoutInput);
+      await userEvent.type(stopTimeoutInput, "300");
+      expect(saveButton).toBeDisabled();
     });
   });
 });

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -377,6 +377,7 @@ export const defaultDeployService = (
     instanceClass: DEFAULT_INSTANCE_CLASS,
     forceZeroDowntime: false,
     naiveHealthCheck: false,
+    stopTimeout: null,
     createdAt: now,
     updatedAt: now,
     ...s,

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -64,6 +64,7 @@ export interface DeployService extends Timestamps {
   instanceClass: InstanceClass;
   forceZeroDowntime: boolean;
   naiveHealthCheck: boolean;
+  stopTimeout: number | null;
 }
 
 export interface AcmeChallenge {
@@ -627,6 +628,7 @@ export interface DeployServiceResponse {
   instance_class: InstanceClass;
   force_zero_downtime: boolean;
   naive_health_check: boolean;
+  stop_timeout: number | null;
   _links: {
     current_release: LinkResponse;
     app?: LinkResponse;

--- a/src/ui/pages/app-detail-service-settings.tsx
+++ b/src/ui/pages/app-detail-service-settings.tsx
@@ -1,16 +1,13 @@
 import {
   fetchApp,
   fetchService,
-  getEndpointUrl,
   selectEndpointsByServiceId,
   selectServiceById,
   updateServiceById,
 } from "@app/deploy";
 import { useDispatch, useLoader, useQuery, useSelector } from "@app/react";
-import { endpointDetailUrl } from "@app/routes";
 import { type SyntheticEvent, useEffect, useState } from "react";
 import { useParams } from "react-router";
-import { Link } from "react-router-dom";
 import {
   Banner,
   BannerMessages,
@@ -18,6 +15,8 @@ import {
   Button,
   ButtonLinkDocs,
   CheckBox,
+  FormGroup,
+  Input,
   Tooltip,
 } from "../shared";
 
@@ -39,7 +38,10 @@ export const AppDetailServiceSettingsPage = () => {
   const action = updateServiceById({ ...nextService });
   const modifyLoader = useLoader(action);
   const cancelChanges = () => setNextService(service);
-  const changesExist = service !== nextService;
+  const changesExist =
+    service.forceZeroDowntime !== nextService.forceZeroDowntime ||
+    service.naiveHealthCheck !== nextService.naiveHealthCheck ||
+    service.stopTimeout !== nextService.stopTimeout;
 
   const onSubmitForm = (e: SyntheticEvent) => {
     e.preventDefault();
@@ -50,78 +52,103 @@ export const AppDetailServiceSettingsPage = () => {
     <div className="flex flex-col gap-4">
       <Box>
         <form onSubmit={onSubmitForm}>
-          <BannerMessages {...modifyLoader} />
+          <BannerMessages {...modifyLoader} className="mb-4" />
           <div className="flex flex-col gap-2">
             <div className="flex justify-between items-start">
-              <h1 className="text-lg text-gray-500 mb-4">Service Settings</h1>
+              <h1 className="text-lg text-gray-500 mb-4">
+                Service Deployment Settings
+              </h1>
               <ButtonLinkDocs href="https://www.aptible.com/docs/core-concepts/apps/deploying-apps/releases/overview" />
             </div>
-            {endpoints.length > 0 ? (
-              <Banner>
-                Service settings are managed through the following Endpoints:
-                {endpoints.map((endpoint, index) => {
-                  return (
-                    <span key={index}>
-                      {index === 0 && " "}
-                      <Link to={endpointDetailUrl(endpoint.id)}>
-                        {getEndpointUrl(endpoint)}
-                      </Link>
-                      {index < endpoints.length - 1 && ", "}
-                    </span>
-                  );
-                })}
-              </Banner>
-            ) : (
-              <>
-                <h2 className="text-md font-semibold">Deployment Strategy</h2>
-                <CheckBox
-                  name="zero-downtime"
-                  label="Enable Zero-Downtime Deployment"
-                  checked={nextService.forceZeroDowntime}
-                  onChange={(e) =>
-                    setNextService({
-                      ...nextService,
-                      forceZeroDowntime: e.currentTarget.checked,
-                    })
-                  }
-                />
-                <div className="flex gap-2">
-                  <Tooltip text="When enabled, ignores Docker healthchecks and instead only waits to ensure the container stays up for at least 30 seconds.">
-                    <CheckBox
-                      name="simple-healthcheck"
-                      label="Use simple healthcheck (30s)"
-                      checked={nextService.naiveHealthCheck}
-                      onChange={(e) =>
+            <div className="flex flex-col gap-2">
+              {endpoints.length > 0 ? (
+                <Banner>
+                  Cannot configure zero-downtime or non-endpoint health checks
+                  for services with endpoints.
+                </Banner>
+              ) : null}
+              {endpoints.length === 0 && (
+                <>
+                  <CheckBox
+                    name="zero-downtime"
+                    label="Enable Zero-Downtime Deployment"
+                    checked={nextService.forceZeroDowntime}
+                    onChange={(e) =>
+                      setNextService({
+                        ...nextService,
+                        forceZeroDowntime: e.currentTarget.checked,
+                      })
+                    }
+                  />
+                  <div className="flex gap-2">
+                    <Tooltip text="When enabled, ignores Docker healthchecks and instead only waits to ensure the container stays up for at least 30 seconds.">
+                      <CheckBox
+                        name="simple-healthcheck"
+                        label="Use simple healthcheck (30s)"
+                        checked={nextService.naiveHealthCheck}
+                        onChange={(e) =>
+                          setNextService({
+                            ...nextService,
+                            naiveHealthCheck: e.currentTarget.checked,
+                          })
+                        }
+                      />
+                    </Tooltip>
+                  </div>
+                </>
+              )}
+              <div className="flex flex-col gap-4 items-center mb-4">
+                <div className="flex flex-col w-full gap-4">
+                  <FormGroup
+                    splitWidthInputs
+                    description={`The time in seconds to wait for the old release's containers to stop before killing them.`}
+                    label="Stop Timeout"
+                    htmlFor="stop-timeout"
+                    className="mt-4"
+                  >
+                    <Input
+                      id="stop-timeout"
+                      type="number"
+                      min={0}
+                      max={900}
+                      value={nextService.stopTimeout ?? ""}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        const parsedValue =
+                          value === "" ? null : Number.parseInt(value);
                         setNextService({
                           ...nextService,
-                          naiveHealthCheck: e.currentTarget.checked,
-                        })
-                      }
+                          stopTimeout:
+                            parsedValue === null
+                              ? null
+                              : Math.min(Math.max(0, parsedValue), 900),
+                        });
+                      }}
                     />
-                  </Tooltip>
+                  </FormGroup>
                 </div>
-                <div className="flex mt-4">
+              </div>
+              <div className="flex mt-4">
+                <Button
+                  name="settings-save"
+                  className="w-40 flex font-semibold"
+                  type="submit"
+                  disabled={!changesExist}
+                  isLoading={modifyLoader.isLoading}
+                >
+                  Save Changes
+                </Button>
+                {changesExist ? (
                   <Button
-                    name="autoscaling"
-                    className="w-40 flex font-semibold"
-                    type="submit"
-                    disabled={!changesExist}
-                    isLoading={modifyLoader.isLoading}
+                    className="w-40 ml-2 flex font-semibold"
+                    onClick={cancelChanges}
+                    variant="white"
                   >
-                    Save Changes
+                    Cancel
                   </Button>
-                  {changesExist ? (
-                    <Button
-                      className="w-40 ml-2 flex font-semibold"
-                      onClick={cancelChanges}
-                      variant="white"
-                    >
-                      Cancel
-                    </Button>
-                  ) : null}
-                </div>
-              </>
-            )}
+                ) : null}
+              </div>
+            </div>
           </div>
         </form>
       </Box>


### PR DESCRIPTION
Needs to wait for https://github.com/aptible/deploy-api/pull/1802

Allows user configuration of the stop timeout added in the previous story. I haven't updated the docs, but the docs page already linked will have the longer explanation with caveats of the setting. It's also a little different that the existing checkbox style settings for worker services since it can be set even without an endpoint. I tried to update the language of the popup banner to be clearer there as well.

I also added a save banner to make it more consistent.

With endpoint
![Screenshot 2025-05-08 at 7 55 09 AM](https://github.com/user-attachments/assets/92ec9898-af80-47a1-9927-d944b2600e6b)

Without endpoint
![Screenshot 2025-05-08 at 7 55 02 AM](https://github.com/user-attachments/assets/d3eed990-d011-45d0-87fc-692f7eaa2d94)
