### PR TITLE
Errors in console

### DIFF
--- a/src/deploy/stats.ts
+++ b/src/deploy/stats.ts
@@ -1,0 +1,41 @@
+import { schema } from "@app/schema";
+import { createSelector } from "starfx";
+import { selectAppsAsList } from "./app";
+import { selectDatabasesAsList } from "./database";
+import { selectEnvironments } from "./environment";
+
+export const selectStackStats = createSelector(
+  selectEnvironments,
+  selectAppsAsList,
+  selectDatabasesAsList,
+  (envs, apps, dbs) => {
+    const mapper: {
+      [key: string]: { envCount: number; appCount: number; dbCount: number };
+    } = {};
+
+    dbs.forEach((db) => {
+      const env = schema.environments.findById(envs, { id: db.environmentId });
+      if (!mapper[env.stackId]) {
+        mapper[env.stackId] = { envCount: 0, appCount: 0, dbCount: 0 };
+      }
+      mapper[env.stackId].dbCount += 1;
+    });
+
+    apps.forEach((app) => {
+      const env = schema.environments.findById(envs, { id: app.environmentId });
+      if (!mapper[env.stackId]) {
+        mapper[env.stackId] = { envCount: 0, appCount: 0, dbCount: 0 };
+      }
+      mapper[env.stackId].appCount += 1;
+    });
+
+    Object.values(envs).forEach((env) => {
+      if (!mapper[env.stackId]) {
+        mapper[env.stackId] = { envCount: 0, appCount: 0, dbCount: 0 };
+      }
+      mapper[env.stackId].envCount += 1;
+    });
+
+    return mapper;
+  },
+);

--- a/src/ui/pages/stacks.tsx
+++ b/src/ui/pages/stacks.tsx
@@ -14,7 +14,7 @@ import {
   type DeployStackRow,
   selectStacksForTableSearch,
 } from "@app/stack-table";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { usePaginate } from "../hooks";
 import { AppSidebarLayout } from "../layouts";
@@ -115,65 +115,9 @@ function StackList() {
     }),
   );
 
-  const envCounts = useSelector((s) => {
-    const counts = new Map<string, number>();
-    stacks.forEach((stack) => {
-      counts.set(
-        stack.id,
-        selectEnvironmentsCountByStack(s, { stackId: stack.id }),
-      );
-    });
-    return counts;
-  });
-
-  const appCounts = useSelector((s) => {
-    const counts = new Map<string, number>();
-    stacks.forEach((stack) => {
-      counts.set(stack.id, selectAppsCountByStack(s, { stackId: stack.id }));
-    });
-    return counts;
-  });
-
-  const dbCounts = useSelector((s) => {
-    const counts = new Map<string, number>();
-    stacks.forEach((stack) => {
-      counts.set(
-        stack.id,
-        selectDatabasesCountByStack(s, { stackId: stack.id }),
-      );
-    });
-    return counts;
-  });
-
-  const sortedStacks = useMemo(() => {
-    if (
-      sortKey === "envCount" ||
-      sortKey === "appCount" ||
-      sortKey === "dbCount"
-    ) {
-      return [...stacks].sort((a, b) => {
-        const aCount =
-          sortKey === "envCount"
-            ? envCounts.get(a.id) || 0
-            : sortKey === "appCount"
-              ? appCounts.get(a.id) || 0
-              : dbCounts.get(a.id) || 0;
-        const bCount =
-          sortKey === "envCount"
-            ? envCounts.get(b.id) || 0
-            : sortKey === "appCount"
-              ? appCounts.get(b.id) || 0
-              : dbCounts.get(b.id) || 0;
-        return sortDirection === "asc" ? aCount - bCount : bCount - aCount;
-      });
-    }
-    return stacks;
-  }, [stacks, sortKey, sortDirection, envCounts, appCounts, dbCounts]);
-
   // Calculate total cost of all stacks
   const totalCost = stacks.reduce((sum, stack) => sum + (stack.cost || 0), 0);
-
-  const paginated = usePaginate(sortedStacks);
+  const paginated = usePaginate(stacks);
 
   const SortIcon = () => (
     <div className="inline-block">

--- a/src/ui/shared/resource-group-box.tsx
+++ b/src/ui/shared/resource-group-box.tsx
@@ -50,13 +50,13 @@ export const ResourceGroupBox = ({
           </div>
           <div>
             <h4 className={`break-words ${tokens.type.h4}`}>{handle}</h4>
-            <p className="text-black-500 text-sm pb-1">
+            <div className="text-black-500 text-sm pb-1">
               {hasDeployEndpoint(vhost) && vhost.status === "provisioned" ? (
                 <EndpointUrl enp={vhost} />
               ) : (
                 "Pending HTTP Endpoint"
               )}
-            </p>
+            </div>
           </div>
         </div>
         <div className="flex items-center mt-1 gap-1">

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -60,7 +60,7 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: "jsdom",
       setupFiles: ["./src/test/setup.ts"],
-      reporters: ["basic"],
+      reporters: [["default", { summary: false }]],
       env: {
         NODE_OPTIONS: "--no-experimental-fetch",
       },


### PR DESCRIPTION
refactor(stacks): precompute stats by stack and used that for sorting

Instead of calculating a stack stats (e.g. env count, app count, db
count) individually, we can precompute all stacks with their stats
inside of a hash map which will make accessing that data easier and
faster.