### PR TITLE
Remove state validation for Canada on billing method form

### DIFF
--- a/src/ui/pages/billing-method.tsx
+++ b/src/ui/pages/billing-method.tsx
@@ -68,7 +68,7 @@ interface FormProps {
   country: string;
 }
 
-const validators = {
+export const validators = {
   zipcode: (p: FormProps) => {
     return existValidator(p.zipcode, "zipcode");
   },

--- a/src/ui/pages/billing-method.tsx
+++ b/src/ui/pages/billing-method.tsx
@@ -83,7 +83,7 @@ const validators = {
   },
   state: (p: FormProps) => {
     const readable = "state / province / district";
-    if ((p.country === "US" || p.country === "CA") && p.state === "NA") {
+    if (p.country === "US" && p.state === "NA") {
       return `${readable} is required`;
     }
   },

--- a/src/ui/pages/billing-method.validators.test.tsx
+++ b/src/ui/pages/billing-method.validators.test.tsx
@@ -35,4 +35,4 @@ describe("Billing Method Validators", () => {
       expect(result).toBeUndefined();
     });
   });
-}); 
+});

--- a/src/ui/pages/billing-method.validators.test.tsx
+++ b/src/ui/pages/billing-method.validators.test.tsx
@@ -1,0 +1,38 @@
+import { validators } from "./billing-method";
+
+describe("Billing Method Validators", () => {
+  describe("state validator", () => {
+    const baseFormProps = {
+      zipcode: "12345",
+      nameOnCard: "John Doe",
+      address1: "123 Main St",
+      address2: "",
+      city: "New York",
+      state: "NA",
+      country: "US",
+    };
+
+    it("requires state selection for US addresses", () => {
+      const result = validators.state(baseFormProps);
+      expect(result).toBe("state / province / district is required");
+    });
+
+    it("allows N/A state for Canadian addresses", () => {
+      const canadaProps = { ...baseFormProps, country: "CA" };
+      const result = validators.state(canadaProps);
+      expect(result).toBeUndefined();
+    });
+
+    it("allows N/A state for non-US/Canada addresses", () => {
+      const otherCountryProps = { ...baseFormProps, country: "GB" };
+      const result = validators.state(otherCountryProps);
+      expect(result).toBeUndefined();
+    });
+
+    it("allows valid state selection for US addresses", () => {
+      const validStateProps = { ...baseFormProps, state: "NY" };
+      const result = validators.state(validStateProps);
+      expect(result).toBeUndefined();
+    });
+  });
+}); 


### PR DESCRIPTION
[sc-32264]

We previously required that a state be selected even when Canada was the chosen country in the billing form. [Confirmed](https://aptible.slack.com/archives/C022BUSF0B1/p1746495292254529?thread_ts=1746473082.801859&cid=C022BUSF0B1) with Finance that we do not require state/province information from Canadian customers. 