### PR TITLE
fix(endpoints): replace hostname in credential without a db selector

### DIFF
--- a/src/deploy/database-credential/connection-url-rewrite.test.ts
+++ b/src/deploy/database-credential/connection-url-rewrite.test.ts
@@ -32,4 +32,16 @@ describe("connectionUrlRewrite", () => {
       "postgresql://user:0passvOQ-ALL3UMEsTQk9jwow@elb-aptible-us-nowhere-1-12345.aptible.in:5432/db";
     expect(actual).toEqual(expected);
   });
+
+  it("should replace original connection url when there is no database selector", () => {
+    const orig = "https://aptible:YXXy1EOF46i9Rp45645789@host:29128";
+    const actual = connectionUrlRewrite(
+      orig,
+      "elb-aptible-us-nowhere-1-12345.aptible.in",
+      [[29128, 8086]],
+    );
+    const expected =
+      "https://aptible:YXXy1EOF46i9Rp45645789@elb-aptible-us-nowhere-1-12345.aptible.in:8086";
+    expect(actual).toEqual(expected);
+  });
 });

--- a/src/deploy/database-credential/index.ts
+++ b/src/deploy/database-credential/index.ts
@@ -62,15 +62,16 @@ export const connectionUrlRewrite = (
   }
   let connectionUrl = connUrl;
   const hostRe = new RegExp(/\@.+\:/);
-  const portRe = new RegExp(/\:([0-9]+)\//);
+  // negative lookahead to find last occurance
+  const portRe = new RegExp(/[0-9]+(?!.*\:[0-9]+)/);
   const port = connectionUrl.match(portRe);
   if (!port) return connUrl;
 
-  const portFound = portMapping.find((pair) => port[1] === `${pair[0]}`);
+  const portFound = portMapping.find((pair) => port[0] === `${pair[0]}`);
   if (!portFound || portFound.length < 2) return connUrl;
   const portPair = portFound[1];
 
   connectionUrl = connectionUrl.replace(hostRe, `@${host}:`);
-  connectionUrl = connectionUrl.replace(portRe, `:${portPair}/`);
+  connectionUrl = connectionUrl.replace(portRe, `${portPair}`);
   return connectionUrl;
 };


### PR DESCRIPTION
Previously our regex was looking for a trailing `/` which only works for connection URLs with a database selector, like postgres.

Many connection URLs do not have a database selector which meant we were not properly replacing their hostnames.

In this revised approach, I use a negative lookahead regex to properly find the last occurence of a `:[0-9]`