### PR TITLE
COnfigurable restart free scaling in HAS

### DIFF
--- a/src/deploy/service-sizing-policy/index.ts
+++ b/src/deploy/service-sizing-policy/index.ts
@@ -31,6 +31,7 @@ export interface DeployServiceSizingPolicyResponse {
   max_cpu_threshold: number | null;
   scale_up_step: number;
   scale_down_step: number;
+  use_horizontal_scale: boolean;
   created_at: string;
   updated_at: string;
   _links: {
@@ -65,6 +66,7 @@ export const defaultServiceSizingPolicyResponse = (
     max_cpu_threshold: 0.9,
     scale_up_step: 1,
     scale_down_step: 1,
+    use_horizontal_scale: false,
     created_at: now,
     updated_at: now,
     _type: "service_sizing_policy",
@@ -102,6 +104,7 @@ export const deserializeDeployServiceSizingPolicy = (
     scaleDownStep: payload.scale_down_step,
     minCpuThreshold: payload.min_cpu_threshold,
     maxCpuThreshold: payload.max_cpu_threshold,
+    useHorizontalScale: payload.use_horizontal_scale,
     createdAt: payload.created_at,
     updatedAt: payload.updated_at,
   };
@@ -170,6 +173,7 @@ export interface ServiceSizingPolicyEditProps {
   maxCpuThreshold: number | null;
   scaleUpStep: number;
   scaleDownStep: number;
+  useHorizontalScale: boolean;
 }
 
 const serializeServiceSizingPolicyEditProps = (
@@ -194,6 +198,7 @@ const serializeServiceSizingPolicyEditProps = (
   max_cpu_threshold: payload.maxCpuThreshold,
   scale_up_step: payload.scaleUpStep,
   scale_down_step: payload.scaleDownStep,
+  use_horizontal_scale: payload.useHorizontalScale,
 });
 
 export interface ModifyServiceSizingPolicyProps

--- a/src/schema/factory.ts
+++ b/src/schema/factory.ts
@@ -723,6 +723,7 @@ export const defaultServiceSizingPolicy = (
     maxCpuThreshold: 0.9,
     scaleUpStep: 1,
     scaleDownStep: 1,
+    useHorizontalScale: false,
     createdAt: now,
     updatedAt: now,
     ...m,

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -674,6 +674,7 @@ export interface DeployServiceSizingPolicy extends Timestamps {
   maxCpuThreshold: number | null;
   scaleUpStep: number;
   scaleDownStep: number;
+  useHorizontalScale: boolean;
 }
 
 export interface DeploySource {

--- a/src/ui/pages/app-detail-service-scale.tsx
+++ b/src/ui/pages/app-detail-service-scale.tsx
@@ -816,6 +816,27 @@ const AutoscalingSection = ({
                   <h2 className="text-md text-gray-500">General Settings</h2>
                   <FormGroup
                     splitWidthInputs
+                    description="Enable scaling the number of containers up and down without restarting all containers"
+                    label="Restart-Free Scale"
+                    htmlFor="horizontal-scale"
+                  >
+                    <Select
+                      id="horizontal-scale"
+                      value={nextPolicy.useHorizontalScale ? "enabled" : "disabled"}
+                      onSelect={(opt) =>
+                        updatePolicy(
+                          "useHorizontalScale",
+                          opt.value === "enabled"
+                        )
+                      }
+                      options={[
+                        { label: "Enabled", value: "enabled" },
+                        { label: "Disabled", value: "disabled" },
+                      ]}
+                    />
+                  </FormGroup>
+                  <FormGroup
+                    splitWidthInputs
                     label="Reset Advanced Settings to Defaults"
                     description="This will restore settings to their default values."
                     htmlFor="reset-button"


### PR DESCRIPTION
In theory this could be a checkbox but that didn't look right with the rest of the configuration options. The enabled/disabled dropdown also matches i.e. enabled/disabling backups on databases.