### PR TITLE
remove legacy dashboard link

### DIFF
--- a/src/ui/shared/footer.tsx
+++ b/src/ui/shared/footer.tsx
@@ -26,15 +26,6 @@ export const Footer = () => {
             Changelog{" "}
             <IconExternalLink className="inline h-4 -ml-1 -mt-1 opacity-60" />
           </a>
-          <a
-            href="https://dashboard.aptible.com/login"
-            target="_blank"
-            className="flex-none text-gray-500 hover:text-indigo text-sm pl-4 uppercase hidden md:block"
-            rel="noreferrer"
-          >
-            Legacy Dashboard{" "}
-            <IconExternalLink className="inline h-4 -ml-1 -mt-1 opacity-60" />
-          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
[sc-33096]

Remove legacy dash link from footer:
<img width="474" alt="image" src="https://github.com/user-attachments/assets/947045ad-7c18-4816-b96f-2979c5745054" />
